### PR TITLE
feat!: adopt hardened QRC20 factory ABI + drop owner param from createToken

### DIFF
--- a/src/abi/CustomERC20ABI.ts
+++ b/src/abi/CustomERC20ABI.ts
@@ -1,4 +1,4 @@
-const CustomERC20ABI: [
+const customERC20ABI = [
     {
         "inputs": [
             {
@@ -73,6 +73,63 @@ const CustomERC20ABI: [
             }
         ],
         "name": "Approval",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "bool",
+                "name": "excluded",
+                "type": "bool"
+            }
+        ],
+        "name": "ExcludedFromLimitsUpdated",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "previousValue",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "newValue",
+                "type": "uint256"
+            }
+        ],
+        "name": "MaxTxLimitUpdated",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "previousValue",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "newValue",
+                "type": "uint256"
+            }
+        ],
+        "name": "MaxWalletAmountUpdated",
         "type": "event"
     },
     {
@@ -248,6 +305,25 @@ const CustomERC20ABI: [
         "type": "function"
     },
     {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "isExcludedFromLimits",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
         "inputs": [],
         "name": "maxSupply",
         "outputs": [
@@ -287,6 +363,24 @@ const CustomERC20ABI: [
         "type": "function"
     },
     {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "to",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "mint",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
         "inputs": [],
         "name": "name",
         "outputs": [
@@ -315,6 +409,50 @@ const CustomERC20ABI: [
     {
         "inputs": [],
         "name": "renounceOwnership",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            },
+            {
+                "internalType": "bool",
+                "name": "excluded",
+                "type": "bool"
+            }
+        ],
+        "name": "setExcludedFromLimits",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "newValue",
+                "type": "uint256"
+            }
+        ],
+        "name": "setMaxTxLimit",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "newValue",
+                "type": "uint256"
+            }
+        ],
+        "name": "setMaxWalletAmount",
         "outputs": [],
         "stateMutability": "nonpayable",
         "type": "function"
@@ -411,419 +549,6 @@ const CustomERC20ABI: [
         "stateMutability": "nonpayable",
         "type": "function"
     }
-] = [
-        {
-            "inputs": [
-                {
-                    "internalType": "string",
-                    "name": "name_",
-                    "type": "string"
-                },
-                {
-                    "internalType": "string",
-                    "name": "symbol_",
-                    "type": "string"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "initialSupply_",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint8",
-                    "name": "decimals_",
-                    "type": "uint8"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "maxSupply_",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "address",
-                    "name": "recipient_",
-                    "type": "address"
-                },
-                {
-                    "internalType": "address",
-                    "name": "owner_",
-                    "type": "address"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "maxWalletAmount_",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "maxTxLimit_",
-                    "type": "uint256"
-                }
-            ],
-            "stateMutability": "nonpayable",
-            "type": "constructor"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": true,
-                    "internalType": "address",
-                    "name": "owner",
-                    "type": "address"
-                },
-                {
-                    "indexed": true,
-                    "internalType": "address",
-                    "name": "spender",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "value",
-                    "type": "uint256"
-                }
-            ],
-            "name": "Approval",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": true,
-                    "internalType": "address",
-                    "name": "previousOwner",
-                    "type": "address"
-                },
-                {
-                    "indexed": true,
-                    "internalType": "address",
-                    "name": "newOwner",
-                    "type": "address"
-                }
-            ],
-            "name": "OwnershipTransferred",
-            "type": "event"
-        },
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": true,
-                    "internalType": "address",
-                    "name": "from",
-                    "type": "address"
-                },
-                {
-                    "indexed": true,
-                    "internalType": "address",
-                    "name": "to",
-                    "type": "address"
-                },
-                {
-                    "indexed": false,
-                    "internalType": "uint256",
-                    "name": "value",
-                    "type": "uint256"
-                }
-            ],
-            "name": "Transfer",
-            "type": "event"
-        },
-        {
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "owner",
-                    "type": "address"
-                },
-                {
-                    "internalType": "address",
-                    "name": "spender",
-                    "type": "address"
-                }
-            ],
-            "name": "allowance",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "spender",
-                    "type": "address"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "amount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "approve",
-            "outputs": [
-                {
-                    "internalType": "bool",
-                    "name": "",
-                    "type": "bool"
-                }
-            ],
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "account",
-                    "type": "address"
-                }
-            ],
-            "name": "balanceOf",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "inputs": [],
-            "name": "decimals",
-            "outputs": [
-                {
-                    "internalType": "uint8",
-                    "name": "",
-                    "type": "uint8"
-                }
-            ],
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "spender",
-                    "type": "address"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "subtractedValue",
-                    "type": "uint256"
-                }
-            ],
-            "name": "decreaseAllowance",
-            "outputs": [
-                {
-                    "internalType": "bool",
-                    "name": "",
-                    "type": "bool"
-                }
-            ],
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "spender",
-                    "type": "address"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "addedValue",
-                    "type": "uint256"
-                }
-            ],
-            "name": "increaseAllowance",
-            "outputs": [
-                {
-                    "internalType": "bool",
-                    "name": "",
-                    "type": "bool"
-                }
-            ],
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "inputs": [],
-            "name": "maxSupply",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "inputs": [],
-            "name": "maxTxLimit",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "inputs": [],
-            "name": "maxWalletAmount",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "inputs": [],
-            "name": "name",
-            "outputs": [
-                {
-                    "internalType": "string",
-                    "name": "",
-                    "type": "string"
-                }
-            ],
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "inputs": [],
-            "name": "owner",
-            "outputs": [
-                {
-                    "internalType": "address",
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "inputs": [],
-            "name": "renounceOwnership",
-            "outputs": [],
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "inputs": [],
-            "name": "symbol",
-            "outputs": [
-                {
-                    "internalType": "string",
-                    "name": "",
-                    "type": "string"
-                }
-            ],
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "inputs": [],
-            "name": "totalSupply",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "recipient",
-                    "type": "address"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "amount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "transfer",
-            "outputs": [
-                {
-                    "internalType": "bool",
-                    "name": "",
-                    "type": "bool"
-                }
-            ],
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "sender",
-                    "type": "address"
-                },
-                {
-                    "internalType": "address",
-                    "name": "recipient",
-                    "type": "address"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "amount",
-                    "type": "uint256"
-                }
-            ],
-            "name": "transferFrom",
-            "outputs": [
-                {
-                    "internalType": "bool",
-                    "name": "",
-                    "type": "bool"
-                }
-            ],
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "newOwner",
-                    "type": "address"
-                }
-            ],
-            "name": "transferOwnership",
-            "outputs": [],
-            "stateMutability": "nonpayable",
-            "type": "function"
-        }
-    ];
+] as const;
 
-export default CustomERC20ABI;
+export { customERC20ABI };

--- a/src/abi/CustomERC20FactoryABI.ts
+++ b/src/abi/CustomERC20FactoryABI.ts
@@ -1,4 +1,4 @@
-const customERC20FactoryABI: [
+const customERC20FactoryABI = [
     {
         "anonymous": false,
         "inputs": [
@@ -51,11 +51,6 @@ const customERC20FactoryABI: [
                 "type": "address"
             },
             {
-                "internalType": "address",
-                "name": "owner_",
-                "type": "address"
-            },
-            {
                 "internalType": "uint256",
                 "name": "maxWalletAmount_",
                 "type": "uint256"
@@ -77,85 +72,6 @@ const customERC20FactoryABI: [
         "stateMutability": "nonpayable",
         "type": "function"
     }
-] = [
-        {
-            "anonymous": false,
-            "inputs": [
-                {
-                    "indexed": true,
-                    "internalType": "address",
-                    "name": "tokenAddress",
-                    "type": "address"
-                },
-                {
-                    "indexed": true,
-                    "internalType": "address",
-                    "name": "owner",
-                    "type": "address"
-                }
-            ],
-            "name": "TokenCreated",
-            "type": "event"
-        },
-        {
-            "inputs": [
-                {
-                    "internalType": "string",
-                    "name": "name_",
-                    "type": "string"
-                },
-                {
-                    "internalType": "string",
-                    "name": "symbol_",
-                    "type": "string"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "initialSupply_",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint8",
-                    "name": "decimals_",
-                    "type": "uint8"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "maxSupply_",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "address",
-                    "name": "recipient_",
-                    "type": "address"
-                },
-                {
-                    "internalType": "address",
-                    "name": "owner_",
-                    "type": "address"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "maxWalletAmount_",
-                    "type": "uint256"
-                },
-                {
-                    "internalType": "uint256",
-                    "name": "maxTxLimit_",
-                    "type": "uint256"
-                }
-            ],
-            "name": "createToken",
-            "outputs": [
-                {
-                    "internalType": "address",
-                    "name": "",
-                    "type": "address"
-                }
-            ],
-            "stateMutability": "nonpayable",
-            "type": "function"
-        }
-    ];
+] as const;
 
 export { customERC20FactoryABI };

--- a/src/components/Core/Body/CreateToken/CreateToken.tsx
+++ b/src/components/Core/Body/CreateToken/CreateToken.tsx
@@ -9,18 +9,16 @@ const CreateToken = observer(() => {
         createToken,
     } = qrlStore;
 
-    const onTokenCreated = async (tokenName: string, tokenSymbol: string, initialSupply: string, decimals: number, maxSupply: undefined | string, initialRecipient: undefined | string, tokenOwner: undefined | string, maxWalletAmount: undefined | string, maxTransactionLimit: undefined | string, mnemonicPhrases: string) => {
+    const onTokenCreated = async (tokenName: string, tokenSymbol: string, initialSupply: string, decimals: number, maxSupply: undefined | string, initialRecipient: undefined | string, maxWalletAmount: undefined | string, maxTransactionLimit: undefined | string, mnemonicPhrases: string) => {
 
         if (!initialRecipient) {
             initialRecipient = "Q0000000000000000000000000000000000000000";
         }
 
-        if (!tokenOwner) {
-            tokenOwner = "Q0000000000000000000000000000000000000000";
-        }
-
+        // Factory requires maxSupply > 0 and maxSupply >= initialSupply.
+        // Default to initialSupply so "leave blank" means "fixed supply".
         if (!maxSupply) {
-            maxSupply = "0";
+            maxSupply = initialSupply;
         }
 
         if (!maxWalletAmount) {
@@ -38,7 +36,6 @@ const CreateToken = observer(() => {
             decimals,
             maxSupply,
             initialRecipient,
-            tokenOwner,
             maxWalletAmount,
             maxTransactionLimit,
             mnemonicPhrases

--- a/src/components/Core/Body/CreateToken/TokenCreationForm/TokenCreationForm.tsx
+++ b/src/components/Core/Body/CreateToken/TokenCreationForm/TokenCreationForm.tsx
@@ -44,8 +44,6 @@ const FormSchema = z
         maxSupply: z.string().optional(),
         changeInitialRecipient: z.boolean(),
         recipientAddress: z.string().optional(),
-        changeTokenOwner: z.boolean(),
-        ownerAddress: z.string().optional(),
         setMaxWalletAmount: z.boolean(),
         maxWalletAmount: z.string().optional(),
         setMaxTransactionLimit: z.boolean(),
@@ -60,20 +58,10 @@ const FormSchema = z
     }, {
         message: "Invalid recipient address. Must be 41 characters starting with 'Q' followed by 40 hex characters",
         path: ["recipientAddress"]
-    })
-    .refine((data) => {
-        // Validate owner address if changeTokenOwner is true
-        if (data.changeTokenOwner && data.ownerAddress) {
-            return isValidQrlAddress(data.ownerAddress);
-        }
-        return true;
-    }, {
-        message: "Invalid owner address. Must be 41 characters starting with 'Q' followed by 40 hex characters",
-        path: ["ownerAddress"]
     });
 
 type TokenCreationFormProps = {
-    onTokenCreated: (tokenName: string, tokenSymbol: string, initialSupply: string, decimals: number, maxSupply: undefined | string, initialRecipient: undefined | string, tokenOwner: undefined | string, maxWalletAmount: undefined | string, maxTransactionLimit: undefined | string, mnemonicPhrases: string) => Promise<void>;
+    onTokenCreated: (tokenName: string, tokenSymbol: string, initialSupply: string, decimals: number, maxSupply: undefined | string, initialRecipient: undefined | string, maxWalletAmount: undefined | string, maxTransactionLimit: undefined | string, mnemonicPhrases: string) => Promise<void>;
 };
 
 export const TokenCreationForm = observer(
@@ -96,7 +84,6 @@ export const TokenCreationForm = observer(
                 decimals: 18,
                 mintable: false,
                 changeInitialRecipient: false,
-                changeTokenOwner: false,
                 setMaxWalletAmount: false,
                 setMaxTransactionLimit: false,
             },
@@ -173,7 +160,6 @@ export const TokenCreationForm = observer(
                 const decimals = formData.decimals;
                 const maxSupply = formData.maxSupply ? ethers.parseUnits(formData.maxSupply, decimals).toString() : undefined;
                 const recipientAddress = formData.recipientAddress;
-                const ownerAddress = formData.ownerAddress;
                 const maxWalletAmount = formData.maxWalletAmount ? ethers.parseUnits(formData.maxWalletAmount, decimals).toString() : undefined;
                 const maxTransactionLimit = formData.maxTransactionLimit ? ethers.parseUnits(formData.maxTransactionLimit, decimals).toString() : undefined;
 
@@ -182,7 +168,7 @@ export const TokenCreationForm = observer(
                 navigate(ROUTES.TOKEN_STATUS);
 
                 // Start token creation in background (don't await here)
-                onTokenCreated(tokenName, tokenSymbol, initialSupply, decimals, maxSupply, recipientAddress, ownerAddress, maxWalletAmount, maxTransactionLimit, mnemonicPhrase)
+                onTokenCreated(tokenName, tokenSymbol, initialSupply, decimals, maxSupply, recipientAddress, maxWalletAmount, maxTransactionLimit, mnemonicPhrase)
                     .catch((error) => {
                         console.error("Token creation failed:", error);
                         // The error state is set within qrlStore and displayed on the status page
@@ -201,7 +187,6 @@ export const TokenCreationForm = observer(
                 decimals: 18,
                 mintable: false,
                 changeInitialRecipient: false,
-                changeTokenOwner: false,
                 setMaxWalletAmount: false,
                 setMaxTransactionLimit: false,
             });
@@ -400,51 +385,6 @@ export const TokenCreationForm = observer(
                                     render={({ field }) => (
                                         <FormItem>
                                             <Label>Recipient Address</Label>
-                                            <FormControl>
-                                                <Input
-                                                    {...field}
-                                                    disabled={isSubmitting}
-                                                    placeholder="Example: Q20b4fb2929cfBe8b002b8A0c572551F755e54aEF"
-                                                    type="text"
-                                                />
-                                            </FormControl>
-                                            <FormMessage />
-                                        </FormItem>
-                                    )}
-                                />
-                            )}
-                            <FormField
-                                control={control}
-                                name="changeTokenOwner"
-                                render={({ field }) => (
-                                    <FormItem>
-                                        <FormControl>
-                                            <div className="flex items-center space-x-2">
-                                                <Checkbox
-                                                    checked={field.value}
-                                                    onCheckedChange={field.onChange}
-                                                    disabled={isSubmitting}
-                                                    id="changeTokenOwner"
-                                                />
-                                                <label
-                                                    htmlFor="changeTokenOwner"
-                                                    className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-                                                >
-                                                    Change Token Owner
-                                                </label>
-                                            </div>
-                                        </FormControl>
-                                        <FormMessage />
-                                    </FormItem>
-                                )}
-                            />
-                            {form.watch("changeTokenOwner") && (
-                                <FormField
-                                    control={control}
-                                    name="ownerAddress"
-                                    render={({ field }) => (
-                                        <FormItem>
-                                            <Label>Owner Address</Label>
                                             <FormControl>
                                                 <Input
                                                     {...field}

--- a/src/stores/qrlStore.ts
+++ b/src/stores/qrlStore.ts
@@ -11,7 +11,7 @@ import { action, computed, makeAutoObservable, observable, runInAction } from "m
 import { customERC20FactoryABI } from "@/abi/CustomERC20FactoryABI";
 import { fetchTokenInfo, fetchBalance, discoverTokens, mergeTokenLists } from "@/utils/web3";
 import { TokenInterface, KNOWN_TOKEN_LIST } from "@/constants";
-import CustomERC20ABI from "@/abi/CustomERC20ABI";
+import { customERC20ABI as CustomERC20ABI } from "@/abi/CustomERC20ABI";
 import { formatUnits } from "ethers";
 import { getOptimalTokenBalance } from "@/utils/formatting";
 
@@ -812,7 +812,6 @@ class QrlStore {
     decimals: number,
     maxSupply: string,
     receipt: string,
-    owner: string,
     maxWalletAmount: string,
     maxTxLimit: string,
     mnemonicPhrases: string
@@ -906,14 +905,15 @@ class QrlStore {
         decimals,
         maxSupply,
         receipt,
-        owner,
         maxWalletAmount,
         maxTxLimit
       );
 
-      const estimateGas = await contractCreateToken.estimateGas({ "from": acc.address })
+      const estimatedGas = await contractCreateToken.estimateGas({ from: acc.address })
+      const gas = (estimatedGas * 12n) / 10n
+      const gasPrice = await web3.qrl.getGasPrice()
 
-      const txObj = { type: '0x2', gas: estimateGas, from: acc.address, data: contractCreateToken.encodeABI(), to: contractAddress }
+      const txObj = { gas, gasPrice, from: acc.address, data: contractCreateToken.encodeABI(), to: contractAddress }
 
       await web3.qrl.sendTransaction(txObj, undefined, {
         checkRevertBeforeSending: true

--- a/src/utils/web3/customERC20.ts
+++ b/src/utils/web3/customERC20.ts
@@ -1,5 +1,5 @@
 import Web3 from "@theqrl/web3";
-import CustomERC20ABI from "@/abi/CustomERC20ABI";
+import { customERC20ABI as CustomERC20ABI } from "@/abi/CustomERC20ABI";
 
 const fetchBalance = async (contractAddress: string, accountAddress: string, rpc_url: string) => {
     const web3 = new Web3(new Web3.providers.HttpProvider(rpc_url));


### PR DESCRIPTION
## Summary

Coordinated frontend update for the hardened QRC20 factory in [DigitalGuards/QRLv2-QRC20-Factory#6](https://github.com/DigitalGuards/QRLv2-QRC20-Factory/pull/6) (merged). The hardening PR addresses 2 High + 2 Medium findings from the security audit: enforced `maxSupply`, mutable caps via owner-gated setters, owner forced to `msg.sender` at the factory, `decimals ≤ 18`, and defense-in-depth constructor guards. This PR brings the wallet into ABI + signature compliance and updates the UI to match.

## What changed

- **`src/abi/CustomERC20FactoryABI.ts`**: regenerated — `createToken` now has 8 params (dropped `owner_`).
- **`src/abi/CustomERC20ABI.ts`**: regenerated — includes new `mint`, `setMaxWalletAmount`, `setMaxTxLimit`, `setExcludedFromLimits`, `isExcludedFromLimits` entries plus `MaxWalletAmountUpdated`, `MaxTxLimitUpdated`, `ExcludedFromLimitsUpdated` events.
- Both ABI files shipped previously with invalid syntax (`const X: [...]` — type annotation, no initializer). Regenerated with `const X = [...] as const`. Strict `tsc` now catches it; the old toolchain was silently letting this slide.
- **Import hygiene**: `CustomERC20ABI` is imported as a named export (`import { customERC20ABI as CustomERC20ABI }`) in `qrlStore.ts` and `customERC20.ts` — matches the ABI file's export shape.
- **`src/stores/qrlStore.ts`**:
  - `createToken()` signature drops `owner` arg.
  - Transaction object drops `type: '0x2'` (EIP-1559 with `gasPrice` is wrong per spec — same refactor we applied in the factory scripts).
  - Adds 20% gas buffer via BigInt math (`estimatedGas * 12n / 10n`) to absorb estimate drift.
- **`src/components/Core/Body/CreateToken/CreateToken.tsx`**: drops `tokenOwner` propagation. Defaults blank `maxSupply` to `initialSupply` — matches the "Mintable checkbox off" UX where the token is fixed-supply with `totalSupply == maxSupply`.
- **`src/components/Core/Body/CreateToken/TokenCreationForm/TokenCreationForm.tsx`**: removes the "Change Token Owner" checkbox, owner-address input, and the zod `refine` that validated it. Updated `onTokenCreated` signature.

## Breaking change

The `createToken` public surface in `qrlStore` drops one positional arg. This is an internal API — only the `CreateToken.tsx` / `TokenCreationForm.tsx` call site consumes it, and both have been updated in this PR. Not a public-facing breaking change.

The new factory at `Q1b7cff4399f7e3a96f5321d72fe050401de97e5a` is already on `ops@49.13.162.117` prod+dev `.env`s as `VITE_CUSTOMERC20FACTORY_ADDRESS`. Rebuilding + deploying this branch completes the swap.

## Validation

- [x] `npm run lint` — clean
- [x] `npm run build` — tsc + vite both clean (no warnings beyond the pre-existing chunk-size notice)
- [ ] Post-merge: rebuild on `ops@49.13.162.117` and smoke-test token creation against the new factory via the UI

## Notes

V1-factory tokens (`Qa5a330ce…` and its children, plus the `Qa9243a…` MQW test token created via the live UI earlier) continue to exist on-chain under the old cap-immutable / owner-forgeable semantics. The wallet's token-discovery flow will still show them because they're standard ERC20s — the hardening only affects new tokens minted against the new factory.