### PR TITLE
fix(scalability/sprint-3c): replace localStorage.setItem monkey-patch

### DIFF
--- a/src/utils/storage/autoLock.ts
+++ b/src/utils/storage/autoLock.ts
@@ -11,6 +11,12 @@ let navigateFunction: ((path: string) => void) | null = null;
 let timeoutMs: number = 0;
 let timerStartTime: number = 0;
 let isActivityTrackingInitialized = false;
+// Monotonic id for serializing concurrent startAutoLockTimer calls. When
+// multiple async setup paths race (e.g. an active-account event arrives
+// while a wallet-settings event is mid-await), only the latest request
+// gets to install the setInterval — older ones detect they've been
+// superseded and bail before creating an orphaned timer.
+let timerSetupRequestId = 0;
 
 /**
  * Checks if there's an active wallet that needs to be protected
@@ -31,6 +37,13 @@ export const hasActiveWallet = async (): Promise<boolean> => {
  * @param navigate - The navigate function from react-router
  */
 export const startAutoLockTimer = async (navigate: (path: string) => void) => {
+  // Claim a request id before any await. If another setup call lands while
+  // we're awaiting hasActiveWallet / getWalletSettings, its id will be
+  // higher and we'll bail at the install point below — preventing the
+  // orphan-timer race where two parallel setups both assign autoLockTimer
+  // and the earlier one keeps ticking forever.
+  const myRequestId = ++timerSetupRequestId;
+
   // Store the navigate function for later use
   navigateFunction = navigate;
 
@@ -58,6 +71,15 @@ export const startAutoLockTimer = async (navigate: (path: string) => void) => {
   if (!timeoutMs || timeoutMs <= 0) {
     console.log("🔒 Auto-lock: DISABLED (timeout set to 0 or negative)");
     return; // Auto-lock is disabled
+  }
+
+  // Bail out if a newer setup request landed while we were awaiting above.
+  // Without this, our `setInterval` below would orphan whatever timer the
+  // newer request later installs (or vice versa) and we'd silently leak
+  // a ticking interval.
+  if (myRequestId !== timerSetupRequestId) {
+    console.log("🔒 Auto-lock: superseded by newer setup request, abandoning install");
+    return;
   }
 
   // Set the timer start time and last activity time to now
@@ -168,6 +190,13 @@ export const checkAndStartAutoLock = async () => {
  * Attaches event listeners to track user activity
  */
 export const setupActivityTracking = () => {
+  // Guard SSR / test environments where `window` is undefined. Matches
+  // the same guard on the dispatch side in storage.ts so the two halves
+  // stay consistent.
+  if (typeof window === 'undefined') {
+    return;
+  }
+
   // Prevent duplicate initialization
   if (isActivityTrackingInitialized) {
     return;

--- a/src/utils/storage/autoLock.ts
+++ b/src/utils/storage/autoLock.ts
@@ -1,5 +1,8 @@
 import { handleLogout } from '../logout';
-import StorageUtil from './storage';
+import StorageUtil, {
+  STORAGE_EVENT_ACTIVE_ACCOUNT,
+  STORAGE_EVENT_WALLET_SETTINGS,
+} from './storage';
 import { isInNativeApp } from '../nativeApp';
 
 let autoLockTimer: NodeJS.Timeout | null = null;
@@ -179,35 +182,36 @@ export const setupActivityTracking = () => {
     });
   });
 
-  // Listen for storage changes to detect settings updates and account changes
+  // Cross-tab storage updates. The native `storage` event only fires in
+  // OTHER tabs (not the one that wrote), so we still need it for
+  // multi-tab sync.
   window.addEventListener('storage', async (event) => {
     if (event.key?.includes('WALLET_SETTINGS')) {
-      console.log("⚙️ Auto-lock: Settings changed, restarting timer");
+      console.log("⚙️ Auto-lock: Settings changed (cross-tab), restarting timer");
       await restartAutoLockTimer();
     }
 
-    // If active account changes, restart the timer (wallet imported or changed)
     if (event.key?.includes('ACTIVE_ACCOUNT')) {
-      console.log("👛 Auto-lock: Wallet status changed, checking if auto-lock should be enabled");
+      console.log("👛 Auto-lock: Wallet status changed (cross-tab), checking auto-lock");
       await checkAndStartAutoLock();
     }
   });
 
-  // Also listen for localStorage changes in the current window
-  // This helps catch changes that don't trigger the storage event in the same window
-  const originalSetItem = localStorage.setItem;
-  localStorage.setItem = function(key, value) {
-    // Call the original function first
-    originalSetItem.apply(this, [key, value]);
-
-    // Then handle the change if it's related to accounts
-    if (key.includes('ACTIVE_ACCOUNT')) {
-      setTimeout(async () => {
-        console.log("👛 Auto-lock: Active account changed in current window");
-        await checkAndStartAutoLock();
-      }, 500); // Small delay to ensure storage is updated
-    }
-  };
+  // Same-tab storage updates. We previously monkey-patched
+  // localStorage.setItem on the prototype to catch these — that
+  // sprayed an async callback over every localStorage write app-wide
+  // (including third-party libs') and was never torn down. Now
+  // StorageUtil dispatches dedicated custom events from its
+  // setActiveAccount / clearActiveAccount / setWalletSettings methods,
+  // and we just subscribe to those.
+  window.addEventListener(STORAGE_EVENT_ACTIVE_ACCOUNT, async () => {
+    console.log("👛 Auto-lock: Active account changed (same-tab), checking auto-lock");
+    await checkAndStartAutoLock();
+  });
+  window.addEventListener(STORAGE_EVENT_WALLET_SETTINGS, async () => {
+    console.log("⚙️ Auto-lock: Settings changed (same-tab), restarting timer");
+    await restartAutoLockTimer();
+  });
 
   isActivityTrackingInitialized = true;
   console.log("👁️ Auto-lock: Activity tracking initialized");

--- a/src/utils/storage/storage.ts
+++ b/src/utils/storage/storage.ts
@@ -19,6 +19,19 @@ const WALLET_SETTINGS_IDENTIFIER = "WALLET_SETTINGS";
 const ENCRYPTED_SEEDS_IDENTIFIER = "ENCRYPTED_SEEDS";
 const AUTO_LOCK_TIMEOUT = 15 * 60 * 1000; // 15 minutes default auto-lock timeout
 
+// Same-tab change events. The native `storage` event only fires in OTHER
+// tabs, so we dispatch these on `window` to let other modules
+// (e.g. autoLock) react to writes happening in the same tab without
+// monkey-patching `localStorage.setItem`. Guarded against environments
+// where `window` is undefined (SSR / tests).
+export const STORAGE_EVENT_ACTIVE_ACCOUNT = 'qrl-wallet:active-account-changed';
+export const STORAGE_EVENT_WALLET_SETTINGS = 'qrl-wallet:wallet-settings-changed';
+const dispatchStorageEvent = (name: string) => {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent(name));
+  }
+};
+
 type TransactionValuesType = {
   receiverAddress?: string;
   amount?: number;
@@ -171,6 +184,7 @@ class StorageUtil {
     } else {
       localStorage.removeItem(blockChainAccountIdentifier);
     }
+    dispatchStorageEvent(STORAGE_EVENT_ACTIVE_ACCOUNT);
   }
 
   static async getActiveAccount(blockchain: string) {
@@ -181,6 +195,7 @@ class StorageUtil {
   static async clearActiveAccount(blockchain: string) {
     const blockChainAccountIdentifier = `${blockchain}_${ACTIVE_ACCOUNT_IDENTIFIER}`;
     localStorage.removeItem(blockChainAccountIdentifier);
+    dispatchStorageEvent(STORAGE_EVENT_ACTIVE_ACCOUNT);
   }
 
   /**
@@ -278,6 +293,7 @@ class StorageUtil {
 
   static async setWalletSettings(settings: WalletSettings) {
     this.setItem(WALLET_SETTINGS_IDENTIFIER, settings);
+    dispatchStorageEvent(STORAGE_EVENT_WALLET_SETTINGS);
   }
 
   static async getWalletSettings(): Promise<WalletSettings> {


### PR DESCRIPTION
## Summary

Audit H3: `setupActivityTracking()` patched the native `localStorage.setItem` **prototype** so every write app-wide — including `@theqrl/web3` internals and any future library — triggered an async wallet-state check. The patch was never torn down and leaked closure references on StrictMode/HMR re-mounts.

### Replacement

Dedicated same-tab event bus:

- `StorageUtil` exports `STORAGE_EVENT_ACTIVE_ACCOUNT` + `STORAGE_EVENT_WALLET_SETTINGS` and dispatches them on `window` from the three writer paths that mutate these keys (`setActiveAccount`, `clearActiveAccount`, `setWalletSettings`). Guarded for environments without `window` (SSR / tests).
- `autoLock` subscribes to those events instead of monkey-patching the prototype.
- Native cross-tab `storage` event still handles multi-tab sync — unchanged.

### Side benefit

`setWalletSettings` now also triggers a same-tab timer restart. Previously the monkey-patch only fired on `ACTIVE_ACCOUNT`, so changing the auto-lock timeout in the same tab wouldn't restart the timer until the next event from elsewhere.

## Test plan

- [x] `npm run build` clean (verified locally)
- [ ] After deploy: import a new account → auto-lock starts without delay (same-tab path)
- [ ] Open two tabs, change settings in one → other tab restarts timer (cross-tab path unchanged)
- [ ] No console errors about leaked localStorage patches