### PR TITLE
fix(transfer): trim balance precision and reserve gas in max slider

### DIFF
--- a/src/components/Core/Body/Transfer/Transfer.tsx
+++ b/src/components/Core/Body/Transfer/Transfer.tsx
@@ -49,6 +49,7 @@ import { SEO } from "@/components/SEO/SEO";
 import { getOptimalTokenBalance, formatAddressShort } from "@/utils/formatting";
 import { fetchBalance } from "@/utils/web3";
 import { formatUnits, parseUnits } from "ethers";
+import { BigNumber } from "bignumber.js";
 
 const Transfer = observer(() => {
   const navigate = useNavigate();
@@ -65,6 +66,7 @@ const Transfer = observer(() => {
     resetTransactionStatus,
     tokenList,
     sendToken: sendTokenToStore,
+    estimateNativeTransferFee,
   } = qrlStore;
   const { blockchain } = qrlConnection;
   const { accountAddress } = activeAccount;
@@ -114,6 +116,7 @@ const Transfer = observer(() => {
   const [amountInputValue, setAmountInputValue] = useState("");
   const [tokenBalance, setTokenBalance] = useState("0");
   const [hasJustCopied, setHasJustCopied] = useState(false);
+  const [nativeGasReserve, setNativeGasReserve] = useState("0");
 
   // QR Scanner state
   const [isScanning, setIsScanning] = useState(false);
@@ -183,6 +186,34 @@ const Transfer = observer(() => {
     setSliderValue(0);
     setValue("amount", 0);
   }, [selectedAsset, setValue]);
+
+  // Keep a worst-case gas fee reserve for native transfers so the slider's
+  // "Max" option doesn't pick a value that leaves nothing for gas.
+  useEffect(() => {
+    if (!isNativeTransfer) {
+      setNativeGasReserve("0");
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const fee = await estimateNativeTransferFee(feeLevel);
+        if (!cancelled) setNativeGasReserve(fee);
+      } catch {
+        if (!cancelled) setNativeGasReserve("0");
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [isNativeTransfer, feeLevel, estimateNativeTransferFee, accountAddress]);
+
+  // Balance available for the transfer amount itself (subtracting gas reserve for native).
+  const maxSendableBalance = useMemo(() => {
+    if (!isNativeTransfer) return accountBalance;
+    const balanceBn = new BigNumber(accountBalance || "0");
+    const reserveBn = new BigNumber(nativeGasReserve || "0");
+    const sendable = balanceBn.minus(reserveBn);
+    return sendable.isPositive() ? sendable.toString() : "0";
+  }, [accountBalance, nativeGasReserve, isNativeTransfer]);
 
   // Validate QRL address format
   const isValidQRLAddress = useCallback((address: string): boolean => {
@@ -388,27 +419,26 @@ const Transfer = observer(() => {
     navigate(ROUTES.HOME);
   };
 
-  const handleSliderChange = (value: number[]) => {
-    const percentage = value[0];
+  const applyPercentage = (percentage: number) => {
     setSliderValue(percentage);
-    if (accountBalance && accountBalance !== "0") {
-      const maxAmount = parseFloat(accountBalance);
+    if (maxSendableBalance && maxSendableBalance !== "0") {
+      const maxAmount = parseFloat(maxSendableBalance);
       const calculatedAmount = (maxAmount * (percentage / 100));
       const formattedAmount = calculatedAmount.toFixed(6).replace(/\.?0+$/, "");
       setAmountInputValue(formattedAmount);
       setValue("amount", parseFloat(formattedAmount));
+    } else {
+      setAmountInputValue("");
+      setValue("amount", 0);
     }
   };
 
+  const handleSliderChange = (value: number[]) => {
+    applyPercentage(value[0]);
+  };
+
   const setPercentage = (percentage: number) => () => {
-    setSliderValue(percentage);
-    if (accountBalance && accountBalance !== "0") {
-      const maxAmount = parseFloat(accountBalance);
-      const calculatedAmount = (maxAmount * (percentage / 100));
-      const formattedAmount = calculatedAmount.toFixed(6).replace(/\.?0+$/, "");
-      setAmountInputValue(formattedAmount);
-      setValue("amount", parseFloat(formattedAmount));
-    }
+    applyPercentage(percentage);
   };
 
   const assetSymbol = isNativeTransfer ? "QRL" : (selectedToken?.symbol || "");
@@ -698,8 +728,8 @@ const Transfer = observer(() => {
                                   setAmountInputValue(value);
                                   const numValue = value === "" ? 0 : parseFloat(value) || 0;
                                   field.onChange(numValue);
-                                  if (accountBalance && parseFloat(accountBalance) > 0) {
-                                    const percentage = Math.min(100, (numValue / parseFloat(accountBalance)) * 100);
+                                  if (maxSendableBalance && parseFloat(maxSendableBalance) > 0) {
+                                    const percentage = Math.min(100, (numValue / parseFloat(maxSendableBalance)) * 100);
                                     setSliderValue(Math.round(percentage));
                                   }
                                 }

--- a/src/components/Core/Body/Transfer/Transfer.tsx
+++ b/src/components/Core/Body/Transfer/Transfer.tsx
@@ -188,23 +188,25 @@ const Transfer = observer(() => {
   }, [selectedAsset, setValue]);
 
   // Keep a worst-case gas fee reserve for native transfers so the slider's
-  // "Max" option doesn't pick a value that leaves nothing for gas.
+  // "Max" option doesn't pick a value that leaves nothing for gas. Extension
+  // wallets sign with a 53000 gas limit (vs 21000 for the in-app path).
   useEffect(() => {
     if (!isNativeTransfer) {
       setNativeGasReserve("0");
       return;
     }
+    const gasLimit = isUsingExtension ? 53000 : 21000;
     let cancelled = false;
     (async () => {
       try {
-        const fee = await estimateNativeTransferFee(feeLevel);
+        const fee = await estimateNativeTransferFee(feeLevel, gasLimit);
         if (!cancelled) setNativeGasReserve(fee);
       } catch {
         if (!cancelled) setNativeGasReserve("0");
       }
     })();
     return () => { cancelled = true; };
-  }, [isNativeTransfer, feeLevel, estimateNativeTransferFee, accountAddress]);
+  }, [isNativeTransfer, isUsingExtension, feeLevel, estimateNativeTransferFee, accountAddress]);
 
   // Balance available for the transfer amount itself (subtracting gas reserve for native).
   const maxSendableBalance = useMemo(() => {
@@ -421,16 +423,23 @@ const Transfer = observer(() => {
 
   const applyPercentage = (percentage: number) => {
     setSliderValue(percentage);
-    if (maxSendableBalance && maxSendableBalance !== "0") {
-      const maxAmount = parseFloat(maxSendableBalance);
-      const calculatedAmount = (maxAmount * (percentage / 100));
-      const formattedAmount = calculatedAmount.toFixed(6).replace(/\.?0+$/, "");
-      setAmountInputValue(formattedAmount);
-      setValue("amount", parseFloat(formattedAmount));
-    } else {
+    const sendableBn = new BigNumber(maxSendableBalance || "0");
+    if (sendableBn.isZero()) {
       setAmountInputValue("");
       setValue("amount", 0);
+      return;
     }
+    // For 100% use the raw max so rounding can't push the amount above the
+    // gas-adjusted balance. Below 100% round down to 6 decimals for display.
+    const formattedAmount = percentage === 100
+      ? sendableBn.toString()
+      : sendableBn
+          .multipliedBy(percentage)
+          .dividedBy(100)
+          .toFixed(6, BigNumber.ROUND_DOWN)
+          .replace(/\.?0+$/, "");
+    setAmountInputValue(formattedAmount);
+    setValue("amount", parseFloat(formattedAmount));
   };
 
   const handleSliderChange = (value: number[]) => {

--- a/src/stores/qrlStore.ts
+++ b/src/stores/qrlStore.ts
@@ -607,12 +607,17 @@ class QrlStore {
   }
 
   // Worst-case fee reserve for a native QRL transfer at the given fee level.
+  // gasLimit defaults to 21000 (matches signAndSendTransaction); callers using
+  // sendTransactionViaExtension must pass 53000 to match that path.
   // Returns the amount in QRL that must stay in the wallet to cover gas.
-  async estimateNativeTransferFee(feeLevel: FeeLevel = 'medium'): Promise<string> {
+  async estimateNativeTransferFee(
+    feeLevel: FeeLevel = 'medium',
+    gasLimit: number = 21000,
+  ): Promise<string> {
     const baseGasPrice = await this.qrlInstance?.getGasPrice();
     if (!baseGasPrice) return "0";
     const { maxFeePerGas } = applyFeeLevel(baseGasPrice, feeLevel);
-    return utils.fromPlanck(BigInt(21000) * maxFeePerGas, "quanta");
+    return utils.fromPlanck(BigInt(gasLimit) * maxFeePerGas, "quanta");
   }
 
   // Refactored signAndSendTransaction

--- a/src/stores/qrlStore.ts
+++ b/src/stores/qrlStore.ts
@@ -606,6 +606,15 @@ class QrlStore {
     }
   }
 
+  // Worst-case fee reserve for a native QRL transfer at the given fee level.
+  // Returns the amount in QRL that must stay in the wallet to cover gas.
+  async estimateNativeTransferFee(feeLevel: FeeLevel = 'medium'): Promise<string> {
+    const baseGasPrice = await this.qrlInstance?.getGasPrice();
+    if (!baseGasPrice) return "0";
+    const { maxFeePerGas } = applyFeeLevel(baseGasPrice, feeLevel);
+    return utils.fromPlanck(BigInt(21000) * maxFeePerGas, "quanta");
+  }
+
   // Refactored signAndSendTransaction
   async signAndSendTransaction(
     from: string,

--- a/src/utils/formatting/balance.ts
+++ b/src/utils/formatting/balance.ts
@@ -77,12 +77,10 @@ export const formatBalance = (
     let formatted = bn.toFixed(decimals, BigNumber.ROUND_DOWN);
 
     // If a non-zero balance rounds to zero at the requested precision,
-    // expand precision so small amounts aren't misleadingly shown as 0.
-    if (!bn.isZero() && new BigNumber(formatted).isZero()) {
-        formatted = bn
-            .toFixed(18, BigNumber.ROUND_DOWN)
-            .replace(/0+$/, '')
-            .replace(/\.$/, '');
+    // expand precision to show the first few significant digits so small
+    // amounts are visible without cluttering the UI.
+    if (!bn.isZero() && parseFloat(formatted) === 0) {
+        formatted = bn.precision(4, BigNumber.ROUND_DOWN).toString();
     }
 
     if (useThousandSeparator) {


### PR DESCRIPTION
Two follow-up fixes after PR #110:

- formatBalance: when a balance rounds to zero at the requested precision,
  show only the first ~4 significant digits (via BigNumber.precision) instead
  of up to 18 decimals. Keeps small balances visible without cluttering the
  UI (e.g. 0.000223749999496 → 0.0002237). Also swaps the regex-based
  trailing-zero strip for BigNumber's native toString.

- Transfer: the percentage slider and Max button used the full wallet
  balance as the target, so picking 100% left nothing to cover gas and the
  transaction reverted. Estimate a worst-case native fee reserve
  (21000 * maxFeePerGas at the selected fee level) and subtract it from
  the slider's max. Gas level changes refresh the reserve.

https://claude.ai/code/session_01KSiU5tGqdbqFwjh8CrrrHK