### PR TITLE
fix(scalability/sprint-3b): pollForReceipt setInterval lifecycle

### DIFF
--- a/src/stores/qrlStore.ts
+++ b/src/stores/qrlStore.ts
@@ -113,6 +113,15 @@ class QrlStore {
   qrlPrice: number = 0; // USD price from Explorer
   qrlPriceChange24h: number = 0; // 24h price change percentage
 
+  // Handle for the pollForReceipt setInterval. Stored on the instance so any
+  // disposal path (resetTransactionStatus, store re-init) can clear it.
+  // Previously this lived in a function-local variable so a navigation or
+  // store re-create left the interval ticking, leaking RPC calls and
+  // potentially racing a stale receipt into the current transactionStatus.
+  // Excluded from mobx via `_receiptPollerIntervalId: false` in
+  // makeAutoObservable below — it's a non-observable runtime handle.
+  _receiptPollerIntervalId: ReturnType<typeof setInterval> | null = null;
+
   // NEW: Computed properties
   // 1) active account balance
   get activeAccountBalance(): string {
@@ -166,6 +175,9 @@ class QrlStore {
       extensionProvider: observable.ref, // Use ref for complex objects like providers
       qrlPrice: observable,
       qrlPriceChange24h: observable,
+      // Runtime handles + their cleanup helper — not observable.
+      _receiptPollerIntervalId: false,
+      cancelReceiptPoller: false,
       activeAccountBalance: computed,
       activeAccountSource: computed,
       activeAccountBalanceUsd: computed,
@@ -228,9 +240,23 @@ class QrlStore {
 
   // Updated reset action
   resetTransactionStatus() {
+    // Always cancel any in-flight poller first so it can't race a stale
+    // receipt into the freshly-reset transactionStatus.
+    this.cancelReceiptPoller();
     runInAction(() => {
       this.transactionStatus = { state: 'idle', txHash: null, receipt: null, error: null, pendingDetails: null };
     });
+  }
+
+  // Cancels the pollForReceipt setInterval (if any) and clears the handle.
+  // Safe to call when no poller is running. Exposed so any external
+  // teardown (page unmount, dapp disconnect, store re-init) can stop the
+  // up-to-5-minute RPC loop instead of leaking it.
+  cancelReceiptPoller() {
+    if (this._receiptPollerIntervalId !== null) {
+      clearInterval(this._receiptPollerIntervalId);
+      this._receiptPollerIntervalId = null;
+    }
   }
 
   async initializeBlockchain() {
@@ -1044,11 +1070,15 @@ class QrlStore {
 
     log(`Starting receipt polling for ${txHash}`);
 
-    const intervalId = setInterval(async () => {
+    // If a previous poll was somehow left running, kill it before starting
+    // a fresh one so we never have two intervals racing into transactionStatus.
+    this.cancelReceiptPoller();
+
+    this._receiptPollerIntervalId = setInterval(async () => {
       // Stop polling if state is no longer pending or hash changed
       if (this.transactionStatus.state !== 'pending' || this.transactionStatus.txHash !== txHash) {
         log(`Stopping receipt polling for ${txHash} (state changed)`);
-        clearInterval(intervalId);
+        this.cancelReceiptPoller();
         return;
       }
 
@@ -1060,7 +1090,7 @@ class QrlStore {
 
         if (receipt) {
           log(`Receipt found for ${txHash}`);
-          clearInterval(intervalId); // Stop polling
+          this.cancelReceiptPoller(); // Stop polling
 
           runInAction(() => {
             // Double-check state again before updating
@@ -1082,7 +1112,7 @@ class QrlStore {
         } else if (attempts >= maxAttempts) {
           // Max attempts reached, transaction likely failed or stuck
           log(`Max polling attempts reached for ${txHash}. Marking as failed.`);
-          clearInterval(intervalId);
+          this.cancelReceiptPoller();
           runInAction(() => {
             if (this.transactionStatus.state === 'pending' && this.transactionStatus.txHash === txHash) {
               this.transactionStatus = {
@@ -1099,7 +1129,7 @@ class QrlStore {
       } catch (error: any) {
         console.error(`Error polling for receipt ${txHash}:`, error);
         log(`Error polling for receipt ${txHash}: ${error.message || error}`);
-        clearInterval(intervalId);
+        this.cancelReceiptPoller();
         // Mark as failed on error
         runInAction(() => {
           if (this.transactionStatus.state === 'pending' && this.transactionStatus.txHash === txHash) {

--- a/src/stores/qrlStore.ts
+++ b/src/stores/qrlStore.ts
@@ -238,14 +238,14 @@ class QrlStore {
     }
   }
 
-  // Updated reset action
+  // Updated reset action. Method body runs inside an action automatically
+  // because makeAutoObservable annotates this as `action.bound` — no
+  // explicit runInAction needed for the synchronous state write.
   resetTransactionStatus() {
     // Always cancel any in-flight poller first so it can't race a stale
     // receipt into the freshly-reset transactionStatus.
     this.cancelReceiptPoller();
-    runInAction(() => {
-      this.transactionStatus = { state: 'idle', txHash: null, receipt: null, error: null, pendingDetails: null };
-    });
+    this.transactionStatus = { state: 'idle', txHash: null, receipt: null, error: null, pendingDetails: null };
   }
 
   // Cancels the pollForReceipt setInterval (if any) and clears the handle.
@@ -260,6 +260,10 @@ class QrlStore {
   }
 
   async initializeBlockchain() {
+    // Re-initializing the blockchain (e.g. network switch) invalidates any
+    // in-flight receipt poller bound to the previous provider's RPC — cancel
+    // it before bringing up the new connection.
+    this.cancelReceiptPoller();
     try {
       const selectedBlockChain = await StorageUtil.getBlockChain();
       const { name, url: baseUrl } = QRL_PROVIDER[selectedBlockChain];


### PR DESCRIPTION
## Summary

Audit H4: `pollForReceipt` stored its `setInterval` handle in a function-local `intervalId` that no cleanup path could reach.

### Symptoms

- Page navigation or store re-init while a tx was pending left the 5-minute (60 × 5 s) interval ticking in the background, leaking RPC calls to the node.
- Two `pollForReceipt` invocations in quick succession spawned concurrent intervals that could race a stale receipt into the current `transactionStatus`.
- Under N concurrent users with submitted txs, the compounding polling load is real pressure on the RPC endpoint.

### Changes (`src/stores/qrlStore.ts`)

- New instance field `_receiptPollerIntervalId`; declared non-observable in `makeAutoObservable` so MobX doesn't wrap a runtime timer handle in an Atom.
- New `cancelReceiptPoller()` helper — idempotent, exposed so any external teardown (page unmount, dapp disconnect, store re-init) can stop the poller.
- `pollForReceipt` now (a) cancels any pre-existing poller before starting, and (b) routes every `clearInterval` through `cancelReceiptPoller` so the field is always nulled out.
- `resetTransactionStatus()` calls `cancelReceiptPoller()` first so a reset can't race a stale receipt write.

## Test plan

- [x] `npm run build` succeeds with no type errors (verified locally)
- [ ] After deploy: submit a tx, navigate away mid-pending → watch Network tab; no more `qrl_getTransactionReceipt` requests after the navigation
- [ ] Submit two txs back-to-back → only the latest tx's receipt populates `transactionStatus`