### PR TITLE
fix(config): default EXPLORER_BASE to zondscan.com when env var is unset

### DIFF
--- a/src/config/networks.ts
+++ b/src/config/networks.ts
@@ -6,9 +6,9 @@ export const SERVER_URL = import.meta.env.VITE_NODE_ENV === 'production'
   ? import.meta.env.VITE_SERVER_URL_PRODUCTION
   : import.meta.env.VITE_SERVER_URL_DEVELOPMENT;
 
-export const EXPLORER_BASE = import.meta.env.VITE_NODE_ENV === 'production'
+export const EXPLORER_BASE = (import.meta.env.VITE_NODE_ENV === 'production'
   ? import.meta.env.VITE_EXPLORER_URL_PRODUCTION
-  : import.meta.env.VITE_EXPLORER_URL_DEVELOPMENT;
+  : import.meta.env.VITE_EXPLORER_URL_DEVELOPMENT) || 'https://zondscan.com';
 
 export const QRL_PROVIDER = {
   TEST_NET: {


### PR DESCRIPTION
When VITE_EXPLORER_URL_* is missing from the runtime env, EXPLORER_BASE resolved to undefined, so explorer links built as
\`\${undefined}/address/...\` got treated as relative URLs under the current origin (e.g. qrlwallet.com/undefined/address/Q...). Fall back to https://zondscan.com at the config level so every call site — address QR codes, tx hash links, pending-tx API, token discovery — gets a valid absolute URL without needing the manual
"|| 'https://zondscan.com'" guards sprinkled in TransactionSuccessful and TokenStatus.

https://claude.ai/code/session_01KSiU5tGqdbqFwjh8CrrrHK