### PR TITLE
fix(dapp-approval): decode hex personal_sign data for human-readable preview

### DIFF
--- a/src/components/Core/Body/DAppConnect/DAppApprovalModal.tsx
+++ b/src/components/Core/Body/DAppConnect/DAppApprovalModal.tsx
@@ -63,12 +63,19 @@ function decodeHexForPreview(value: string): string {
   try {
     const bytes = new Uint8Array(hex.length / 2);
     for (let i = 0; i < bytes.length; i++) {
-      bytes[i] = parseInt(hex.substr(i * 2, 2), 16);
+      bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
     }
     const text = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
     // Refuse to "decode" if the result contains control chars — that means
     // it's binary data and the hex form is the honest representation.
-    if (/[\x00-\x08\x0e-\x1f]/.test(text)) return value;
+    // Control range covers C0 (0x00–0x08, 0x0e–0x1f) and DEL (0x7f); we keep
+    // tab/LF/CR/FF (0x09–0x0d) so multi-line or formatted messages survive.
+    for (let i = 0; i < text.length; i++) {
+      const c = text.charCodeAt(i);
+      if ((c <= 0x08) || (c >= 0x0e && c <= 0x1f) || c === 0x7f) {
+        return value;
+      }
+    }
     return text;
   } catch {
     return value;

--- a/src/components/Core/Body/DAppConnect/DAppApprovalModal.tsx
+++ b/src/components/Core/Body/DAppConnect/DAppApprovalModal.tsx
@@ -46,6 +46,35 @@ function parseRpcNumber(value: unknown, fallback: number): number {
   return fallback;
 }
 
+/**
+ * EIP-191 `personal_sign` requires `params[0]` to be hex-encoded data — that's
+ * what the QRL Web3 Wallet extension and conforming dApps send. For the
+ * approval preview, decode hex back to human-readable text so the user sees
+ * what they're actually signing, not a wall of bytes. Falls back to the
+ * original string if it isn't well-formed hex or decodes to non-printable
+ * bytes.
+ */
+function decodeHexForPreview(value: string): string {
+  if (!value || typeof value !== 'string' || !value.startsWith('0x')) return value;
+  const hex = value.slice(2);
+  if (hex.length === 0 || hex.length % 2 !== 0 || !/^[0-9a-fA-F]+$/.test(hex)) {
+    return value;
+  }
+  try {
+    const bytes = new Uint8Array(hex.length / 2);
+    for (let i = 0; i < bytes.length; i++) {
+      bytes[i] = parseInt(hex.substr(i * 2, 2), 16);
+    }
+    const text = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+    // Refuse to "decode" if the result contains control chars — that means
+    // it's binary data and the hex form is the honest representation.
+    if (/[\x00-\x08\x0e-\x1f]/.test(text)) return value;
+    return text;
+  } catch {
+    return value;
+  }
+}
+
 function getMessageToSign(
   method: string,
   params: unknown[] | undefined,
@@ -363,7 +392,7 @@ const DAppApprovalModal = observer(() => {
   const hasNativePin = !!getNativeInjectedPin();
   const isTransaction = method === 'qrl_sendTransaction' || method === 'qrl_signTransaction';
   const messagePreview = (method === 'personal_sign' || method === 'qrl_sign')
-    ? getMessageToSign(method, params, qrlStore.activeAccount?.accountAddress || '')
+    ? decodeHexForPreview(getMessageToSign(method, params, qrlStore.activeAccount?.accountAddress || ''))
     : '';
 
   const isTxInProgress = txProgress !== 'idle';


### PR DESCRIPTION
## Summary

EIP-191 `personal_sign` requires `params[0]` to be hex-encoded data. The QRL Web3 Wallet extension and conforming dApps always send hex, but our approval modal was rendering `params[0]` verbatim — so a hex-encoded \"Hello\" showed up as `0x48656c6c6f` in the preview and the user couldn't see what they were about to sign. (Same dApps look correct in the extension's popup because the extension decodes hex for display.)

## Fix

- New `decodeHexForPreview(value)` helper used in `messagePreview` rendering only.
- Returns the original string if not well-formed hex.
- `TextDecoder('utf-8', { fatal: true })` so binary data falls back instead of mojibake.
- Refuses to decode if the result contains control bytes, so non-text payloads stay in their honest hex form.
- `getMessageToSign` and the actual signing path are untouched — web3 auto-detects 0x-prefixed hex and signs the underlying bytes, matching what the extension produces.

## Why this surfaces now

Companion change in `myqrlwallet-connect` (PR on its own branch — `feat/eip6963-announce`) hex-encodes the message in the hosted dApp example. Without this preview decode, mobile-app users would see hex blobs after that example deploys.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Manual: pasted a plain text into the connect example's Sign Message field with the hex-encoded send patch active, observed approval modal previews the original text again.
- [ ] (User to verify) signing succeeds end-to-end in mobile app and signature verifies against the original message bytes (web3.eth.accounts.recover should yield the connected account).