### PR TITLE
v2.0: PQP2 parser, fetch+verify PK from relay, nginx example fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A modern, secure web wallet for the Quantum Resistant Ledger's QRL 2.0 blockchai
 - **Token Discovery** - Automatic detection of tokens held by your address
 - **Multi-Network** - Testnet, Mainnet, and custom RPC support
 - **Mobile App Integration** - Native features when running in [MyQRLWallet App](https://github.com/DigitalGuards/myqrlwallet-app)
+- **dApp Connect** - Pair with web dApps by scanning a `qrlconnect://` QR code in the mobile app or tapping a deep link. Handshake and session management run through the [`@qrlwallet/connect`](https://github.com/DigitalGuards/myqrlwallet-connect) SDK with a post-quantum key exchange (ML-KEM-768) and an E2E-encrypted relay channel.
 - **Responsive Design** - Works on desktop and mobile browsers
 
 ## Getting Started
@@ -207,10 +208,30 @@ When running inside the [MyQRLWallet App](https://github.com/DigitalGuards/myqrl
 - **Native Share** - System share sheet
 - **Secure Storage** - Seeds backed up in device SecureStore (iOS Keychain / Android Keystore)
 
+## dApp Connect
+
+The wallet pairs with web dApps over an E2E-encrypted relay channel driven by [`@qrlwallet/connect`](https://github.com/DigitalGuards/myqrlwallet-connect). The dApp publishes a `qrlconnect://` URI (rendered as a QR code or a mobile deep-link button), the wallet joins the channel, and all subsequent dApp ↔ wallet traffic (account requests, transaction signing, `accountsChanged` events) flows encrypted end-to-end.
+
+**Entry points** — one of:
+
+- **QR scan from the mobile app**: tapping "Scan dApp" in MyQRLWallet App opens the native camera; the URI is forwarded to the web wallet as `DAPP_URI`.
+- **Deep link**: tapping a `qrlconnect://…` link in the mobile browser opens MyQRLWallet App, which forwards the URI to the web wallet.
+- **Paste in desktop**: on desktop, a user can paste a `qrlconnect://…` URI into the wallet's dApp Connect screen directly.
+
+**Approval UX** is rendered in the web wallet only — a single source of truth for session approval, signing prompts, and disconnect. The mobile shell is a passive transport.
+
+**Handshake**: post-quantum key exchange (ML-KEM-768) + fingerprint verification against the PK the dApp published to the relay. SYN / SYNACK / ACK is idempotent (duplicate or late messages don't double-connect).
+
+**Session lifecycle**: stored in `localStorage` for auto-reconnect across browser refresh and app relaunch. Either side can disconnect; if the dApp leaves the relay channel, the wallet uses a grace-period stale-session timeout before cleanup.
+
+See [`src/services/dappConnect/`](src/services/dappConnect/) for the wallet-side service, [`DigitalGuards/myqrlwallet-connect`](https://github.com/DigitalGuards/myqrlwallet-connect) for the SDK consumed by dApps.
+
 ## Related Projects
 
-- [myqrlwallet-backend](https://github.com/DigitalGuards/myqrlwallet-backend) - API server (RPC proxy, support email, tx history)
-- [myqrlwallet-app](https://github.com/DigitalGuards/myqrlwallet-app) - React Native mobile app
+- [myqrlwallet-backend](https://github.com/DigitalGuards/myqrlwallet-backend) - API server (RPC proxy, support email, tx history, dApp Connect relay)
+- [myqrlwallet-app](https://github.com/DigitalGuards/myqrlwallet-app) - React Native mobile app (native QR scanning, `qrlconnect://` deep-link handler, SecureStore seed backup)
+- [myqrlwallet-connect](https://github.com/DigitalGuards/myqrlwallet-connect) - `@qrlwallet/connect` npm SDK that dApps use to pair with MyQRLWallet
+- [QRC20-Factory](https://github.com/DigitalGuards/QRC20-Factory) - Hyperion contracts + deploy scripts for the custom QRC20 token factory consumed by the Create Token flow
 - [QuantaPool](https://github.com/DigitalGuards/QuantaPool) - Liquid staking protocol
 
 ## Security

--- a/deploy/nginx.conf.example
+++ b/deploy/nginx.conf.example
@@ -42,6 +42,10 @@ server {
 
     # Security Headers (applied to locations without their own add_header)
     # NOTE: These are NOT inherited by location blocks that have add_header directives
+    # If you serve both apex and www subdomain, adjust connect-src to include
+    # both variants (or use a wildcard like *.yourdomain.com) so CSP doesn't
+    # flag the other variant as cross-origin when a user lands on one but
+    # the API / relay answers on the other.
     add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://yourdomain.com/api/* wss://yourdomain.com https://zondscan.com; img-src 'self' data:; font-src 'self' data:;" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "DENY" always;

--- a/deploy/nginx.conf.example
+++ b/deploy/nginx.conf.example
@@ -15,8 +15,12 @@ server {
 
 # HTTPS server
 server {
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    # Do NOT add `http2` here if nginx < 1.25.1 and Cloudflare is in front.
+    # nginx 1.24 doesn't support WebSocket-over-HTTP/2 (RFC 8441), so CF
+    # opens an HTTP/2 connection to the origin and the relay's WebSocket
+    # dies every ~5s. CF still serves HTTP/2 to end users regardless.
+    listen 443 ssl;
+    listen [::]:443 ssl;
     server_name yourdomain.com www.yourdomain.com;
 
     # SSL Configuration - update paths to your certificates
@@ -38,7 +42,7 @@ server {
 
     # Security Headers (applied to locations without their own add_header)
     # NOTE: These are NOT inherited by location blocks that have add_header directives
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://yourdomain.com/api/* https://zondscan.com; img-src 'self' data:; font-src 'self' data:;" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://yourdomain.com/api/* wss://yourdomain.com https://zondscan.com; img-src 'self' data:; font-src 'self' data:;" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "DENY" always;
     add_header X-XSS-Protection "1; mode=block" always;
@@ -119,9 +123,12 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_cache_bypass $http_upgrade;
 
-        # Long-lived connections for WebSocket
-        proxy_read_timeout 300s;
-        proxy_send_timeout 300s;
+        # Long-lived connections for WebSocket — 24h allows persistent
+        # sessions across phone backgrounding / screen-off cycles.
+        proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
+        # Disable response buffering so WebSocket frames flow immediately.
+        proxy_buffering off;
     }
 
     # Backend down handler - returns JSON error
@@ -135,7 +142,7 @@ server {
         expires 1y;
         # IMPORTANT: Must repeat security headers since this block has add_header
         add_header Cache-Control "public, no-transform";
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://yourdomain.com/api/* https://zondscan.com; img-src 'self' data:; font-src 'self' data:;" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://yourdomain.com/api/* wss://yourdomain.com https://zondscan.com; img-src 'self' data:; font-src 'self' data:;" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-Frame-Options "DENY" always;
         add_header X-XSS-Protection "1; mode=block" always;
@@ -148,7 +155,7 @@ server {
         try_files $uri $uri/ /index.html?$args;
 
         # Security Headers (must be repeated here because add_header clears parent headers)
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://yourdomain.com/api/* https://zondscan.com; img-src 'self' data:; font-src 'self' data:;" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://yourdomain.com/api/* wss://yourdomain.com https://zondscan.com; img-src 'self' data:; font-src 'self' data:;" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-Frame-Options "DENY" always;
         add_header X-XSS-Protection "1; mode=block" always;
@@ -157,7 +164,7 @@ server {
         # Prevent caching of index.html for instant updates
         # IMPORTANT: Must repeat security headers since this block has add_header
         add_header Cache-Control "no-store, no-cache, must-revalidate" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://yourdomain.com/api/* https://zondscan.com; img-src 'self' data:; font-src 'self' data:;" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://yourdomain.com/api/* wss://yourdomain.com https://zondscan.com; img-src 'self' data:; font-src 'self' data:;" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-Frame-Options "DENY" always;
         add_header X-XSS-Protection "1; mode=block" always;

--- a/src/services/dappConnect/DAppConnectService.ts
+++ b/src/services/dappConnect/DAppConnectService.ts
@@ -9,7 +9,6 @@
 import {
   KeyExchange,
   type AckMessage,
-  type SynAckMessage,
 } from './KeyExchange';
 import { parseConnectionURI, cidToString, computeFingerprint, fingerprintEquals } from './qrUri';
 import { fromBase64 } from './PQCrypto';
@@ -219,16 +218,7 @@ export class DAppConnectService {
       }
       connection.dappPublicKey = pk;
 
-      let synack: SynAckMessage;
-      try {
-        synack = await keyExchange.receiveQR(parsed.cid, pk);
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        dlog(`KEM encaps failed: ${msg}`);
-        this.connections.delete(channelId);
-        this.handlers?.onSessionsChanged();
-        return { success: false, error: msg };
-      }
+      const synack = await keyExchange.receiveQR(parsed.cid, pk);
 
       // Send SYNACK — this kicks off the visible portion of the handshake.
       await socketClient.sendMessage({
@@ -245,6 +235,16 @@ export class DAppConnectService {
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);
       dlog(`Connection failed: ${errMsg}`);
+      // Tear the half-built connection down completely: without the
+      // socketClient.disconnect() below, the underlying socket stays
+      // joined to the relay channel and keeps firing onMessage handlers
+      // for a channel whose ActiveConnection we've already dropped.
+      try {
+        socketClient.leaveChannel();
+      } catch {
+        // ignore — we're already in the error path
+      }
+      socketClient.disconnect();
       this.connections.delete(channelId);
       SessionStore.remove(channelId);
       this.handlers?.onSessionsChanged();
@@ -330,7 +330,11 @@ export class DAppConnectService {
           await conn.keyExchange.onAck(message as AckMessage);
         } catch (err) {
           dlog(`ACK verify failed: ${err instanceof Error ? err.message : err}`);
-          this.disconnectSession(channelId, false);
+          // Fire-and-forget: we're inside the per-channel message queue
+          // handler. Awaiting disconnectSession here would block the queue
+          // during the 800ms TERMINATE flush and stall any buffered ACK
+          // follow-ups on other channels.
+          void this.disconnectSession(channelId, false);
         }
         return;
       }
@@ -430,7 +434,10 @@ export class DAppConnectService {
       }
 
       case MessageType.TERMINATE: {
-        this.disconnectSession(channelId);
+        // Fire-and-forget: we're in the inbound message handler, and we
+        // don't need to round-trip a TERMINATE back at the dApp that just
+        // sent us one.
+        void this.disconnectSession(channelId);
         break;
       }
 
@@ -489,15 +496,12 @@ export class DAppConnectService {
     if (isInNativeApp()) triggerHaptic('error');
   }
 
-  disconnectSession(channelId: string, explicit = true): void {
+  async disconnectSession(channelId: string, explicit = true): Promise<void> {
     dlog(`disconnectSession called for ${channelId}`);
     this.clearDappLeaveTimeout(channelId);
     const conn = this.connections.get(channelId);
-    let finalized = false;
-    const finalize = () => {
-      if (finalized) return;
-      finalized = true;
 
+    const finalize = () => {
       const activeConn = this.connections.get(channelId);
       if (activeConn) {
         activeConn.socketClient.leaveChannel();
@@ -534,12 +538,14 @@ export class DAppConnectService {
       }
     };
 
-    void Promise.race([
-      sendTerminate(),
-      new Promise((resolve) => setTimeout(resolve, TERMINATE_SEND_TIMEOUT_MS)),
-    ]).finally(() => {
+    try {
+      await Promise.race([
+        sendTerminate(),
+        new Promise((resolve) => setTimeout(resolve, TERMINATE_SEND_TIMEOUT_MS)),
+      ]);
+    } finally {
       finalize();
-    });
+    }
   }
 
   getActiveSessions(): DAppSession[] {
@@ -621,11 +627,11 @@ export class DAppConnectService {
     this.handlers?.onSessionsChanged();
   }
 
-  disconnectAll(): void {
+  async disconnectAll(): Promise<void> {
     dlog(`disconnectAll called with ${this.connections.size} connections`);
-    for (const channelId of this.connections.keys()) {
-      this.disconnectSession(channelId);
-    }
+    // Snapshot before awaiting — disconnectSession mutates the map.
+    const channelIds = Array.from(this.connections.keys());
+    await Promise.all(channelIds.map((cid) => this.disconnectSession(cid)));
   }
 
   static isConnectionURI(uri: string): boolean {
@@ -659,7 +665,8 @@ export class DAppConnectService {
       this.dappLeaveTimers.delete(channelId);
       if (!this.connections.has(channelId)) return;
       dlog(`dApp absent for ${DAPP_REJOIN_GRACE_MS}ms; disconnecting`);
-      this.disconnectSession(channelId, false);
+      // Fire-and-forget: this is a setTimeout callback, nothing to await into.
+      void this.disconnectSession(channelId, false);
     }, DAPP_REJOIN_GRACE_MS);
     this.dappLeaveTimers.set(channelId, timeout);
     dlog(`Scheduled stale-session timeout for channel ${channelId}`);

--- a/src/services/dappConnect/DAppConnectService.ts
+++ b/src/services/dappConnect/DAppConnectService.ts
@@ -330,11 +330,14 @@ export class DAppConnectService {
           await conn.keyExchange.onAck(message as AckMessage);
         } catch (err) {
           dlog(`ACK verify failed: ${err instanceof Error ? err.message : err}`);
-          // Fire-and-forget: we're inside the per-channel message queue
-          // handler. Awaiting disconnectSession here would block the queue
-          // during the 800ms TERMINATE flush and stall any buffered ACK
-          // follow-ups on other channels.
-          void this.disconnectSession(channelId, false);
+          // Await the teardown: the message queue is PER-CHANNEL, so
+          // blocking this queue until the channel is fully torn down is
+          // the correct behaviour on a security failure (prevents any
+          // subsequent buffered message on this compromised channel from
+          // being processed during the 800ms TERMINATE flush window).
+          await this.disconnectSession(channelId, false).catch((err) =>
+            console.error('[DAppConnect] disconnect-on-ack-fail failed:', err)
+          );
         }
         return;
       }
@@ -434,10 +437,13 @@ export class DAppConnectService {
       }
 
       case MessageType.TERMINATE: {
-        // Fire-and-forget: we're in the inbound message handler, and we
-        // don't need to round-trip a TERMINATE back at the dApp that just
-        // sent us one.
-        void this.disconnectSession(channelId);
+        // Await the teardown: the message queue is per-channel, so
+        // halting it while we finalize this same channel is the correct
+        // behaviour — any further buffered messages for a channel that's
+        // being torn down are meaningless.
+        await this.disconnectSession(channelId).catch((err) =>
+          console.error('[DAppConnect] disconnect-on-terminate failed:', err)
+        );
         break;
       }
 
@@ -501,7 +507,15 @@ export class DAppConnectService {
     this.clearDappLeaveTimeout(channelId);
     const conn = this.connections.get(channelId);
 
+    // Idempotence guard: concurrent callers (e.g. the user tapping
+    // Disconnect at the same moment an inbound TERMINATE arrives from the
+    // dApp) must not each run the full teardown and fire a second
+    // DAPP_DISCONNECTED bridge message / onSessionDisconnected callback.
+    let finalized = false;
     const finalize = () => {
+      if (finalized) return;
+      finalized = true;
+
       const activeConn = this.connections.get(channelId);
       if (activeConn) {
         activeConn.socketClient.leaveChannel();


### PR DESCRIPTION
## Summary
- Wallet-side **PQP2** parser and handshake: parse URI → \`{ cid, fp }\`, fetch PK from relay's \`join_channel\` ack, verify \`SHA-256(\"pq-fp/v2\" || cid || pk) === fp\`, then proceed with Encaps.
- Tear-down on handshake failure: if fp verification throws after we've added an entry to \`connections\`, the socket is now explicitly \`leaveChannel + disconnect\`'d (previously leaked an orphan socket with a live onMessage handler).
- **\`disconnectSession\` is now async**, \`disconnectAll\` awaits \`Promise.all\`. Prevents the half-finalized state window where \`SessionStore.remove\` / \`socketClient.disconnect\` ran up to 800ms after the caller returned.
- **Duplicate-scan fp re-check**: rescan of the same cid used to silently return success; now re-derives fp against the live session's pinned pk and rejects on mismatch.
- **base45/qrUri parser hardening** mirroring the SDK-side audit fixes.
- **nginx example**: removed \`http2\` from listen directives (nginx <1.25.1 doesn't support WS-over-HTTP/2; CF closed the WebSocket every ~5s), added \`proxy_buffering off\` to \`/relay\`, added \`wss://\` to CSP \`connect-src\`. Already applied live to both prod and dev.qrlwallet.com.

## Dependencies
- Requires relay with PQP2 support (\`myqrlwallet-backend#38\`).
- Requires SDK 2.0.0 (\`myqrlwallet-connect#9\`).

## Test plan
- [x] \`npm run lint\`
- [x] \`tsc --noEmit\`
- [x] \`npm run build\`
- [x] iPhone live on dev.qrlwallet.com — all §4.5 scenarios green (see sibling PRs)