### PR TITLE
perf(scalability/sprint-3d.1): MLDSA87 seed derivation off main thread

### DIFF
--- a/src/stores/qrlStore.ts
+++ b/src/stores/qrlStore.ts
@@ -1,5 +1,5 @@
 import { QRL_PROVIDER, EXPLORER_BASE, getPendingTxApiUrl } from "@/config";
-import { getHexSeedFromMnemonic } from "@/utils/crypto";
+import { getHexSeedFromMnemonic, deriveHexSeedAsync } from "@/utils/crypto";
 import { StorageUtil, AccountListItem, AccountSource } from "@/utils/storage";
 import { log } from "@/utils";
 import Web3, {
@@ -680,7 +680,10 @@ class QrlStore {
         maxPriorityFeePerGas: utils.toHex(maxPriorityFeePerGas),
         nonce: nonce,
       };
-      const privateKey = getHexSeedFromMnemonic(mnemonicPhrases);
+      // Run the MLDSA87 derivation in the crypto worker so the 50–300 ms
+      // expansion doesn't freeze the main thread mid-Send animation.
+      // Subsequent signTransaction call is comparatively cheap.
+      const privateKey = await deriveHexSeedAsync(mnemonicPhrases);
 
       // Sign the transaction first to ensure validity before proceeding
       const signedTransaction =

--- a/src/utils/crypto/cryptoWorker.ts
+++ b/src/utils/crypto/cryptoWorker.ts
@@ -1,9 +1,16 @@
 /**
  * Web Worker for CPU-intensive cryptographic operations.
- * Runs PBKDF2 key derivation off the main thread to keep UI responsive.
+ *
+ * Operations handled off the main thread:
+ * - encrypt / decrypt / reEncrypt: PBKDF2 (600k iterations) + AES.
+ * - deriveHexSeed: MLDSA87 wallet expansion from a mnemonic. This is
+ *   50–300 ms of pure JS work and was previously running on the main
+ *   thread inside getHexSeedFromMnemonic, blocking any animation /
+ *   signing UI for the duration.
  */
 
 import CryptoJS from 'crypto-js';
+import { MLDSA87 } from '@theqrl/wallet.js';
 
 // Error codes for crypto operations
 export const CryptoErrorCode = {
@@ -17,12 +24,14 @@ export type CryptoErrorCode = typeof CryptoErrorCode[keyof typeof CryptoErrorCod
 export type CryptoWorkerMessage =
   | { type: 'encrypt'; mnemonic: string; hexSeed: string; pin: string }
   | { type: 'decrypt'; encryptedData: string; pin: string }
-  | { type: 'reEncrypt'; encryptedSeed: string; oldPin: string; newPin: string };
+  | { type: 'reEncrypt'; encryptedSeed: string; oldPin: string; newPin: string }
+  | { type: 'deriveHexSeed'; mnemonic: string };
 
 export type CryptoWorkerResponse =
   | { type: 'encrypt'; success: true; encryptedSeed: string }
   | { type: 'decrypt'; success: true; mnemonic: string; hexSeed: string }
   | { type: 'reEncrypt'; success: true; encryptedSeed: string }
+  | { type: 'deriveHexSeed'; success: true; hexSeed: string }
   | { type: 'error'; success: false; code: CryptoErrorCode; error: string };
 
 // Version constants
@@ -129,6 +138,16 @@ self.onmessage = (event: MessageEvent<MessageWithRequestId>) => {
         const decrypted = decryptSeed(message.encryptedSeed, message.oldPin);
         const reEncrypted = encryptSeed(decrypted.mnemonic, decrypted.hexSeed, message.newPin);
         self.postMessage({ type: 'reEncrypt', success: true, encryptedSeed: reEncrypted, requestId });
+        break;
+      }
+
+      case 'deriveHexSeed': {
+        // MLDSA87 wallet expansion (50–300 ms on mobile). Returns the
+        // extended seed in hex form; the main thread feeds it into
+        // signTransaction() like before.
+        const wallet = MLDSA87.newWalletFromMnemonic(message.mnemonic.trim());
+        const hexSeed = wallet.getHexExtendedSeed();
+        self.postMessage({ type: 'deriveHexSeed', success: true, hexSeed, requestId });
         break;
       }
     }

--- a/src/utils/crypto/cryptoWorkerClient.ts
+++ b/src/utils/crypto/cryptoWorkerClient.ts
@@ -184,6 +184,20 @@ export async function reEncryptSeedAsync(
 }
 
 /**
+ * Derive the hex-encoded extended seed from a BIP39 mnemonic using the
+ * Web Worker so the 50–300 ms MLDSA87 expansion runs off the main
+ * thread. Equivalent output to the synchronous getHexSeedFromMnemonic
+ * but doesn't block animations / signing UI during the derivation.
+ */
+export async function deriveHexSeedAsync(mnemonic: string): Promise<string> {
+  const result = await postToWorker<'deriveHexSeed'>({
+    type: 'deriveHexSeed',
+    mnemonic,
+  });
+  return result.hexSeed;
+}
+
+/**
  * Terminate all workers in the pool.
  * Call when crypto operations are no longer needed.
  */

--- a/src/utils/crypto/cryptoWorkerClient.ts
+++ b/src/utils/crypto/cryptoWorkerClient.ts
@@ -188,8 +188,14 @@ export async function reEncryptSeedAsync(
  * Web Worker so the 50–300 ms MLDSA87 expansion runs off the main
  * thread. Equivalent output to the synchronous getHexSeedFromMnemonic
  * but doesn't block animations / signing UI during the derivation.
+ *
+ * Matches getHexSeedFromMnemonic's empty-input contract: returns "" for
+ * undefined / empty / whitespace-only input without acquiring a worker.
  */
 export async function deriveHexSeedAsync(mnemonic: string): Promise<string> {
+  if (!mnemonic || !mnemonic.trim()) {
+    return "";
+  }
   const result = await postToWorker<'deriveHexSeed'>({
     type: 'deriveHexSeed',
     mnemonic,

--- a/src/utils/crypto/index.ts
+++ b/src/utils/crypto/index.ts
@@ -15,6 +15,7 @@ export {
   encryptSeedAsync,
   decryptSeedAsync,
   reEncryptSeedAsync,
+  deriveHexSeedAsync,
   CryptoOperationError,
   CryptoErrorCode,
 } from './cryptoWorkerClient';


### PR DESCRIPTION
## Summary

Audit H2 first slice — plumb the heavy ML-DSA-87 mnemonic→hexSeed expansion into the existing crypto worker pool so it stops freezing the UI for 50–300 ms every time the user signs a transaction.

### Approach

- New `deriveHexSeed` op on the existing `cryptoWorker.ts`. The worker already runs PBKDF2 / AES off-thread for PIN flows; this just adds an import of `@theqrl/wallet.js`'s `MLDSA87` and one more case to the message switch.
- `deriveHexSeedAsync(mnemonic): Promise<string>` exposed via `cryptoWorkerClient.ts` and the crypto barrel.
- **One call site migrated this PR** — `signAndSendTransaction` in `qrlStore.ts:683`. The synchronous `getHexSeedFromMnemonic` stays in the module so the unmigrated sites keep compiling.

### Follow-ups (separate PRs)

- PR-3d.2: migrate `qrlStore.ts:766` (sendToken), `qrlStore.ts:853` (createToken), `DAppApprovalModal.tsx`. `ImportAccountForm.tsx` already `await`s the sync function — trivial swap.
- PR-3d.3 (optional): `getAddressFromMnemonic` callers (Transfer, SendTokenModal, TokenCreationForm) — same ML-DSA-87 derivation, also blocking on form submit.

### Bundle cost

`cryptoWorker` chunk grows ~70 KB → ~140 KB (gzipped). Loaded lazily when the user starts a crypto op (decrypt PIN, sign tx) — not on first paint. No measurable change to the index/vendor chunks.

## Test plan

- [x] `npm run build` clean; worker bundle emitted (`cryptoWorker-*.js`)
- [ ] After deploy: open DevTools Performance, send a transaction, observe no long task on the main thread during the signing step (was a 50–300 ms block before)
- [ ] Signed tx still validates on the network (no off-by-one in the seed → tx pipeline)