### PR TITLE
perf(scalability/sprint-3d.3): getAddressFromMnemonic off main thread

### DIFF
--- a/src/components/Core/Body/CreateToken/TokenCreationForm/TokenCreationForm.tsx
+++ b/src/components/Core/Body/CreateToken/TokenCreationForm/TokenCreationForm.tsx
@@ -137,20 +137,26 @@ export const TokenCreationForm = observer(
                         return;
                     }
 
-                    // Decrypt the seed using the PIN
+                    // Decrypt the seed using the PIN. Keep the worker-derive
+                    // call OUTSIDE this try block — a crash inside the
+                    // crypto worker is not a wrong-PIN error and shouldn't
+                    // be misreported as one.
                     try {
                         const decryptedSeed = WalletEncryptionUtil.decryptSeedWithPin(encryptedSeed, pin);
                         mnemonicPhrase = decryptedSeed.mnemonic;
-
-                        // Verify the mnemonic corresponds to the active account.
-                        // MLDSA87 derivation runs in the crypto worker.
-                        const address = await getAddressFromMnemonicAsync(mnemonicPhrase, qrlStore.qrlInstance!);
-                        if (address.toLowerCase() !== activeAccount.accountAddress.toLowerCase()) {
-                            setPinError("PIN decrypted an invalid seed. Please import your account again.");
-                            return;
-                        }
                     } catch (_error) {
                         setPinError("Invalid PIN. Please try again.");
+                        return;
+                    }
+
+                    // Verify the mnemonic corresponds to the active account.
+                    // MLDSA87 derivation runs in the crypto worker; any
+                    // failure here propagates to the outer onSubmit handler
+                    // and surfaces as a worker / system error rather than
+                    // "invalid PIN".
+                    const address = await getAddressFromMnemonicAsync(mnemonicPhrase, qrlStore.qrlInstance!);
+                    if (address.toLowerCase() !== activeAccount.accountAddress.toLowerCase()) {
+                        setPinError("PIN decrypted an invalid seed. Please import your account again.");
                         return;
                     }
                 }

--- a/src/components/Core/Body/CreateToken/TokenCreationForm/TokenCreationForm.tsx
+++ b/src/components/Core/Body/CreateToken/TokenCreationForm/TokenCreationForm.tsx
@@ -30,7 +30,7 @@ import { ROUTES } from "@/router/router";
 import { PinInput } from "@/components/UI/PinInput/PinInput";
 import { WalletEncryptionUtil } from "@/utils/crypto";
 import { StorageUtil } from "@/utils/storage";
-import { getAddressFromMnemonic } from "@/utils/crypto";
+import { getAddressFromMnemonicAsync } from "@/utils/crypto";
 import { Label } from "@/components/UI/Label";
 import { isValidQrlAddress } from "@/utils/web3";
 
@@ -142,8 +142,9 @@ export const TokenCreationForm = observer(
                         const decryptedSeed = WalletEncryptionUtil.decryptSeedWithPin(encryptedSeed, pin);
                         mnemonicPhrase = decryptedSeed.mnemonic;
 
-                        // Verify the mnemonic corresponds to the active account
-                        const address = getAddressFromMnemonic(mnemonicPhrase, qrlStore.qrlInstance!);
+                        // Verify the mnemonic corresponds to the active account.
+                        // MLDSA87 derivation runs in the crypto worker.
+                        const address = await getAddressFromMnemonicAsync(mnemonicPhrase, qrlStore.qrlInstance!);
                         if (address.toLowerCase() !== activeAccount.accountAddress.toLowerCase()) {
                             setPinError("PIN decrypted an invalid seed. Please import your account again.");
                             return;

--- a/src/components/Core/Body/Tokens/SendTokenModal.tsx/SendTokenModal.tsx
+++ b/src/components/Core/Body/Tokens/SendTokenModal.tsx/SendTokenModal.tsx
@@ -14,7 +14,7 @@ import { useStore } from "@/stores/store";
 import { TokenInterface } from "@/constants";
 import { fetchBalance, fetchTokenInfo } from "@/utils/web3";
 import { Loader2 } from "lucide-react";
-import { getAddressFromMnemonic } from "@/utils/crypto";
+import { getAddressFromMnemonicAsync } from "@/utils/crypto";
 import { StorageUtil } from "@/utils/storage";
 import { QRL_PROVIDER } from "@/config";
 import { formatUnits, parseUnits } from "ethers";
@@ -82,8 +82,9 @@ export function SendTokenModal({ isOpen, onClose, token }: { isOpen: boolean, on
                     return;
                 }
                 
-                // Verify the mnemonic corresponds to the active account
-                const senderAddress = getAddressFromMnemonic(mnemonic, qrlStore.qrlInstance!);
+                // Verify the mnemonic corresponds to the active account.
+                // MLDSA87 derivation runs in the crypto worker.
+                const senderAddress = await getAddressFromMnemonicAsync(mnemonic, qrlStore.qrlInstance!);
                 if (senderAddress.toLowerCase() !== activeAccountAddress.toLowerCase()) {
                     setPinError("PIN decrypted an invalid seed. Please import your account again.");
                     setIsLoading(false);

--- a/src/components/Core/Body/Transfer/Transfer.tsx
+++ b/src/components/Core/Body/Transfer/Transfer.tsx
@@ -42,7 +42,7 @@ import { TransactionSuccessful } from "./TransactionSuccessful/TransactionSucces
 import { getExplorerAddressUrl, getExplorerTxUrl, QRL_PROVIDER } from "@/config";
 import { Slider } from "@/components/UI/Slider";
 import { PinInput } from "@/components/UI/PinInput/PinInput";
-import { WalletEncryptionUtil, getAddressFromMnemonic } from "@/utils/crypto";
+import { WalletEncryptionUtil, getAddressFromMnemonicAsync } from "@/utils/crypto";
 import { copyToClipboard, openExternalUrl, isInNativeApp, requestQRScan, subscribeToNativeMessages, triggerHaptic } from "@/utils/nativeApp";
 import { FeeLevel } from "@/stores/qrlStore";
 import { SEO } from "@/components/SEO/SEO";
@@ -359,8 +359,10 @@ const Transfer = observer(() => {
           return;
         }
 
-        // Verify decrypted mnemonic matches the expected account address
-        const senderAddress = getAddressFromMnemonic(mnemonicPhrases, qrlStore.qrlInstance!);
+        // Verify decrypted mnemonic matches the expected account address.
+        // MLDSA87 derivation runs in the crypto worker — keeps the
+        // Transfer modal animating smoothly during the 50–300 ms check.
+        const senderAddress = await getAddressFromMnemonicAsync(mnemonicPhrases, qrlStore.qrlInstance!);
         if (senderAddress.toLowerCase() !== accountAddress.toLowerCase()) {
           control.setError("pin", { message: "Security error: seed mismatch detected. Please re-import this account." });
           return;
@@ -394,7 +396,7 @@ const Transfer = observer(() => {
         return;
       }
 
-      const senderAddress = getAddressFromMnemonic(mnemonic, qrlStore.qrlInstance!);
+      const senderAddress = await getAddressFromMnemonicAsync(mnemonic, qrlStore.qrlInstance!);
       if (senderAddress.toLowerCase() !== accountAddress.toLowerCase()) {
         control.setError("pin", { message: "PIN decrypted an invalid seed." });
         return;

--- a/src/utils/crypto/index.ts
+++ b/src/utils/crypto/index.ts
@@ -9,6 +9,7 @@ export {
   getMnemonicFromHexSeed,
   getHexSeedFromMnemonic,
   getAddressFromMnemonic,
+  getAddressFromMnemonicAsync,
 } from './mnemonic';
 
 export {

--- a/src/utils/crypto/mnemonic.ts
+++ b/src/utils/crypto/mnemonic.ts
@@ -1,6 +1,7 @@
 import { MLDSA87, ExtendedSeed } from "@theqrl/wallet.js";
 import { Buffer } from "buffer";
 import type { Web3QRLInterface } from "@theqrl/web3";
+import { deriveHexSeedAsync } from "./cryptoWorkerClient";
 
 export const getMnemonicFromHexSeed = (hexSeed?: string) => {
   if (!hexSeed) return "";
@@ -28,4 +29,20 @@ export const getAddressFromMnemonic = (mnemonic: string | undefined, qrlInstance
   const hexSeed = wallet.getHexExtendedSeed();
   const account = qrlInstance.accounts.seedToAccount(hexSeed);
   return account.address;
+};
+
+/**
+ * Async sibling of getAddressFromMnemonic that runs the heavy MLDSA87
+ * expansion in the crypto worker. The subsequent seedToAccount call
+ * (deterministic mapping of hexSeed → address) is comparatively cheap
+ * and stays on the main thread.
+ */
+export const getAddressFromMnemonicAsync = async (
+  mnemonic: string | undefined,
+  qrlInstance: Web3QRLInterface,
+): Promise<string> => {
+  if (!mnemonic) return "";
+  const hexSeed = await deriveHexSeedAsync(mnemonic);
+  if (!hexSeed) return "";
+  return qrlInstance.accounts.seedToAccount(hexSeed).address;
 };


### PR DESCRIPTION
## Summary

Last slice of the wallet-frontend ML-DSA migration. `getAddressFromMnemonic` was still expanding the MLDSA87 wallet on the main thread on every Transfer / SendToken / CreateToken submit (to verify the decrypted mnemonic matches the active account) — 50–300 ms of UI freeze on the click-to-confirm path.

### New helper

`src/utils/crypto/mnemonic.ts::getAddressFromMnemonicAsync(mnemonic, qrlInstance)` delegates the heavy derivation to `deriveHexSeedAsync` (the worker pool from #133). The subsequent `seedToAccount(hexSeed)` call is a deterministic mapping that stays on the main thread (~µs).

### Migrations

| File | Call sites |
|---|---|
| `Transfer.tsx` | handleNativeTransfer (line 363) + handleTokenTransfer (line 397) |
| `SendTokenModal.tsx` | line 86 |
| `TokenCreationForm.tsx` | line 146 |

All call sites were already inside `async` handlers; adding `await` was trivial. The sync `getAddressFromMnemonic` stays exported for any external / test consumers.

### Sprint 3 wrap

Every MLDSA87 expansion on the wallet's hot paths now runs in the existing crypto worker pool. Combined with the bundle split (#130), receipt poller cleanup (#131), localStorage event bus (#132), and the earlier signing migrations (#133, #134), Sprint 3 closes the audit's HIGH-severity wallet-frontend findings.

## Test plan

- [x] `npm run build` clean (verified locally)
- [ ] After deploy: confirm Transfer → enter PIN → submit shows no long-task on the main thread during the address-verification step
- [ ] Send Token / Create Token flows still validate the mnemonic correctly (no false-positive `seed mismatch` errors)