### PR TITLE
docs: document dApp Connect feature + link sibling repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A modern, secure web wallet for the Quantum Resistant Ledger's QRL 2.0 blockchai
 - **Token Discovery** - Automatic detection of tokens held by your address
 - **Multi-Network** - Testnet, Mainnet, and custom RPC support
 - **Mobile App Integration** - Native features when running in [MyQRLWallet App](https://github.com/DigitalGuards/myqrlwallet-app)
+- **dApp Connect** - Pair with web dApps by scanning a `qrlconnect://` QR code in the mobile app or tapping a deep link. Handshake and session management run through the [`@qrlwallet/connect`](https://github.com/DigitalGuards/myqrlwallet-connect) SDK with a post-quantum key exchange (ML-KEM-768) and an E2E-encrypted relay channel.
 - **Responsive Design** - Works on desktop and mobile browsers
 
 ## Getting Started
@@ -207,10 +208,30 @@ When running inside the [MyQRLWallet App](https://github.com/DigitalGuards/myqrl
 - **Native Share** - System share sheet
 - **Secure Storage** - Seeds backed up in device SecureStore (iOS Keychain / Android Keystore)
 
+## dApp Connect
+
+The wallet pairs with web dApps over an E2E-encrypted relay channel driven by [`@qrlwallet/connect`](https://github.com/DigitalGuards/myqrlwallet-connect). The dApp publishes a `qrlconnect://` URI (rendered as a QR code or a mobile deep-link button), the wallet joins the channel, and all subsequent dApp ↔ wallet traffic (account requests, transaction signing, `accountsChanged` events) flows encrypted end-to-end.
+
+**Entry points** — one of:
+
+- **QR scan from the mobile app**: tapping "Scan dApp" in MyQRLWallet App opens the native camera; the URI is forwarded to the web wallet as `DAPP_URI`.
+- **Deep link**: tapping a `qrlconnect://…` link in the mobile browser opens MyQRLWallet App, which forwards the URI to the web wallet.
+- **Paste in desktop**: on desktop, a user can paste a `qrlconnect://…` URI into the wallet's dApp Connect screen directly.
+
+**Approval UX** is rendered in the web wallet only — a single source of truth for session approval, signing prompts, and disconnect. The mobile shell is a passive transport.
+
+**Handshake**: post-quantum key exchange (ML-KEM-768) + fingerprint verification against the PK the dApp published to the relay. SYN / SYNACK / ACK is idempotent (duplicate or late messages don't double-connect).
+
+**Session lifecycle**: stored in `localStorage` for auto-reconnect across browser refresh and app relaunch. Either side can disconnect; if the dApp leaves the relay channel, the wallet uses a grace-period stale-session timeout before cleanup.
+
+See [`src/services/dappConnect/`](src/services/dappConnect/) for the wallet-side service, [`DigitalGuards/myqrlwallet-connect`](https://github.com/DigitalGuards/myqrlwallet-connect) for the SDK consumed by dApps.
+
 ## Related Projects
 
-- [myqrlwallet-backend](https://github.com/DigitalGuards/myqrlwallet-backend) - API server (RPC proxy, support email, tx history)
-- [myqrlwallet-app](https://github.com/DigitalGuards/myqrlwallet-app) - React Native mobile app
+- [myqrlwallet-backend](https://github.com/DigitalGuards/myqrlwallet-backend) - API server (RPC proxy, support email, tx history, dApp Connect relay)
+- [myqrlwallet-app](https://github.com/DigitalGuards/myqrlwallet-app) - React Native mobile app (native QR scanning, `qrlconnect://` deep-link handler, SecureStore seed backup)
+- [myqrlwallet-connect](https://github.com/DigitalGuards/myqrlwallet-connect) - `@qrlwallet/connect` npm SDK that dApps use to pair with MyQRLWallet
+- [QRC20-Factory](https://github.com/DigitalGuards/QRC20-Factory) - Hyperion contracts + deploy scripts for the custom QRC20 token factory consumed by the Create Token flow
 - [QuantaPool](https://github.com/DigitalGuards/QuantaPool) - Liquid staking protocol
 
 ## Security


### PR DESCRIPTION
## Summary

The README currently doesn't mention dApp Connect at all — despite it being a major shipping feature (post-quantum handshake landed in [#119](https://github.com/DigitalGuards/myqrlwallet-frontend/pull/119) + PQP2 in [#123](https://github.com/DigitalGuards/myqrlwallet-frontend/pull/123)) and despite `@qrlwallet/connect` being a first-class workspace sibling. Also missing the QRC20-Factory link (recently renamed from QRLv2-QRC20-Factory).

## Changes

- **Features list**: add a dApp Connect bullet mentioning the `qrlconnect://` scan + deep-link entry flow, the `@qrlwallet/connect` SDK, and the ML-KEM-768 post-quantum handshake.
- **New 'dApp Connect' section** after Mobile App Integration, covering:
  - Three entry points (QR scan in mobile app / browser deep link / desktop paste)
  - Approval UX contract (web wallet is the single source of truth; mobile shell is a passive transport)
  - Handshake (ML-KEM-768, fingerprint verification, idempotent SYN/SYNACK/ACK)
  - Session lifecycle (localStorage persistence, auto-reconnect, grace-period stale-session cleanup)
  - Pointer to `src/services/dappConnect/` and the SDK repo
- **Related Projects**: add `myqrlwallet-connect` and `QRC20-Factory`. Expand the existing backend + mobile-app one-liners to call out their dApp Connect roles (relay on backend, `qrlconnect://` deep-link handler on mobile).

No code changes. README-only.