### PR TITLE
fix(transfer): bind estimateNativeTransferFee and drop duplicate QRL label

### DIFF
--- a/src/components/Core/Body/Transfer/GasFeeNotice/GasFeeNotice.tsx
+++ b/src/components/Core/Body/Transfer/GasFeeNotice/GasFeeNotice.tsx
@@ -115,7 +115,7 @@ export const GasFeeNotice = ({
             ) : gasFee.error ? (
               <span className="text-sm">{gasFee.error}</span>
             ) : (
-              <span className="text-sm">~{gasFee.estimatedGas} QRL</span>
+              <span className="text-sm">~{gasFee.estimatedGas}</span>
             )}
           </div>
         </div>

--- a/src/stores/qrlStore.ts
+++ b/src/stores/qrlStore.ts
@@ -195,6 +195,7 @@ class QrlStore {
       hideToken: action.bound,
       unhideToken: action.bound,
       loadHiddenTokens: action.bound,
+      estimateNativeTransferFee: action.bound,
     });
 
     // Log initialization


### PR DESCRIPTION
Two bugs surfaced after PR #111 deployed:

- Max still reverted because Transfer destructures
  estimateNativeTransferFee from qrlStore, and the method wasn't declared
  as action.bound. Destructuring dropped its `this`, so `this.qrlInstance`
  was undefined, the helper hit its falsy baseGasPrice guard and returned
  "0", and the slider never subtracted any gas reserve from the balance.
  Register it alongside the other bound actions in makeAutoObservable.

- The gas fee notice rendered "~0.0000315 QRL QRL" because
  getOptimalGasFee already appends the symbol. Drop the redundant " QRL"
  suffix in the JSX.

https://claude.ai/code/session_01KSiU5tGqdbqFwjh8CrrrHK