### PR TITLE
fix(home): harden video autoplay and hide play-button overlay properly

### DIFF
--- a/src/components/Core/Body/Home/Home.tsx
+++ b/src/components/Core/Body/Home/Home.tsx
@@ -45,21 +45,29 @@ const Home = observer(() => {
     return openDialogs.length > 0;
   };
 
-  // Kick off playback of the active-account card video. iOS Safari and some
-  // other browsers don't reliably honor the autoPlay attribute on
-  // React-managed <video> elements after a route change, so call play()
-  // explicitly once the element is mounted. isLoading is in the deps
-  // because the <video> is gated behind the loading spinner; without it
-  // the effect first runs while the ref is still null and never re-runs
-  // once the element actually mounts.
+  // WebKit-based browsers (Safari and Chrome on iOS both) don't reliably
+  // honor the autoPlay attribute on React-managed <video> elements after
+  // a route change. The <video>'s onCanPlay handler below covers the
+  // normal case; this effect is a backup for when the element was
+  // buffered in a previous render (canPlay already fired) and it just
+  // needs a nudge.
   useEffect(() => {
     const video = activeAccountVideoRef.current;
-    if (!video) return;
+    if (!video || !video.paused) return;
     video.play().catch(() => {
       // Autoplay policy may still block playback; fail silently so the
       // element degrades to a static first frame.
     });
   }, [activeAccount.accountAddress, isLoading]);
+
+  const handleVideoCanPlay = (e: React.SyntheticEvent<HTMLVideoElement>) => {
+    const video = e.currentTarget;
+    if (!video.paused) return;
+    video.play().catch(() => {
+      // Autoplay policy may still block playback; fail silently so the
+      // element degrades to a static first frame.
+    });
+  };
 
   // Set up auto-refresh for balances
   useEffect(() => {
@@ -141,6 +149,9 @@ const Home = observer(() => {
                       loop
                       playsInline
                       preload="auto"
+                      disableRemotePlayback
+                      onCanPlay={handleVideoCanPlay}
+                      onLoadedData={handleVideoCanPlay}
                       className="decorative-video w-full h-full object-cover opacity-30"
                     >
                       <source src="qrl-video-dark.mp4" type="video/mp4" />

--- a/src/index.css
+++ b/src/index.css
@@ -249,16 +249,20 @@
     user-select: none;
   }
 
-  /* Hide WebKit's overlay play-button on decorative background videos
-     when autoplay is blocked (e.g. iOS Safari), so they degrade to a
-     static first frame instead of showing a prominent play icon. */
-  .decorative-video::-webkit-media-controls,
-  .decorative-video::-webkit-media-controls-start-playback-button,
-  .decorative-video::-webkit-media-controls-overlay-play-button,
-  .decorative-video::-webkit-media-controls-panel {
-    display: none !important;
-    -webkit-appearance: none;
-  }
-
   /* min-height handled by Body.tsx (md: only) to avoid bottom gaps on mobile */
+}
+
+/* Hide WebKit's overlay play-button on decorative background videos when
+   autoplay is blocked (Safari and Chrome on iOS both use WebKit). These
+   rules sit outside @layer base so they outrank the UA stylesheet for
+   the shadow-DOM pseudo-elements. */
+.decorative-video::-webkit-media-controls,
+.decorative-video::-webkit-media-controls-start-playback-button,
+.decorative-video::-webkit-media-controls-overlay-play-button,
+.decorative-video::-webkit-media-controls-panel,
+.decorative-video::-webkit-media-controls-enclosure {
+  display: none !important;
+  -webkit-appearance: none !important;
+  pointer-events: none !important;
+  opacity: 0 !important;
 }


### PR DESCRIPTION
The previous attempt still left the active-account card video paused after a Transfer → Home navigation on iOS, and WebKit's play-button overlay stayed visible behind the balance.

- Video wasn't playing: useEffect called play() on mount, but for a fresh video element the data isn't buffered yet and play() rejects silently. Added onCanPlay and onLoadedData handlers that call play() once the element is actually ready; the useEffect is kept as a backup for re-renders where the video is already buffered.

- Play-button overlay was still showing: the ::-webkit-media-controls-* rules were inside @layer base, which has lower specificity than the UA stylesheet for those shadow-DOM pseudo-elements. Moved the block outside @layer base and also hid ::-webkit-media-controls-enclosure, with opacity / pointer-events fallbacks in case a given WebKit build ignores display: none on a specific pseudo.

- Added disableRemotePlayback on the <video> so AirPlay etc. don't introduce another set of surface controls.

https://claude.ai/code/session_01KSiU5tGqdbqFwjh8CrrrHK