### PR TITLE
fix(home): force active-account video autoplay and hide WebKit play overlay

### DIFF
--- a/src/components/Core/Body/Home/Home.tsx
+++ b/src/components/Core/Body/Home/Home.tsx
@@ -34,6 +34,7 @@ const Home = observer(() => {
   const { isLoading, isConnected, blockchain } = qrlConnection;
   const hasAccountCreationPreference = !!state?.hasAccountCreationPreference;
   const refreshIntervalRef = useRef<NodeJS.Timeout | null>(null);
+  const activeAccountVideoRef = useRef<HTMLVideoElement | null>(null);
   const [txHistoryOpen, setTxHistoryOpen] = useState(false);
   const [receiveOpen, setReceiveOpen] = useState(false);
 
@@ -43,6 +44,19 @@ const Home = observer(() => {
     const openDialogs = document.querySelectorAll('div[role="dialog"]');
     return openDialogs.length > 0;
   };
+
+  // Kick off playback of the active-account card video. iOS Safari and some
+  // other browsers don't reliably honor the autoPlay attribute on
+  // React-managed <video> elements after a route change, so call play()
+  // explicitly once the element is mounted.
+  useEffect(() => {
+    const video = activeAccountVideoRef.current;
+    if (!video) return;
+    video.play().catch(() => {
+      // Autoplay policy may still block playback; fail silently so the
+      // element degrades to a static first frame.
+    });
+  }, [activeAccount.accountAddress]);
 
   // Set up auto-refresh for balances
   useEffect(() => {
@@ -118,11 +132,13 @@ const Home = observer(() => {
                 <Card className="w-full relative overflow-hidden border-l-4 border-l-blue-accent">
                   <div className="absolute inset-0 overflow-hidden">
                     <video
+                      ref={activeAccountVideoRef}
                       autoPlay
                       muted
                       loop
                       playsInline
-                      className="w-full h-full object-cover opacity-30"
+                      preload="auto"
+                      className="decorative-video w-full h-full object-cover opacity-30"
                     >
                       <source src="qrl-video-dark.mp4" type="video/mp4" />
                     </video>

--- a/src/index.css
+++ b/src/index.css
@@ -249,5 +249,16 @@
     user-select: none;
   }
 
+  /* Hide WebKit's overlay play-button on decorative background videos
+     when autoplay is blocked (e.g. iOS Safari), so they degrade to a
+     static first frame instead of showing a prominent play icon. */
+  .decorative-video::-webkit-media-controls,
+  .decorative-video::-webkit-media-controls-start-playback-button,
+  .decorative-video::-webkit-media-controls-overlay-play-button,
+  .decorative-video::-webkit-media-controls-panel {
+    display: none !important;
+    -webkit-appearance: none;
+  }
+
   /* min-height handled by Body.tsx (md: only) to avoid bottom gaps on mobile */
 }


### PR DESCRIPTION
WebKit-based browsers (Safari and Chrome on iOS both use WebKit) don't
reliably honor the autoPlay attribute on React-managed <video> elements
after a route change, so the active-account card video stayed paused
until the user navigated away and back. When it stalls, WebKit also
overlays its native play button on top of the frame, which is jarring
for a decorative background.

- Attach a ref to the video and call play() from useEffect whenever the
  active account changes; swallow rejections since autoplay policy can
  still block playback.
- Add preload="auto" so the element has a frame ready on mount.
- Add a decorative-video class and scoped CSS that hides the
  ::-webkit-media-controls-* pseudo-elements, so the element degrades
  to a static first frame instead of showing a play-button overlay when
  playback is blocked.

https://claude.ai/code/session_01KSiU5tGqdbqFwjh8CrrrHK