### PR TITLE
perf(scalability/sprint-3d.2): migrate remaining sync derivation sites

### DIFF
--- a/src/components/Core/Body/ImportAccount/ImportAccountForm/ImportAccountForm.tsx
+++ b/src/components/Core/Body/ImportAccount/ImportAccountForm/ImportAccountForm.tsx
@@ -21,7 +21,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { Download, Loader } from "lucide-react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
-import { getHexSeedFromMnemonic } from "@/utils/crypto";
+import { deriveHexSeedAsync } from "@/utils/crypto";
 import { ExtendedWalletAccount } from "@/utils/crypto";
 
 const FormSchema = z.object({
@@ -51,7 +51,7 @@ export const ImportAccountForm = ({ onAccountImported }: ImportAccountFormProps)
 
   async function onSubmit(formData: z.output<typeof FormSchema>) {
     try {
-      const hexSeed = await getHexSeedFromMnemonic(formData.mnemonicPhrases);
+      const hexSeed = await deriveHexSeedAsync(formData.mnemonicPhrases);
       const account = qrlInstance?.accounts.seedToAccount(hexSeed) as ExtendedWalletAccount;
       
       if (!account) {

--- a/src/stores/qrlStore.ts
+++ b/src/stores/qrlStore.ts
@@ -762,6 +762,12 @@ class QrlStore {
   }
 
   async sendToken(token: TokenInterface, amount: string, mnemonicPhrases: string, toAddress: string, feeLevel: FeeLevel = 'medium') {
+    // Reset transaction state up front (matches signAndSendTransaction).
+    // This also cancels any in-flight receipt poller from a previous tx
+    // so it can't race a stale receipt into this send's status updates
+    // — important now that the worker-derive introduces extra awaits
+    // before the new tx hash is observed.
+    this.resetTransactionStatus();
     try {
       const selectedBlockChain = await StorageUtil.getBlockChain();
       const { url } = QRL_PROVIDER[selectedBlockChain as keyof typeof QRL_PROVIDER];
@@ -851,6 +857,10 @@ class QrlStore {
     maxTxLimit: string,
     mnemonicPhrases: string
   ) {
+    // Reset transaction state up front (matches signAndSendTransaction /
+    // sendToken). Cancels any in-flight receipt poller from a previous
+    // tx so it can't race into this contract-deploy's status updates.
+    this.resetTransactionStatus();
     try {
       this.setCreatingToken(tokenName, true);
       const selectedBlockChain = await StorageUtil.getBlockChain();

--- a/src/stores/qrlStore.ts
+++ b/src/stores/qrlStore.ts
@@ -1,5 +1,5 @@
 import { QRL_PROVIDER, EXPLORER_BASE, getPendingTxApiUrl } from "@/config";
-import { getHexSeedFromMnemonic, deriveHexSeedAsync } from "@/utils/crypto";
+import { deriveHexSeedAsync } from "@/utils/crypto";
 import { StorageUtil, AccountListItem, AccountSource } from "@/utils/storage";
 import { log } from "@/utils";
 import Web3, {
@@ -766,7 +766,9 @@ class QrlStore {
       const selectedBlockChain = await StorageUtil.getBlockChain();
       const { url } = QRL_PROVIDER[selectedBlockChain as keyof typeof QRL_PROVIDER];
       const web3 = new Web3(new Web3.providers.HttpProvider(url));
-      const seed = getHexSeedFromMnemonic(mnemonicPhrases);
+      // MLDSA87 derivation on the worker — same reasoning as
+      // signAndSendTransaction (50–300 ms off the main thread).
+      const seed = await deriveHexSeedAsync(mnemonicPhrases);
       const acc = web3.qrl.accounts.seedToAccount(seed)
       web3.qrl.wallet?.add(seed);
       web3.qrl.transactionConfirmationBlocks = 1;
@@ -853,7 +855,9 @@ class QrlStore {
       this.setCreatingToken(tokenName, true);
       const selectedBlockChain = await StorageUtil.getBlockChain();
       const { url } = QRL_PROVIDER[selectedBlockChain as keyof typeof QRL_PROVIDER];
-      const seed = getHexSeedFromMnemonic(mnemonicPhrases);
+      // MLDSA87 derivation on the worker (avoids freezing UI during the
+      // 50–300 ms expansion just before deploying a new token contract).
+      const seed = await deriveHexSeedAsync(mnemonicPhrases);
       const web3 = new Web3(new Web3.providers.HttpProvider(url));
       const acc = web3.qrl.accounts.seedToAccount(seed)
       web3.qrl.wallet?.add(seed);


### PR DESCRIPTION
## Summary

Follow-up to #133 (PR-3d.1). Migrates the remaining three call sites of the synchronous `getHexSeedFromMnemonic` to the worker-backed `deriveHexSeedAsync`.

| Site | Before | After |
|---|---|---|
| `src/stores/qrlStore.ts::sendToken` (was line 769) | `getHexSeedFromMnemonic(m)` | `await deriveHexSeedAsync(m)` |
| `src/stores/qrlStore.ts::createToken` (was line 856) | same | same |
| `src/components/Core/Body/ImportAccount/ImportAccountForm.tsx:54` | `await getHexSeedFromMnemonic(m)` | `await deriveHexSeedAsync(m)` |

`ImportAccountForm` already `await`'d the sync function so this is just a function-name swap; both qrlStore sites are inside `async` methods so the `await` is trivial. Net: every sync MLDSA87 expansion in transaction-signing flows now runs off the main thread.

## Not in scope

- `DAppApprovalModal` — gets `hexSeed` from `decryptSeedAsync` (already worker path); the audit's reference to it was slightly misleading.
- `getAddressFromMnemonic` callers (Transfer.tsx, SendTokenModal.tsx, TokenCreationForm.tsx) — same expansion, used on form-submit to compute an address rather than to sign. Same fix class but lower urgency; queued as PR-3d.3.
- `mnemonic.ts::getHexSeedFromMnemonic` itself stays in the module for backwards-compat / non-perf-critical callers.

## Test plan

- [x] `npm run build` clean (verified locally)
- [ ] After deploy: send a token / create a token / import an account → DevTools Performance shows no long-task block during the derivation step
- [ ] Token/account flow still completes successfully (no off-by-one in the await chain)