### PR TITLE
feat(nft): qrlStore split + Home card visibility toggles + ERC-721/1155 support

### DIFF
--- a/src/abi/ERC1155ABI.ts
+++ b/src/abi/ERC1155ABI.ts
@@ -1,0 +1,34 @@
+// Minimal ERC-1155 ABI — metadata URI + balanceOf(owner, id) + the
+// non-batched safeTransferFrom. ERC-1155 has no on-chain name/symbol.
+export const erc1155ABI = [
+  {
+    inputs: [{ internalType: "uint256", name: "id", type: "uint256" }],
+    name: "uri",
+    outputs: [{ internalType: "string", name: "", type: "string" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "account", type: "address" },
+      { internalType: "uint256", name: "id", type: "uint256" },
+    ],
+    name: "balanceOf",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "from", type: "address" },
+      { internalType: "address", name: "to", type: "address" },
+      { internalType: "uint256", name: "id", type: "uint256" },
+      { internalType: "uint256", name: "amount", type: "uint256" },
+      { internalType: "bytes", name: "data", type: "bytes" },
+    ],
+    name: "safeTransferFrom",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+];

--- a/src/abi/ERC165ABI.ts
+++ b/src/abi/ERC165ABI.ts
@@ -1,0 +1,21 @@
+// Minimal ERC-165 — only the introspection method we actually call.
+// Used to discriminate ERC-721 (interfaceId 0x80ac58cd), ERC-1155
+// (0xd9b67a26), and ERC721Enumerable (0x780e9d63) before falling
+// through to ERC-20 behaviour.
+export const erc165ABI = [
+  {
+    inputs: [{ internalType: "bytes4", name: "interfaceId", type: "bytes4" }],
+    name: "supportsInterface",
+    outputs: [{ internalType: "bool", name: "", type: "bool" }],
+    stateMutability: "view",
+    type: "function",
+  },
+];
+
+export const ERC165_INTERFACE_IDS = {
+  ERC721: "0x80ac58cd",
+  ERC721_ENUMERABLE: "0x780e9d63",
+  ERC721_METADATA: "0x5b5e139f",
+  ERC1155: "0xd9b67a26",
+  ERC1155_METADATA_URI: "0x0e89341c",
+} as const;

--- a/src/abi/ERC721ABI.ts
+++ b/src/abi/ERC721ABI.ts
@@ -1,0 +1,64 @@
+// Minimal ERC-721 ABI — collection metadata, ownership, metadata URI,
+// transfer, plus the ERC721Enumerable owner-side enumeration helpers
+// the gallery uses when the contract supports it.
+//
+// Avoid `as const` here — Web3QRLInterface.Contract generics handle the
+// non-readonly ABI shape; a readonly tuple breaks method-arg inference.
+export const erc721ABI = [
+  {
+    inputs: [],
+    name: "name",
+    outputs: [{ internalType: "string", name: "", type: "string" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "symbol",
+    outputs: [{ internalType: "string", name: "", type: "string" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "owner", type: "address" }],
+    name: "balanceOf",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "uint256", name: "tokenId", type: "uint256" }],
+    name: "ownerOf",
+    outputs: [{ internalType: "address", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "uint256", name: "tokenId", type: "uint256" }],
+    name: "tokenURI",
+    outputs: [{ internalType: "string", name: "", type: "string" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "owner", type: "address" },
+      { internalType: "uint256", name: "index", type: "uint256" },
+    ],
+    name: "tokenOfOwnerByIndex",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "from", type: "address" },
+      { internalType: "address", name: "to", type: "address" },
+      { internalType: "uint256", name: "tokenId", type: "uint256" },
+    ],
+    name: "safeTransferFrom",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+];

--- a/src/components/Core/Body/CreateToken/CreateToken.tsx
+++ b/src/components/Core/Body/CreateToken/CreateToken.tsx
@@ -4,10 +4,8 @@ import { useStore } from "@/stores/store";
 import { SEO } from "@/components/SEO/SEO";
 
 const CreateToken = observer(() => {
-    const { qrlStore } = useStore();
-    const {
-        createToken,
-    } = qrlStore;
+    const { tokenStore } = useStore();
+    const { createToken } = tokenStore;
 
     const onTokenCreated = async (tokenName: string, tokenSymbol: string, initialSupply: string, decimals: number, maxSupply: undefined | string, initialRecipient: undefined | string, maxWalletAmount: undefined | string, maxTransactionLimit: undefined | string, mnemonicPhrases: string) => {
 

--- a/src/components/Core/Body/CreateToken/TokenCreationForm/TokenCreationForm.tsx
+++ b/src/components/Core/Body/CreateToken/TokenCreationForm/TokenCreationForm.tsx
@@ -67,7 +67,7 @@ type TokenCreationFormProps = {
 export const TokenCreationForm = observer(
     ({ onTokenCreated }: TokenCreationFormProps) => {
         const navigate = useNavigate();
-        const { qrlStore } = useStore();
+        const { qrlStore, tokenStore } = useStore();
         const { activeAccount, activeAccountSource } = qrlStore;
         const [pin, setPin] = useState("");
         const [pinError, setPinError] = useState("");
@@ -171,14 +171,14 @@ export const TokenCreationForm = observer(
                 const maxTransactionLimit = formData.maxTransactionLimit ? ethers.parseUnits(formData.maxTransactionLimit, decimals).toString() : undefined;
 
                 // Navigate immediately to show loading state, then start creation
-                qrlStore.setCreatingToken(tokenName, true);
+                tokenStore.setCreatingToken(tokenName, true);
                 navigate(ROUTES.TOKEN_STATUS);
 
                 // Start token creation in background (don't await here)
                 onTokenCreated(tokenName, tokenSymbol, initialSupply, decimals, maxSupply, recipientAddress, maxWalletAmount, maxTransactionLimit, mnemonicPhrase)
                     .catch((error) => {
                         console.error("Token creation failed:", error);
-                        // The error state is set within qrlStore and displayed on the status page
+                        // The error state is set within tokenStore and displayed on the status page
                     });
             } catch (error) {
                 console.error("Error creating token:", error);

--- a/src/components/Core/Body/CreateToken/TokenStatus.tsx
+++ b/src/components/Core/Body/CreateToken/TokenStatus.tsx
@@ -13,8 +13,9 @@ import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { QRL_PROVIDER } from "@/config";
 
 const TokenStatus = observer(() => {
-    const { qrlStore } = useStore();
-    const { addToken, createdToken, creatingToken, qrlConnection } = qrlStore;
+    const { qrlStore, tokenStore } = useStore();
+    const { qrlConnection } = qrlStore;
+    const { addToken, createdToken, creatingToken } = tokenStore;
     const { name, symbol, decimals, address, tx, blockNumber, blockHash, gasUsed, effectiveGasPrice } = createdToken;
     const explorerUrl = QRL_PROVIDER[qrlConnection.blockchain as keyof typeof QRL_PROVIDER]?.explorer || "https://zondscan.com";
 

--- a/src/components/Core/Body/Home/Home.tsx
+++ b/src/components/Core/Body/Home/Home.tsx
@@ -15,6 +15,7 @@ import { TransactionHistoryPopup } from "../AccountList/ActiveAccount/Transactio
 import { ReceivePopup } from "./ReceivePopup";
 import { isInNativeApp, requestQRScan } from "@/utils/nativeApp";
 import ConnectionBadge from "./ConnectionBadge/ConnectionBadge";
+import { StorageUtil, STORAGE_EVENT_WALLET_SETTINGS } from "@/utils/storage";
 
 const AccountCreateImport = withSuspense(
   lazy(() => import("./AccountCreateImport/AccountCreateImport"))
@@ -27,6 +28,10 @@ const TokenForm = withSuspense(
   lazy(() => import("../Tokens/TokenForm/TokenForm"))
 );
 
+const NftGallery = withSuspense(
+  lazy(() => import("../Nfts/NftGallery"))
+);
+
 const Home = observer(() => {
   const { state } = useLocation();
   const { qrlStore, tokenStore } = useStore();
@@ -37,6 +42,28 @@ const Home = observer(() => {
   const activeAccountVideoRef = useRef<HTMLVideoElement | null>(null);
   const [txHistoryOpen, setTxHistoryOpen] = useState(false);
   const [receiveOpen, setReceiveOpen] = useState(false);
+  const [showTokensCard, setShowTokensCard] = useState(true);
+  const [showNftsCard, setShowNftsCard] = useState(true);
+
+  // Load card-visibility prefs and refresh whenever Settings re-saves
+  // (StorageUtil dispatches STORAGE_EVENT_WALLET_SETTINGS on write so
+  // toggles take effect without a page reload).
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      const s = await StorageUtil.getWalletSettings();
+      if (cancelled) return;
+      setShowTokensCard(s.showTokensCard ?? true);
+      setShowNftsCard(s.showNftsCard ?? true);
+    };
+    load();
+    const handler = () => { load(); };
+    window.addEventListener(STORAGE_EVENT_WALLET_SETTINGS, handler);
+    return () => {
+      cancelled = true;
+      window.removeEventListener(STORAGE_EVENT_WALLET_SETTINGS, handler);
+    };
+  }, []);
 
   // Function to track if any modal is open
   const checkIfModalOpen = () => {
@@ -192,9 +219,14 @@ const Home = observer(() => {
                     </div>
                   </Card>
               )}
-              {activeAccount.accountAddress && (
+              {activeAccount.accountAddress && showTokensCard && (
                 <div className="relative z-10">
                   <TokenForm />
+                </div>
+              )}
+              {activeAccount.accountAddress && showNftsCard && (
+                <div className="relative z-10">
+                  <NftGallery />
                 </div>
               )}
               {isConnected ? <AccountCreateImport /> : <ConnectionFailed />}

--- a/src/components/Core/Body/Home/Home.tsx
+++ b/src/components/Core/Body/Home/Home.tsx
@@ -29,7 +29,7 @@ const TokenForm = withSuspense(
 
 const Home = observer(() => {
   const { state } = useLocation();
-  const { qrlStore } = useStore();
+  const { qrlStore, tokenStore } = useStore();
   const { qrlConnection, activeAccount } = qrlStore;
   const { isLoading, isConnected, blockchain } = qrlConnection;
   const hasAccountCreationPreference = !!state?.hasAccountCreationPreference;
@@ -74,7 +74,7 @@ const Home = observer(() => {
     if (activeAccount.accountAddress) {
       // Refresh immediately on mount
       qrlStore.fetchAccounts();
-      qrlStore.refreshTokenBalances();
+      tokenStore.refreshTokenBalances();
       qrlStore.fetchQrlPrice();
 
       // Set up recurring refresh every 30 seconds
@@ -82,18 +82,18 @@ const Home = observer(() => {
         // Only refresh if no modals are open
         if (!checkIfModalOpen()) {
           qrlStore.fetchAccounts();
-          qrlStore.refreshTokenBalances();
+          tokenStore.refreshTokenBalances();
           qrlStore.fetchQrlPrice();
         }
       }, 30000); // 30 seconds
     }
-    
+
     return () => {
       if (refreshIntervalRef.current) {
         clearInterval(refreshIntervalRef.current);
       }
     };
-  }, [activeAccount.accountAddress, qrlStore]);
+  }, [activeAccount.accountAddress, qrlStore, tokenStore]);
 
   const accountCreateImportClasses = cva("flex gap-4 md:gap-8", {
     variants: {

--- a/src/components/Core/Body/Nfts/AddNftModal.tsx
+++ b/src/components/Core/Body/Nfts/AddNftModal.tsx
@@ -116,6 +116,9 @@ export function AddNftModal({ isOpen, onClose }: AddNftModalProps) {
       const rpcUrl = QRL_PROVIDER[blockchain].url;
 
       let ids: string[] = [];
+      // ERC-1155 balance cache so the metadata loop below doesn't re-fetch
+      // a balance we already needed to check during the ownership gate.
+      const balanceCache: Record<string, bigint> = {};
       if (detection.standard === "ERC721") {
         // Prefer enumeration when available.
         const enumerated = await fetchOwned721Ids(
@@ -158,10 +161,11 @@ export function AddNftModal({ isOpen, onClose }: AddNftModalProps) {
           setIsAdding(false);
           return;
         }
+        const trimmedId = tokenId.trim();
         const balance = await fetchErc1155Balance(
           contractAddress,
           accountAddress,
-          tokenId.trim(),
+          trimmedId,
           rpcUrl,
         );
         if (balance <= 0n) {
@@ -169,7 +173,8 @@ export function AddNftModal({ isOpen, onClose }: AddNftModalProps) {
           setIsAdding(false);
           return;
         }
-        ids = [tokenId.trim()];
+        balanceCache[trimmedId] = balance;
+        ids = [trimmedId];
       }
 
       // Resolve metadata for each id (best-effort; tolerant of failures).
@@ -205,12 +210,15 @@ export function AddNftModal({ isOpen, onClose }: AddNftModalProps) {
           image: metaImage,
           balance:
             detection.standard === "ERC1155"
-              ? (await fetchErc1155Balance(
-                  contractAddress,
-                  accountAddress,
-                  id,
-                  rpcUrl,
-                )).toString()
+              ? (
+                  balanceCache[id] ??
+                  (await fetchErc1155Balance(
+                    contractAddress,
+                    accountAddress,
+                    id,
+                    rpcUrl,
+                  ))
+                ).toString()
               : undefined,
           fetchedAt: Date.now(),
         };

--- a/src/components/Core/Body/Nfts/AddNftModal.tsx
+++ b/src/components/Core/Body/Nfts/AddNftModal.tsx
@@ -1,0 +1,338 @@
+import { useEffect, useState } from "react";
+import { Loader2 } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/UI/Dialog";
+import { Button } from "@/components/UI/Button";
+import { Input } from "@/components/UI/Input";
+import { Label } from "@/components/UI/Label";
+import { useStore } from "@/stores/store";
+import { StorageUtil } from "@/utils/storage";
+import { QRL_PROVIDER } from "@/config";
+import {
+  detectTokenStandard,
+  fetchNftCollectionInfo,
+  fetchNftMetadata,
+  fetchOwned721Ids,
+  fetchErc1155Balance,
+  fetchTokenUri,
+  isErc721Owner,
+  type NftCollectionInfo,
+  type NftStandard,
+} from "@/utils/web3/nft";
+import { isValidQrlAddress } from "@/utils/web3";
+import { NFTInterface } from "@/constants";
+
+interface AddNftModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function AddNftModal({ isOpen, onClose }: AddNftModalProps) {
+  const { qrlStore, nftStore } = useStore();
+  const { accountAddress } = qrlStore.activeAccount;
+
+  const [contractAddress, setContractAddress] = useState("");
+  const [tokenId, setTokenId] = useState("");
+  const [detection, setDetection] = useState<{
+    standard: NftStandard;
+    info: NftCollectionInfo;
+  } | null>(null);
+  const [isDetecting, setIsDetecting] = useState(false);
+  const [isAdding, setIsAdding] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      // Reset on close so a fresh open is empty.
+      setContractAddress("");
+      setTokenId("");
+      setDetection(null);
+      setError(null);
+      setIsDetecting(false);
+      setIsAdding(false);
+    }
+  }, [isOpen]);
+
+  // Re-run detection on contract-address change once the format looks valid.
+  useEffect(() => {
+    let cancelled = false;
+    const detect = async () => {
+      setDetection(null);
+      if (!isValidQrlAddress(contractAddress)) return;
+      setError(null);
+      setIsDetecting(true);
+      try {
+        const blockchain = await StorageUtil.getBlockChain();
+        const rpcUrl = QRL_PROVIDER[blockchain].url;
+        const standard = await detectTokenStandard(contractAddress, rpcUrl);
+        if (cancelled) return;
+        if (!standard) {
+          setError(
+            "This address doesn't look like an ERC-721 or ERC-1155 contract.",
+          );
+          setIsDetecting(false);
+          return;
+        }
+        const info = await fetchNftCollectionInfo(
+          contractAddress,
+          rpcUrl,
+          standard,
+        );
+        if (cancelled) return;
+        setDetection({ standard, info });
+      } catch (err) {
+        if (cancelled) return;
+        setError(
+          err instanceof Error
+            ? `Detection failed: ${err.message}`
+            : "Detection failed.",
+        );
+      } finally {
+        if (!cancelled) setIsDetecting(false);
+      }
+    };
+    detect();
+    return () => {
+      cancelled = true;
+    };
+  }, [contractAddress]);
+
+  const onAdd = async () => {
+    if (!detection) return;
+    if (!accountAddress) {
+      setError("Connect an account first.");
+      return;
+    }
+    setIsAdding(true);
+    setError(null);
+    try {
+      const blockchain = await StorageUtil.getBlockChain();
+      const rpcUrl = QRL_PROVIDER[blockchain].url;
+
+      let ids: string[] = [];
+      if (detection.standard === "ERC721") {
+        // Prefer enumeration when available.
+        const enumerated = await fetchOwned721Ids(
+          contractAddress,
+          accountAddress,
+          rpcUrl,
+        );
+        if (enumerated && enumerated.length > 0) {
+          ids = enumerated;
+        } else if (enumerated && enumerated.length === 0) {
+          setError("This account doesn't own any token in that collection.");
+          setIsAdding(false);
+          return;
+        } else {
+          // Non-enumerable — fall back to user-supplied tokenId.
+          if (!tokenId.trim()) {
+            setError(
+              "This contract doesn't expose ownership enumeration. Please enter a Token ID.",
+            );
+            setIsAdding(false);
+            return;
+          }
+          const owned = await isErc721Owner(
+            contractAddress,
+            accountAddress,
+            tokenId.trim(),
+            rpcUrl,
+          );
+          if (!owned) {
+            setError("This account does not own that token ID.");
+            setIsAdding(false);
+            return;
+          }
+          ids = [tokenId.trim()];
+        }
+      } else {
+        // ERC-1155 requires explicit tokenId.
+        if (!tokenId.trim()) {
+          setError("ERC-1155 contracts need a Token ID.");
+          setIsAdding(false);
+          return;
+        }
+        const balance = await fetchErc1155Balance(
+          contractAddress,
+          accountAddress,
+          tokenId.trim(),
+          rpcUrl,
+        );
+        if (balance <= 0n) {
+          setError("This account holds 0 of that token.");
+          setIsAdding(false);
+          return;
+        }
+        ids = [tokenId.trim()];
+      }
+
+      // Resolve metadata for each id (best-effort; tolerant of failures).
+      for (const id of ids) {
+        let metaName: string | undefined;
+        let metaImage: string | undefined;
+        let metaDescription: string | undefined;
+        try {
+          const uri = await fetchTokenUri(
+            contractAddress,
+            id,
+            rpcUrl,
+            detection.standard,
+          );
+          if (uri) {
+            const meta = await fetchNftMetadata(uri);
+            metaName = meta?.name;
+            metaImage = meta?.image;
+            metaDescription = meta?.description;
+          }
+        } catch (err) {
+          console.error(`fetchTokenUri/Metadata failed for ${id}:`, err);
+        }
+
+        const nft: NFTInterface = {
+          contractAddress,
+          standard: detection.standard,
+          tokenId: id,
+          collectionName: detection.info.name,
+          collectionSymbol: detection.info.symbol,
+          name: metaName,
+          description: metaDescription,
+          image: metaImage,
+          balance:
+            detection.standard === "ERC1155"
+              ? (await fetchErc1155Balance(
+                  contractAddress,
+                  accountAddress,
+                  id,
+                  rpcUrl,
+                )).toString()
+              : undefined,
+          fetchedAt: Date.now(),
+        };
+        await nftStore.addNft(nft);
+      }
+
+      onClose();
+    } catch (err) {
+      setError(
+        err instanceof Error ? `Add failed: ${err.message}` : "Add failed.",
+      );
+    } finally {
+      setIsAdding(false);
+    }
+  };
+
+  const needsTokenId =
+    detection?.standard === "ERC1155" ||
+    (detection?.standard === "ERC721" && !detection.info.supportsEnumerable);
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-[600px]">
+        <DialogHeader>
+          <DialogTitle>Add NFT</DialogTitle>
+          <DialogDescription>
+            Add an ERC-721 or ERC-1155 collectible to your wallet.
+          </DialogDescription>
+        </DialogHeader>
+
+        {error && (
+          <div
+            role="alert"
+            className="rounded-md bg-destructive/15 p-3 text-sm text-destructive"
+          >
+            {error}
+          </div>
+        )}
+
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="nft-contract">Contract Address</Label>
+          <Input
+            id="nft-contract"
+            value={contractAddress}
+            onChange={(e) => {
+              setContractAddress(e.target.value.trim());
+              setError(null);
+            }}
+            placeholder="Q…"
+            disabled={isAdding}
+          />
+        </div>
+
+        {isDetecting && (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Detecting contract standard…
+          </div>
+        )}
+
+        {detection && (
+          <div className="rounded-md border bg-muted/30 p-3 text-sm">
+            <div>
+              <span className="text-muted-foreground">Standard:</span>{" "}
+              <span className="font-medium">{detection.standard}</span>
+            </div>
+            {detection.info.name && (
+              <div>
+                <span className="text-muted-foreground">Collection:</span>{" "}
+                <span className="font-medium">
+                  {detection.info.name}
+                  {detection.info.symbol ? ` (${detection.info.symbol})` : ""}
+                </span>
+              </div>
+            )}
+            {detection.standard === "ERC721" && (
+              <div>
+                <span className="text-muted-foreground">
+                  Owner enumeration:
+                </span>{" "}
+                <span className="font-medium">
+                  {detection.info.supportsEnumerable ? "yes" : "no"}
+                </span>
+              </div>
+            )}
+          </div>
+        )}
+
+        {needsTokenId && (
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="nft-token-id">Token ID</Label>
+            <Input
+              id="nft-token-id"
+              value={tokenId}
+              onChange={(e) => {
+                setTokenId(e.target.value.trim());
+                setError(null);
+              }}
+              placeholder="e.g. 42"
+              disabled={isAdding}
+            />
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button
+            type="button"
+            className="w-full"
+            disabled={!detection || isAdding || isDetecting}
+            onClick={onAdd}
+          >
+            {isAdding ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Adding…
+              </>
+            ) : (
+              "Add NFT"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/Core/Body/Nfts/NftCard.tsx
+++ b/src/components/Core/Body/Nfts/NftCard.tsx
@@ -1,0 +1,76 @@
+import { useNavigate } from "react-router-dom";
+import { EyeOff } from "lucide-react";
+import { NFTInterface } from "@/constants";
+import { Card } from "@/components/UI/Card";
+import { Button } from "@/components/UI/Button";
+import { useStore } from "@/stores/store";
+import { nftKey } from "@/utils/web3/nft";
+import { NftImage } from "./NftImage";
+import { ROUTES } from "@/router/router";
+
+interface NftCardProps {
+  nft: NFTInterface;
+}
+
+export function NftCard({ nft }: NftCardProps) {
+  const { nftStore } = useStore();
+  const navigate = useNavigate();
+  const key = nftKey(nft.contractAddress, nft.tokenId);
+
+  const onHide = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    await nftStore.hideNft(key);
+  };
+
+  const onOpen = () => {
+    navigate(
+      `${ROUTES.NFT_DETAIL.replace(":contractAddress", nft.contractAddress).replace(":tokenId", nft.tokenId)}`,
+    );
+  };
+
+  const subtitle = nft.collectionName
+    ? `${nft.collectionName} • #${truncateId(nft.tokenId)}`
+    : `${truncateAddress(nft.contractAddress)} • #${truncateId(nft.tokenId)}`;
+
+  return (
+    <Card
+      className="group relative cursor-pointer overflow-hidden border-l-4 border-l-secondary transition-shadow hover:shadow-md"
+      onClick={onOpen}
+    >
+      <NftImage
+        src={nft.image}
+        alt={nft.name ?? `Token #${nft.tokenId}`}
+        className="aspect-square w-full"
+      />
+      <div className="space-y-1 p-3">
+        <div className="truncate text-sm font-semibold">
+          {nft.name ?? `Token #${truncateId(nft.tokenId)}`}
+        </div>
+        <div className="truncate text-xs text-muted-foreground">{subtitle}</div>
+        {nft.standard === "ERC1155" && nft.balance && BigInt(nft.balance) > 1n && (
+          <div className="text-xs text-muted-foreground">
+            Balance: {nft.balance}
+          </div>
+        )}
+      </div>
+      <Button
+        variant="ghost"
+        size="icon"
+        title="Hide NFT"
+        onClick={onHide}
+        className="absolute right-2 top-2 h-7 w-7 opacity-0 transition-opacity group-hover:opacity-100"
+      >
+        <EyeOff className="h-4 w-4" />
+      </Button>
+    </Card>
+  );
+}
+
+function truncateAddress(addr: string) {
+  return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
+}
+
+function truncateId(id: string) {
+  if (id.length <= 12) return id;
+  return `${id.slice(0, 6)}…${id.slice(-4)}`;
+}

--- a/src/components/Core/Body/Nfts/NftDetail.tsx
+++ b/src/components/Core/Body/Nfts/NftDetail.tsx
@@ -1,0 +1,390 @@
+import { observer } from "mobx-react-lite";
+import { useNavigate, useParams } from "react-router-dom";
+import { useEffect, useMemo, useState } from "react";
+import { ArrowLeft, ExternalLink, Loader2, Send } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/UI/Card";
+import { Button } from "@/components/UI/Button";
+import { Input } from "@/components/UI/Input";
+import { Label } from "@/components/UI/Label";
+import { Separator } from "@/components/UI/Separator";
+import { PinInput } from "@/components/UI/PinInput/PinInput";
+import { useStore } from "@/stores/store";
+import { StorageUtil } from "@/utils/storage";
+import { QRL_PROVIDER } from "@/config";
+import {
+  isValidQrlAddress,
+  getAddressValidationError,
+} from "@/utils/web3";
+import { WalletEncryptionUtil } from "@/utils/crypto";
+import { getAddressFromMnemonicAsync } from "@/utils/crypto";
+import { NftImage } from "./NftImage";
+import { ROUTES } from "@/router/router";
+
+const NftDetail = observer(() => {
+  const navigate = useNavigate();
+  const { contractAddress = "", tokenId = "" } = useParams();
+  const { qrlStore, nftStore } = useStore();
+  const { accountAddress } = qrlStore.activeAccount;
+  const activeSource = qrlStore.activeAccountSource;
+  const isExtension = activeSource === "extension";
+
+  const nft = useMemo(
+    () =>
+      nftStore.nftList.find(
+        (n) =>
+          n.contractAddress.toLowerCase() === contractAddress.toLowerCase() &&
+          n.tokenId === tokenId,
+      ),
+    [nftStore.nftList, contractAddress, tokenId],
+  );
+
+  const [toAddress, setToAddress] = useState("");
+  const [toAddressError, setToAddressError] = useState("");
+  const [amount, setAmount] = useState("1");
+  const [pin, setPin] = useState("");
+  const [pinError, setPinError] = useState("");
+  const [sendError, setSendError] = useState<string | null>(null);
+  const [isSending, setIsSending] = useState(false);
+
+  const txStatus = qrlStore.transactionStatus;
+
+  useEffect(() => {
+    // Reset on unmount
+    return () => {
+      qrlStore.resetTransactionStatus();
+    };
+  }, [qrlStore]);
+
+  if (!nft) {
+    return (
+      <div className="mx-auto max-w-2xl px-2 py-4">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => navigate(ROUTES.HOME)}
+        >
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Back
+        </Button>
+        <Card className="mt-4">
+          <CardContent className="py-8 text-center text-sm text-muted-foreground">
+            NFT not found in your wallet. Add it from the Home page first.
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const explorerUrl =
+    QRL_PROVIDER[qrlStore.qrlConnection.blockchain as keyof typeof QRL_PROVIDER]
+      ?.explorer ?? "https://zondscan.com";
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSendError(null);
+    setPinError("");
+    setToAddressError("");
+
+    if (!isValidQrlAddress(toAddress)) {
+      setToAddressError(getAddressValidationError(toAddress));
+      return;
+    }
+    if (toAddress.toLowerCase() === accountAddress.toLowerCase()) {
+      setToAddressError("Cannot send to your own address.");
+      return;
+    }
+
+    let amountBig: bigint;
+    try {
+      amountBig = BigInt(amount);
+    } catch {
+      setSendError("Amount must be a whole number.");
+      return;
+    }
+    if (nft.standard === "ERC721" && amountBig !== 1n) {
+      setSendError("ERC-721 transfers are always 1 token.");
+      return;
+    }
+    if (amountBig <= 0n) {
+      setSendError("Amount must be positive.");
+      return;
+    }
+    if (nft.balance && BigInt(nft.balance) < amountBig) {
+      setSendError(`You only hold ${nft.balance} of this token.`);
+      return;
+    }
+
+    setIsSending(true);
+    try {
+      if (isExtension) {
+        // Extension-signed NFT writes aren't wired yet — surface a clear
+        // message rather than silently using the encrypted-seed path.
+        setSendError(
+          "Extension-signed NFT transfers are coming soon. Switch to an imported account to transfer for now.",
+        );
+        setIsSending(false);
+        return;
+      }
+
+      if (!pin || pin.length < 4) {
+        setPinError("Enter your PIN to sign the transfer.");
+        setIsSending(false);
+        return;
+      }
+
+      const blockchain = await StorageUtil.getBlockChain();
+      const encryptedSeed = await StorageUtil.getEncryptedSeed(
+        blockchain,
+        accountAddress,
+      );
+      if (!encryptedSeed) {
+        setPinError(
+          "No stored seed for this account. Re-import to set up a PIN.",
+        );
+        setIsSending(false);
+        return;
+      }
+      let mnemonic: string;
+      try {
+        const decrypted = WalletEncryptionUtil.decryptSeedWithPin(
+          encryptedSeed,
+          pin,
+        );
+        mnemonic = decrypted.mnemonic;
+      } catch {
+        setPinError("Invalid PIN.");
+        setIsSending(false);
+        return;
+      }
+      const sender = await getAddressFromMnemonicAsync(
+        mnemonic,
+        qrlStore.qrlInstance!,
+      );
+      if (sender.toLowerCase() !== accountAddress.toLowerCase()) {
+        setPinError("PIN decrypted an invalid seed. Re-import this account.");
+        setIsSending(false);
+        return;
+      }
+
+      const ok = await nftStore.transferNft(
+        nft,
+        toAddress,
+        mnemonic,
+        amountBig,
+      );
+      if (!ok) {
+        setSendError(qrlStore.transactionStatus.error ?? "Transfer failed.");
+      }
+    } catch (err) {
+      setSendError(
+        err instanceof Error ? err.message : "Unexpected transfer error.",
+      );
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto w-full max-w-3xl px-2 py-4 md:py-8">
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => navigate(ROUTES.HOME)}
+        className="mb-4"
+      >
+        <ArrowLeft className="mr-2 h-4 w-4" />
+        Back
+      </Button>
+
+      <div className="grid gap-4 md:grid-cols-2 md:gap-8">
+        <NftImage
+          src={nft.image}
+          alt={nft.name ?? `Token #${nft.tokenId}`}
+          className="aspect-square w-full rounded-lg"
+        />
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-2xl">
+              {nft.name ?? `Token #${nft.tokenId}`}
+            </CardTitle>
+            {nft.collectionName && (
+              <p className="text-sm text-muted-foreground">
+                {nft.collectionName}
+                {nft.collectionSymbol ? ` (${nft.collectionSymbol})` : ""}
+              </p>
+            )}
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm">
+            <Row label="Standard" value={nft.standard} />
+            <Row label="Token ID" value={nft.tokenId} mono />
+            <Row
+              label="Contract"
+              value={
+                <a
+                  className="inline-flex items-center gap-1 text-blue-accent underline"
+                  href={`${explorerUrl}/address/${nft.contractAddress}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {nft.contractAddress.slice(0, 6)}…
+                  {nft.contractAddress.slice(-4)}
+                  <ExternalLink className="h-3 w-3" />
+                </a>
+              }
+            />
+            {nft.standard === "ERC1155" && nft.balance && (
+              <Row label="Balance" value={nft.balance} />
+            )}
+            {nft.description && (
+              <>
+                <Separator />
+                <div>
+                  <div className="text-xs font-medium uppercase text-muted-foreground">
+                    Description
+                  </div>
+                  <p className="mt-1 whitespace-pre-wrap text-sm">
+                    {nft.description}
+                  </p>
+                </div>
+              </>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card className="mt-6 border-l-4 border-l-blue-accent">
+        <CardHeader>
+          <CardTitle className="text-lg">Transfer</CardTitle>
+        </CardHeader>
+        <form onSubmit={onSubmit}>
+          <CardContent className="space-y-4">
+            {sendError && (
+              <div
+                role="alert"
+                className="rounded-md bg-destructive/15 p-3 text-sm text-destructive"
+              >
+                {sendError}
+              </div>
+            )}
+            {txStatus.state === "confirmed" && txStatus.txHash && (
+              <div
+                role="status"
+                className="rounded-md bg-green-500/15 p-3 text-sm text-green-600 dark:text-green-400"
+              >
+                Transfer confirmed.{" "}
+                <a
+                  className="underline"
+                  href={`${explorerUrl}/tx/${txStatus.txHash}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  View on explorer
+                </a>
+              </div>
+            )}
+            {txStatus.state === "pending" && (
+              <div className="flex items-center gap-2 rounded-md bg-muted p-3 text-sm">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Broadcasting transaction…
+              </div>
+            )}
+
+            <div>
+              <Label htmlFor="nft-to">Recipient Address</Label>
+              <Input
+                id="nft-to"
+                value={toAddress}
+                onChange={(e) => {
+                  setToAddress(e.target.value.trim());
+                  setToAddressError("");
+                }}
+                placeholder="Q…"
+                disabled={isSending}
+              />
+              {toAddressError && (
+                <p className="mt-1 text-xs text-destructive">
+                  {toAddressError}
+                </p>
+              )}
+            </div>
+
+            {nft.standard === "ERC1155" && (
+              <div>
+                <Label htmlFor="nft-amount">Amount</Label>
+                <Input
+                  id="nft-amount"
+                  value={amount}
+                  onChange={(e) => setAmount(e.target.value.trim())}
+                  inputMode="numeric"
+                  disabled={isSending}
+                />
+                {nft.balance && (
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Holding: {nft.balance}
+                  </p>
+                )}
+              </div>
+            )}
+
+            {!isExtension && (
+              <div>
+                <Label>Wallet PIN</Label>
+                <PinInput
+                  value={pin}
+                  onChange={setPin}
+                  placeholder="Enter PIN"
+                  error={pinError || undefined}
+                  disabled={isSending}
+                />
+              </div>
+            )}
+          </CardContent>
+          <CardFooter>
+            <Button
+              type="submit"
+              className="w-full"
+              disabled={isSending || !accountAddress}
+            >
+              {isSending ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Sending…
+                </>
+              ) : (
+                <>
+                  <Send className="mr-2 h-4 w-4" />
+                  Transfer
+                </>
+              )}
+            </Button>
+          </CardFooter>
+        </form>
+      </Card>
+    </div>
+  );
+});
+
+function Row({
+  label,
+  value,
+  mono,
+}: {
+  label: string;
+  value: React.ReactNode;
+  mono?: boolean;
+}) {
+  return (
+    <div className="flex items-baseline justify-between gap-3">
+      <div className="text-xs uppercase text-muted-foreground">{label}</div>
+      <div className={mono ? "font-mono text-sm" : "text-sm"}>{value}</div>
+    </div>
+  );
+}
+
+export default NftDetail;

--- a/src/components/Core/Body/Nfts/NftGallery.tsx
+++ b/src/components/Core/Body/Nfts/NftGallery.tsx
@@ -1,0 +1,117 @@
+import { observer } from "mobx-react-lite";
+import { useEffect, useState } from "react";
+import { Loader2, Plus, RefreshCw, Sparkles } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/UI/Card";
+import { Button } from "@/components/UI/Button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/UI/Tooltip";
+import { useStore } from "@/stores/store";
+import { NftCard } from "./NftCard";
+import { AddNftModal } from "./AddNftModal";
+
+const NftGallery = observer(() => {
+  const { nftStore } = useStore();
+  const [isAddOpen, setIsAddOpen] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  // Refresh ownership/balances on mount so a stale list gets corrected
+  // when the wallet has been used elsewhere since the last visit.
+  useEffect(() => {
+    void nftStore.refreshNftBalances();
+  }, [nftStore]);
+
+  const onRefresh = async () => {
+    setIsRefreshing(true);
+    try {
+      await nftStore.refreshNftBalances();
+    } finally {
+      setIsRefreshing(false);
+    }
+  };
+
+  const nfts = nftStore.visibleNftList;
+
+  return (
+    <Card className="border-l-4 border-l-secondary">
+      <CardHeader className="flex flex-row items-center justify-between bg-gradient-to-r from-secondary/5 to-transparent">
+        <CardTitle className="text-2xl font-bold">NFTs</CardTitle>
+        <div className="flex gap-2">
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={onRefresh}
+                  disabled={isRefreshing}
+                  aria-label="Refresh NFT ownership"
+                >
+                  {isRefreshing ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <RefreshCw className="h-4 w-4" />
+                  )}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>Refresh ownership and balances</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setIsAddOpen(true)}
+            aria-label="Add NFT"
+          >
+            <Plus className="h-4 w-4" />
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {nfts.length === 0 ? (
+          <EmptyState onAdd={() => setIsAddOpen(true)} />
+        ) : (
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4">
+            {nfts.map((nft) => (
+              <NftCard
+                key={`${nft.contractAddress.toLowerCase()}:${nft.tokenId}`}
+                nft={nft}
+              />
+            ))}
+          </div>
+        )}
+      </CardContent>
+      <AddNftModal isOpen={isAddOpen} onClose={() => setIsAddOpen(false)} />
+    </Card>
+  );
+});
+
+function EmptyState({ onAdd }: { onAdd: () => void }) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 py-8 text-center">
+      <Sparkles className="h-10 w-10 text-muted-foreground/50" />
+      <div>
+        <p className="text-sm font-medium">No collectibles yet</p>
+        <p className="text-xs text-muted-foreground">
+          Paste an ERC-721 or ERC-1155 contract address to add one.
+        </p>
+      </div>
+      <Button variant="outline" size="sm" onClick={onAdd}>
+        <Plus className="mr-2 h-4 w-4" />
+        Add NFT
+      </Button>
+    </div>
+  );
+}
+
+export default NftGallery;

--- a/src/components/Core/Body/Nfts/NftImage.tsx
+++ b/src/components/Core/Body/Nfts/NftImage.tsx
@@ -1,0 +1,73 @@
+import { useMemo, useState } from "react";
+import { Skeleton } from "@/components/UI/skeleton";
+import { ImageIcon } from "lucide-react";
+import { resolveIpfsUri } from "@/utils/web3/nft";
+
+interface NftImageProps {
+  src?: string;
+  alt: string;
+  className?: string;
+}
+
+export function NftImage({ src, alt, className }: NftImageProps) {
+  // Compute the resolved URL from props; derived, not stored. When `src`
+  // changes the outer component re-renders with a new memoized value and
+  // the inner <Inner> remounts via its key, resetting load/error state.
+  const imageSrc = useMemo(
+    () => (src ? resolveIpfsUri(src) : null),
+    [src],
+  );
+  const wrapper = `relative overflow-hidden bg-muted ${className ?? ""}`;
+  if (!imageSrc) {
+    return <Fallback wrapper={wrapper} alt={alt} />;
+  }
+  return <Inner key={imageSrc} wrapper={wrapper} src={imageSrc} alt={alt} />;
+}
+
+function Inner({
+  wrapper,
+  src,
+  alt,
+}: {
+  wrapper: string;
+  src: string;
+  alt: string;
+}) {
+  // Component is keyed by src, so this state always resets on src change.
+  // setState only fires from <img> event callbacks — never inside an effect.
+  const [status, setStatus] = useState<"loading" | "loaded" | "error">(
+    "loading",
+  );
+
+  if (status === "error") {
+    return <Fallback wrapper={wrapper} alt={alt} />;
+  }
+
+  return (
+    <div className={wrapper}>
+      {status === "loading" && <Skeleton className="absolute inset-0" />}
+      <img
+        src={src}
+        alt={alt}
+        loading="lazy"
+        onLoad={() => setStatus("loaded")}
+        onError={() => setStatus("error")}
+        className={`h-full w-full object-cover transition-opacity ${
+          status === "loaded" ? "opacity-100" : "opacity-0"
+        }`}
+      />
+    </div>
+  );
+}
+
+function Fallback({ wrapper, alt }: { wrapper: string; alt: string }) {
+  return (
+    <div
+      className={`${wrapper} flex items-center justify-center text-muted-foreground`}
+      role="img"
+      aria-label={`${alt} (image unavailable)`}
+    >
+      <ImageIcon className="h-10 w-10 opacity-50" />
+    </div>
+  );
+}

--- a/src/components/Core/Body/Settings/Settings.tsx
+++ b/src/components/Core/Body/Settings/Settings.tsx
@@ -45,6 +45,8 @@ const SettingsFormSchema = z.object({
     showTestNetworks: z.boolean(),
     hideSmallBalances: z.boolean(),
     hideUnknownTokens: z.boolean(),
+    showTokensCard: z.boolean(),
+    showNftsCard: z.boolean(),
 });
 
 type SettingsFormValues = z.infer<typeof SettingsFormSchema>;
@@ -116,6 +118,8 @@ const Settings = observer(() => {
                 showTestNetworks: settings.showTestNetworks || false,
                 hideSmallBalances: settings.hideSmallBalances || false,
                 hideUnknownTokens: settings.hideUnknownTokens || true,
+                showTokensCard: settings.showTokensCard ?? true,
+                showNftsCard: settings.showNftsCard ?? true,
             };
         },
     });
@@ -455,6 +459,48 @@ const Settings = observer(() => {
                                                         <FormLabel>Hide Unknown Tokens</FormLabel>
                                                         <FormDescription>
                                                             Hide tokens that haven't been verified or added manually
+                                                        </FormDescription>
+                                                    </div>
+                                                    <FormControl>
+                                                        <Switch
+                                                            checked={field.value ?? true}
+                                                            onCheckedChange={field.onChange}
+                                                        />
+                                                    </FormControl>
+                                                </FormItem>
+                                            )}
+                                        />
+
+                                        <FormField
+                                            control={form.control}
+                                            name="showTokensCard"
+                                            render={({ field }) => (
+                                                <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+                                                    <div className="space-y-0.5">
+                                                        <FormLabel>Show Tokens Card</FormLabel>
+                                                        <FormDescription>
+                                                            Display the Tokens section on the Home page
+                                                        </FormDescription>
+                                                    </div>
+                                                    <FormControl>
+                                                        <Switch
+                                                            checked={field.value ?? true}
+                                                            onCheckedChange={field.onChange}
+                                                        />
+                                                    </FormControl>
+                                                </FormItem>
+                                            )}
+                                        />
+
+                                        <FormField
+                                            control={form.control}
+                                            name="showNftsCard"
+                                            render={({ field }) => (
+                                                <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+                                                    <div className="space-y-0.5">
+                                                        <FormLabel>Show NFTs Card</FormLabel>
+                                                        <FormDescription>
+                                                            Display the NFT collection section on the Home page
                                                         </FormDescription>
                                                     </div>
                                                     <FormControl>

--- a/src/components/Core/Body/Tokens/AddTokenModal/AddTokenModal.tsx
+++ b/src/components/Core/Body/Tokens/AddTokenModal/AddTokenModal.tsx
@@ -17,11 +17,9 @@ import { QRL_PROVIDER } from "@/config";
 import { StorageUtil } from "@/utils/storage";
 
 export function AddTokenModal({ isOpen, onClose }: { isOpen: boolean, onClose: () => void }) {
-    const { qrlStore } = useStore();
-    const {
-        addToken: addTokenToStore,
-        activeAccount: { accountAddress: activeAccountAddress },
-    } = qrlStore;
+    const { qrlStore, tokenStore } = useStore();
+    const { addToken: addTokenToStore } = tokenStore;
+    const { accountAddress: activeAccountAddress } = qrlStore.activeAccount;
     const [tokenAddress, setTokenAddress] = useState("");
     const [tokenInfo, setTokenInfo] = useState<TokenInterface | null>(null);
     const [isLoading, setIsLoading] = useState(false);

--- a/src/components/Core/Body/Tokens/AddTokenModal/AddTokenModal.tsx
+++ b/src/components/Core/Body/Tokens/AddTokenModal/AddTokenModal.tsx
@@ -48,12 +48,19 @@ export function AddTokenModal({ isOpen, onClose }: { isOpen: boolean, onClose: (
             if (tokenAddress.length === 41 && tokenAddress.startsWith("Q")) {
                 try {
                     setIsLoading(true);
+                    setError(null);
                     const selectedBlockChain = await StorageUtil.getBlockChain();
                     const { name, symbol, decimals } = await fetchTokenInfo(tokenAddress, QRL_PROVIDER[selectedBlockChain].url);
                     const balance = await fetchBalance(tokenAddress, activeAccountAddress, QRL_PROVIDER[selectedBlockChain].url);
                     setTokenInfo({ name, symbol, decimals: parseInt(decimals.toString()), address: tokenAddress, amount: balance.toString() });
-                } catch (error) {
-                    console.error("Error fetching token info", error);
+                } catch (err) {
+                    console.error("Error fetching token info", err);
+                    setTokenInfo(null);
+                    setError(
+                        err instanceof Error
+                            ? `Could not fetch token info — the address may not be a QRC-20 token contract. (${err.message})`
+                            : "Could not fetch token info. The address may not be a token contract."
+                    );
                 }
             }
             setIsLoading(false);

--- a/src/components/Core/Body/Tokens/SendTokenModal.tsx/SendTokenModal.tsx
+++ b/src/components/Core/Body/Tokens/SendTokenModal.tsx/SendTokenModal.tsx
@@ -24,13 +24,10 @@ import { WalletEncryptionUtil } from "@/utils/crypto";
 import { isValidQrlAddress } from "@/utils/web3";
 
 export function SendTokenModal({ isOpen, onClose, token }: { isOpen: boolean, onClose: () => void, token: TokenInterface }) {
-    const { qrlStore } = useStore();
-    const {
-        activeAccount: { accountAddress: activeAccountAddress },
-        tokenList,
-        activeAccountSource,
-        sendToken: sendTokenToStore
-    } = qrlStore;
+    const { qrlStore, tokenStore } = useStore();
+    const { accountAddress: activeAccountAddress } = qrlStore.activeAccount;
+    const { activeAccountSource } = qrlStore;
+    const { tokenList, sendToken: sendTokenToStore } = tokenStore;
     const [amount, setAmount] = useState("");
     const [maxAmount, setMaxAmount] = useState("0");
     const [pin, setPin] = useState("");
@@ -125,7 +122,7 @@ export function SendTokenModal({ isOpen, onClose, token }: { isOpen: boolean, on
                                 onClose();
                                 // Wait a short time to ensure modal is fully closed before refreshing balances
                                 setTimeout(() => {
-                                    qrlStore.refreshTokenBalances();
+                                    tokenStore.refreshTokenBalances();
                                 }, 300);
                             }, 1500);
                         } else {

--- a/src/components/Core/Body/Tokens/TokenForm/TokenForm.tsx
+++ b/src/components/Core/Body/Tokens/TokenForm/TokenForm.tsx
@@ -35,12 +35,10 @@ import { ROUTES } from "@/router/router";
 import { getOptimalTokenBalance } from "@/utils/formatting";
 
 const TokenForm = observer(() => {
-    const { qrlStore } = useStore();
+    const { qrlStore, tokenStore } = useStore();
     const navigate = useNavigate();
-    const {
-        activeAccount: { accountAddress: activeAccountAddress },
-        visibleTokenList,
-    } = qrlStore;
+    const { accountAddress: activeAccountAddress } = qrlStore.activeAccount;
+    const { visibleTokenList } = tokenStore;
 
     const [tokenList, setTokenList] = useState<TokenInterface[]>(visibleTokenList);
     const [isAddTokenModalOpen, setIsAddTokenModalOpen] = useState(false);
@@ -52,17 +50,17 @@ const TokenForm = observer(() => {
         try {
             // Clear hidden tokens so they reappear
             await StorageUtil.clearHiddenTokens();
-            await qrlStore.loadHiddenTokens();
+            await tokenStore.loadHiddenTokens();
 
             // Clear existing token list to prevent tokens from other accounts showing
             await StorageUtil.clearTokenList();
-            await qrlStore.setTokenList([]);
+            await tokenStore.setTokenList([]);
 
             // Discover tokens for the active account only
-            await qrlStore.discoverAndAddTokens(activeAccountAddress);
+            await tokenStore.discoverAndAddTokens(activeAccountAddress);
 
             // Then refresh all balances
-            await qrlStore.refreshTokenBalances();
+            await tokenStore.refreshTokenBalances();
         } catch (error) {
             console.error("Failed to refresh tokens:", error);
         } finally {

--- a/src/components/Core/Body/Tokens/TokenForm/columns.tsx
+++ b/src/components/Core/Body/Tokens/TokenForm/columns.tsx
@@ -65,11 +65,11 @@ const CopyableText = ({ text }: { text: string }) => {
 };
 
 const HideTokenButton = ({ tokenAddress }: { tokenAddress: string }) => {
-    const { qrlStore } = useStore();
+    const { tokenStore } = useStore();
 
     const handleHide = async (e: React.MouseEvent) => {
         e.stopPropagation();
-        await qrlStore.hideToken(tokenAddress);
+        await tokenStore.hideToken(tokenAddress);
     };
 
     return (

--- a/src/components/Core/Body/Transfer/Transfer.tsx
+++ b/src/components/Core/Body/Transfer/Transfer.tsx
@@ -54,7 +54,7 @@ import { BigNumber } from "bignumber.js";
 const Transfer = observer(() => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const { qrlStore } = useStore();
+  const { qrlStore, tokenStore } = useStore();
   const {
     activeAccount,
     getAccountBalance,
@@ -64,10 +64,9 @@ const Transfer = observer(() => {
     qrlConnection,
     transactionStatus,
     resetTransactionStatus,
-    tokenList,
-    sendToken: sendTokenToStore,
     estimateNativeTransferFee,
   } = qrlStore;
+  const { tokenList, sendToken: sendTokenToStore } = tokenStore;
   const { blockchain } = qrlConnection;
   const { accountAddress } = activeAccount;
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -4,3 +4,5 @@ export {
   QRL_WEB3_WALLET_PROVIDER_INFO,
   type TokenInterface,
 } from './tokens';
+
+export { type NFTInterface } from './nft';

--- a/src/constants/nft.ts
+++ b/src/constants/nft.ts
@@ -1,0 +1,17 @@
+import type { NftStandard } from "@/utils/web3/nft";
+
+export interface NFTInterface {
+  contractAddress: string;
+  standard: NftStandard;
+  tokenId: string;
+  collectionName?: string;
+  collectionSymbol?: string;
+  name?: string;
+  description?: string;
+  image?: string;
+  // ERC-1155 holdings can be > 1 of the same id; stored as a decimal
+  // string so it survives serialization. Undefined for ERC-721 (always 1).
+  balance?: string;
+  // Snapshot of when we last fetched metadata, for cache-warming UI.
+  fetchedAt?: number;
+}

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -20,6 +20,7 @@ const TokenStatus = lazy(() => import("../components/Core/Body/CreateToken/Token
 const TransactionHistory = lazy(() => import("../components/Core/Body/TransactionHistory/TransactionHistory.tsx"));
 const Transfer = lazy(() => import("../components/Core/Body/Transfer/Transfer.tsx"));
 const DAppSessionsList = lazy(() => import("../components/Core/Body/DAppConnect/DAppSessionsList.tsx"));
+const NftDetail = lazy(() => import("../components/Core/Body/Nfts/NftDetail.tsx"));
 
 const ROUTES = {
   HOME: "/",
@@ -37,6 +38,7 @@ const ROUTES = {
   TOKEN_STATUS: "/token-status",
   TRANSACTION_HISTORY: "/tx-history",
   DAPP_SESSIONS: "/dapp-sessions",
+  NFT_DETAIL: "/nft/:contractAddress/:tokenId",
 } as const;
 
 const router = createBrowserRouter([
@@ -157,6 +159,14 @@ const router = createBrowserRouter([
         element: (
           <Suspense fallback={<Loading />}>
             <DAppSessionsList />
+          </Suspense>
+        )
+      },
+      {
+        path: ROUTES.NFT_DETAIL,
+        element: (
+          <Suspense fallback={<Loading />}>
+            <NftDetail />
           </Suspense>
         )
       },

--- a/src/stores/nftStore.ts
+++ b/src/stores/nftStore.ts
@@ -1,0 +1,28 @@
+import { makeAutoObservable } from "mobx";
+import { log } from "@/utils";
+import type QrlStore from "./qrlStore";
+import type TokenStore from "./tokenStore";
+
+// Empty observable shell. Populated in the NFT support phase (ERC-721 +
+// ERC-1155 detection, gallery, transfer). Constructed with refs to the
+// other two stores so future actions can read wallet state and reuse
+// the token transaction-status surface.
+class NftStore {
+  constructor(
+    // Held for the upcoming ERC-721/1155 actions (read activeAccount,
+    // qrlConnection, signing helpers, transaction status).
+    private qrlStore: QrlStore,
+    // Held so NFT actions can co-exist with the token transaction-status
+    // surface where shared (e.g. refresh-after-transfer hooks).
+    private tokenStore: TokenStore,
+  ) {
+    makeAutoObservable(this);
+    // Touch the refs so the unused-parameter lint stays happy while the
+    // shell is empty. Removed once real fields/actions land.
+    void this.qrlStore;
+    void this.tokenStore;
+    log("NftStore initialized");
+  }
+}
+
+export default NftStore;

--- a/src/stores/nftStore.ts
+++ b/src/stores/nftStore.ts
@@ -1,27 +1,345 @@
-import { makeAutoObservable } from "mobx";
+import {
+  action,
+  computed,
+  makeAutoObservable,
+  observable,
+  runInAction,
+} from "mobx";
+import Web3, { TransactionReceipt, utils } from "@theqrl/web3";
 import { log } from "@/utils";
+import { QRL_PROVIDER } from "@/config";
+import { StorageUtil } from "@/utils/storage";
+import { deriveHexSeedAsync } from "@/utils/crypto";
+import { NFTInterface } from "@/constants";
+import { erc721ABI } from "@/abi/ERC721ABI";
+import { erc1155ABI } from "@/abi/ERC1155ABI";
+import {
+  fetchErc1155Balance,
+  isErc721Owner,
+  nftKey,
+} from "@/utils/web3/nft";
 import type QrlStore from "./qrlStore";
 import type TokenStore from "./tokenStore";
+import { applyFeeLevel, type FeeLevel } from "./qrlStore";
 
-// Empty observable shell. Populated in the NFT support phase (ERC-721 +
-// ERC-1155 detection, gallery, transfer). Constructed with refs to the
-// other two stores so future actions can read wallet state and reuse
-// the token transaction-status surface.
 class NftStore {
+  nftList: NFTInterface[] = [];
+  hiddenNfts: string[] = [];
+
   constructor(
-    // Held for the upcoming ERC-721/1155 actions (read activeAccount,
-    // qrlConnection, signing helpers, transaction status).
     private qrlStore: QrlStore,
-    // Held so NFT actions can co-exist with the token transaction-status
-    // surface where shared (e.g. refresh-after-transfer hooks).
+    // Held for future cross-domain hooks (e.g. refresh after transfer
+    // shares the transactionStatus surface). Currently unused; lint-
+    // silenced by referencing it in the constructor body.
     private tokenStore: TokenStore,
   ) {
-    makeAutoObservable(this);
-    // Touch the refs so the unused-parameter lint stays happy while the
-    // shell is empty. Removed once real fields/actions land.
-    void this.qrlStore;
+    makeAutoObservable(this, {
+      nftList: observable.struct,
+      hiddenNfts: observable,
+      visibleNftList: computed,
+      initialize: action.bound,
+      handleActiveAccountChanged: action.bound,
+      addNft: action.bound,
+      removeNft: action.bound,
+      hideNft: action.bound,
+      unhideNft: action.bound,
+      loadHiddenNfts: action.bound,
+      setNftList: action.bound,
+      refreshNftBalances: action.bound,
+      transferNft: action.bound,
+    });
     void this.tokenStore;
     log("NftStore initialized");
+  }
+
+  get visibleNftList(): NFTInterface[] {
+    return this.nftList.filter(
+      (nft) =>
+        !this.hiddenNfts.some(
+          (k) =>
+            k.toLowerCase() === nftKey(nft.contractAddress, nft.tokenId),
+        ),
+    );
+  }
+
+  async initialize() {
+    const persisted = await StorageUtil.getNftList();
+    runInAction(() => {
+      this.nftList = persisted;
+    });
+    await this.loadHiddenNfts();
+  }
+
+  async handleActiveAccountChanged(newActiveAccount?: string) {
+    if (!newActiveAccount) {
+      return;
+    }
+    // Mirror the token-store policy: clear list on account change so
+    // collectibles from a prior account don't leak into the new one. The
+    // user re-adds them manually (or via future auto-discovery).
+    await StorageUtil.clearNftList();
+    runInAction(() => {
+      this.nftList = [];
+    });
+  }
+
+  async setNftList(list: NFTInterface[]) {
+    await StorageUtil.updateNftList(list);
+    runInAction(() => {
+      this.nftList = list;
+    });
+  }
+
+  async addNft(nft: NFTInterface) {
+    const key = nftKey(nft.contractAddress, nft.tokenId);
+    const existing = this.nftList.find(
+      (n) => nftKey(n.contractAddress, n.tokenId) === key,
+    );
+    if (existing) {
+      // If hidden, treat add-again as unhide.
+      const isHidden = this.hiddenNfts.some(
+        (k) => k.toLowerCase() === key,
+      );
+      if (isHidden) {
+        await this.unhideNft(key);
+      }
+      return existing;
+    }
+    const next = [...this.nftList, nft];
+    await this.setNftList(next);
+    return nft;
+  }
+
+  async removeNft(key: string) {
+    const next = this.nftList.filter(
+      (n) => nftKey(n.contractAddress, n.tokenId) !== key.toLowerCase(),
+    );
+    await this.setNftList(next);
+  }
+
+  async loadHiddenNfts() {
+    const list = await StorageUtil.getHiddenNfts();
+    runInAction(() => {
+      this.hiddenNfts = list;
+    });
+  }
+
+  async hideNft(key: string) {
+    await StorageUtil.hideNft(key);
+    runInAction(() => {
+      const lower = key.toLowerCase();
+      if (!this.hiddenNfts.some((k) => k.toLowerCase() === lower)) {
+        this.hiddenNfts = [...this.hiddenNfts, lower];
+      }
+    });
+  }
+
+  async unhideNft(key: string) {
+    await StorageUtil.unhideNft(key);
+    runInAction(() => {
+      this.hiddenNfts = this.hiddenNfts.filter(
+        (k) => k.toLowerCase() !== key.toLowerCase(),
+      );
+    });
+  }
+
+  /**
+   * For each NFT in the list: confirm 721 ownership / refresh 1155
+   * balance. Drops NFTs the wallet no longer owns (e.g. transferred
+   * out from another client) so the gallery stays honest.
+   */
+  async refreshNftBalances() {
+    const owner = this.qrlStore.activeAccount.accountAddress;
+    if (!owner || this.nftList.length === 0) return;
+    const selectedBlockChain = await StorageUtil.getBlockChain();
+    const rpcUrl =
+      QRL_PROVIDER[selectedBlockChain as keyof typeof QRL_PROVIDER].url;
+
+    const updated: NFTInterface[] = [];
+    for (const nft of this.nftList) {
+      try {
+        if (nft.standard === "ERC721") {
+          const stillOwner = await isErc721Owner(
+            nft.contractAddress,
+            owner,
+            nft.tokenId,
+            rpcUrl,
+          );
+          if (stillOwner) {
+            updated.push(nft);
+          }
+          // dropped if no longer owner
+        } else {
+          const bal = await fetchErc1155Balance(
+            nft.contractAddress,
+            owner,
+            nft.tokenId,
+            rpcUrl,
+          );
+          if (bal > 0n) {
+            updated.push({ ...nft, balance: bal.toString() });
+          }
+          // dropped if balance == 0
+        }
+      } catch (err) {
+        // Keep stale entries on transient errors so a flaky RPC doesn't
+        // wipe the gallery; log + carry on.
+        console.error(
+          `refreshNftBalances: ${nft.contractAddress}#${nft.tokenId}`,
+          err,
+        );
+        updated.push(nft);
+      }
+    }
+    await this.setNftList(updated);
+  }
+
+  /**
+   * Sign + broadcast safeTransferFrom for the supplied NFT. Writes
+   * transaction state into qrlStore.transactionStatus so the existing
+   * Transfer UX (status banners, history) just works.
+   */
+  async transferNft(
+    nft: NFTInterface,
+    toAddress: string,
+    mnemonicPhrases: string,
+    amount: bigint = 1n,
+    feeLevel: FeeLevel = "medium",
+  ): Promise<boolean> {
+    this.qrlStore.resetTransactionStatus();
+    try {
+      const selectedBlockChain = await StorageUtil.getBlockChain();
+      const { url } =
+        QRL_PROVIDER[selectedBlockChain as keyof typeof QRL_PROVIDER];
+      const web3 = new Web3(new Web3.providers.HttpProvider(url));
+      const seed = await deriveHexSeedAsync(mnemonicPhrases);
+      const acc = web3.qrl.accounts.seedToAccount(seed);
+      web3.qrl.wallet?.add(seed);
+      web3.qrl.transactionConfirmationBlocks = 1;
+
+      const baseGasPrice =
+        (await web3.qrl.getGasPrice()) ?? BigInt(1000000000);
+      const { maxFeePerGas, maxPriorityFeePerGas } = applyFeeLevel(
+        baseGasPrice,
+        feeLevel,
+      );
+
+      let data: string;
+      if (nft.standard === "ERC721") {
+        const contract = new web3.qrl.Contract(
+          erc721ABI as any,
+          nft.contractAddress,
+        );
+        data = (contract.methods as any)
+          .safeTransferFrom(acc.address, toAddress, nft.tokenId)
+          .encodeABI();
+      } else {
+        const contract = new web3.qrl.Contract(
+          erc1155ABI as any,
+          nft.contractAddress,
+        );
+        data = (contract.methods as any)
+          .safeTransferFrom(
+            acc.address,
+            toAddress,
+            nft.tokenId,
+            amount.toString(),
+            "0x",
+          )
+          .encodeABI();
+      }
+
+      const txObj = {
+        type: "0x2",
+        from: acc.address,
+        to: nft.contractAddress,
+        data,
+        maxFeePerGas,
+        maxPriorityFeePerGas,
+      } as const;
+
+      // Let the node estimate gas to handle wildly varying ERC-1155
+      // implementations; fall back to a sane 200k cap if estimation fails.
+      let gas: bigint;
+      try {
+        const estimated = await web3.qrl.estimateGas({
+          from: acc.address,
+          to: nft.contractAddress,
+          data,
+        });
+        gas = (BigInt(estimated) * 12n) / 10n;
+      } catch (err) {
+        log(`estimateGas failed for NFT transfer, using fallback: ${err}`);
+        gas = 200_000n;
+      }
+
+      const finalTx = { ...txObj, gas };
+
+      const promiEvent = web3.qrl.sendTransaction(finalTx, undefined, {
+        checkRevertBeforeSending: true,
+      });
+
+      promiEvent
+        .on("transactionHash", (hash: string | Uint8Array) => {
+          runInAction(() => {
+            const txHash =
+              typeof hash === "string" ? hash : utils.bytesToHex(hash);
+            this.qrlStore.transactionStatus = {
+              state: "pending",
+              txHash,
+              receipt: null,
+              error: null,
+              pendingDetails: null,
+            };
+            log(`NFT transfer pending: ${txHash}`);
+            this.qrlStore.fetchPendingTxDetails(txHash);
+          });
+        })
+        .on("receipt", (receipt: TransactionReceipt) => {
+          runInAction(() => {
+            const txHashString = utils.bytesToHex(receipt.transactionHash);
+            this.qrlStore.transactionStatus = {
+              state: "confirmed",
+              txHash: txHashString,
+              receipt,
+              error: null,
+              pendingDetails: null,
+            };
+            log(`NFT transfer confirmed: ${txHashString}`);
+            // Refresh ownership state so the transferred NFT drops out
+            // of the gallery on its own.
+            this.refreshNftBalances();
+            this.qrlStore.fetchAccounts();
+          });
+        })
+        .on("error", (error: Error) => {
+          runInAction(() => {
+            const txHash = this.qrlStore.transactionStatus.txHash;
+            this.qrlStore.transactionStatus = {
+              state: "failed",
+              txHash,
+              receipt: null,
+              error: error.message || "NFT transfer failed",
+              pendingDetails: null,
+            };
+            log(`NFT transfer failed: ${error.message}`);
+          });
+        });
+
+      return true;
+    } catch (error: any) {
+      runInAction(() => {
+        this.qrlStore.transactionStatus = {
+          state: "failed",
+          txHash: null,
+          receipt: null,
+          error: `NFT transfer failed: ${error.message || error}`,
+          pendingDetails: null,
+        };
+        log(`NFT transfer preparation failed: ${error}`);
+      });
+      return false;
+    }
   }
 }
 

--- a/src/stores/qrlStore.ts
+++ b/src/stores/qrlStore.ts
@@ -8,12 +8,6 @@ import Web3, {
   utils,
 } from "@theqrl/web3";
 import { action, computed, makeAutoObservable, observable, runInAction } from "mobx";
-import { customERC20FactoryABI } from "@/abi/CustomERC20FactoryABI";
-import { fetchTokenInfo, fetchBalance, discoverTokens, mergeTokenLists } from "@/utils/web3";
-import { TokenInterface, KNOWN_TOKEN_LIST } from "@/constants";
-import { customERC20ABI as CustomERC20ABI } from "@/abi/CustomERC20ABI";
-import { formatUnits } from "ethers";
-import { getOptimalTokenBalance } from "@/utils/formatting";
 
 type ActiveAccountType = {
   accountAddress: string;
@@ -31,24 +25,6 @@ type QrlAccountsType = {
   isLoading: boolean;
 };
 
-type CreatingTokenType = {
-  name: string;
-  creating: boolean;
-  error?: string;
-}
-
-type CreatedTokenType = {
-  name: string;
-  symbol: string;
-  decimals: number;
-  address: string;
-  tx: string;
-  blockNumber: number;
-  gasUsed: number;
-  effectiveGasPrice: number;
-  blockHash: string;
-}
-
 // Type for relevant pending transaction details from Explorer API
 type PendingTxInfo = {
   from: string;
@@ -61,13 +37,14 @@ type PendingTxInfo = {
   lastSeen: number; // Unix timestamp
 }
 
-// New type for transaction status
-type TransactionStatus = {
+// Transaction status type — exported so token/NFT stores can write into
+// the shared `transactionStatus` slot on this store.
+export type TransactionStatus = {
   state: 'idle' | 'pending' | 'confirmed' | 'failed';
   txHash: string | null;
   receipt: TransactionReceipt | null;
   error: string | null;
-  pendingDetails: PendingTxInfo | null; // Add field for pending details
+  pendingDetails: PendingTxInfo | null;
 }
 
 export type FeeLevel = 'low' | 'medium' | 'high';
@@ -78,7 +55,9 @@ const FEE_MULTIPLIERS: Record<FeeLevel, { maxFee: bigint; priorityFee: bigint }>
   high:   { maxFee: BigInt(200), priorityFee: BigInt(150) },  // 2x / 1.5x
 };
 
-function applyFeeLevel(baseGasPrice: bigint, level: FeeLevel) {
+// Exported so token/NFT stores can share the same fee-multiplier math
+// they used to call when this lived inside qrlStore directly.
+export function applyFeeLevel(baseGasPrice: bigint, level: FeeLevel) {
   const m = FEE_MULTIPLIERS[level];
   return {
     maxFeePerGas: (baseGasPrice * m.maxFee) / BigInt(100),
@@ -102,10 +81,6 @@ class QrlStore {
   };
   qrlAccounts: QrlAccountsType = { accounts: [], isLoading: false };
   activeAccount: ActiveAccountType = { accountAddress: "", lastSeen: 0 };
-  creatingToken: CreatingTokenType = { name: "", creating: false };
-  createdToken: CreatedTokenType = { name: "", symbol: "", decimals: 0, address: "", tx: "", blockNumber: 0, gasUsed: 0, effectiveGasPrice: 0, blockHash: "" };
-  tokenList: TokenInterface[] = [];
-  hiddenTokens: string[] = []; // List of hidden token addresses
   customRpcUrl: string = "";
   // Updated initial state
   transactionStatus: TransactionStatus = { state: 'idle', txHash: null, receipt: null, error: null, pendingDetails: null };
@@ -121,6 +96,12 @@ class QrlStore {
   // Excluded from mobx via `_receiptPollerIntervalId: false` in
   // makeAutoObservable below — it's a non-observable runtime handle.
   _receiptPollerIntervalId: ReturnType<typeof setInterval> | null = null;
+
+  // Callbacks wired by Store after construction so token/NFT init can run
+  // *after* QrlStore has a live qrlInstance and network selection — and
+  // without QrlStore taking a direct dependency on the other stores.
+  onBlockchainReady?: () => Promise<void>;
+  onActiveAccountChanged?: (newActiveAccount?: string) => Promise<void>;
 
   // NEW: Computed properties
   // 1) active account balance
@@ -151,25 +132,12 @@ class QrlStore {
     return balance * this.qrlPrice;
   }
 
-  // 4) Visible tokens (filtered by hidden list)
-  get visibleTokenList(): TokenInterface[] {
-    return this.tokenList.filter(
-      (token) => !this.hiddenTokens.some(
-        (hidden) => hidden.toLowerCase() === token.address.toLowerCase()
-      )
-    );
-  }
-
   constructor() {
     makeAutoObservable(this, {
       qrlInstance: observable.struct,
       qrlConnection: observable.struct,
       qrlAccounts: observable.struct,
       activeAccount: observable.struct,
-      creatingToken: observable.struct,
-      createdToken: observable.struct,
-      tokenList: observable.struct,
-      hiddenTokens: observable,
       customRpcUrl: observable.struct,
       transactionStatus: observable.struct,
       extensionProvider: observable.ref, // Use ref for complex objects like providers
@@ -178,35 +146,24 @@ class QrlStore {
       // Runtime handles + their cleanup helper — not observable.
       _receiptPollerIntervalId: false,
       cancelReceiptPoller: false,
+      // Callback hooks injected by Store — not observable.
+      onBlockchainReady: false,
+      onActiveAccountChanged: false,
       activeAccountBalance: computed,
       activeAccountSource: computed,
       activeAccountBalanceUsd: computed,
-      visibleTokenList: computed,
       fetchQrlPrice: action.bound,
       setCustomRpcUrl: action.bound,
-      addToken: action.bound,
-      removeToken: action.bound,
-      updateToken: action.bound,
-      setTokenList: action.bound,
-      setCreatedToken: action.bound,
-      setCreatingToken: action.bound,
       selectBlockchain: action.bound,
       setActiveAccount: action.bound,
       fetchQrlConnection: action.bound,
       fetchAccounts: action.bound,
       getAccountBalance: action.bound,
       signAndSendTransaction: action.bound,
-      createToken: action.bound,
       resetTransactionStatus: action.bound,
-      sendToken: action.bound,
-      refreshTokenBalances: action.bound,
       fetchPendingTxDetails: action.bound,
       setExtensionProvider: action.bound,
       sendTransactionViaExtension: action.bound,
-      discoverAndAddTokens: action.bound,
-      hideToken: action.bound,
-      unhideToken: action.bound,
-      loadHiddenTokens: action.bound,
       estimateNativeTransferFee: action.bound,
     });
 
@@ -290,17 +247,15 @@ class QrlStore {
         this.qrlInstance = qrl;
       });
 
-      this.tokenList = await StorageUtil.getTokenList();
-      await this.loadHiddenTokens();
-
-      for (const token of KNOWN_TOKEN_LIST) {
-        await this.addToken(token);
-      }
-
       await this.fetchQrlConnection();
       await this.fetchAccounts();
       this.fetchQrlPrice(); // Fire-and-forget, non-blocking
       await this.validateActiveAccount();
+
+      // Hand off to TokenStore (and any other domain store wired by Store)
+      // for its post-connection bootstrap. Token state used to be loaded
+      // inline here; it's now owned by tokenStore.initialize().
+      await this.onBlockchainReady?.();
 
       // Log successful initialization
       log("Blockchain initialized successfully");
@@ -313,52 +268,6 @@ class QrlStore {
   async selectBlockchain(selectedBlockchain: string) {
     await StorageUtil.setBlockChain(selectedBlockchain);
     await this.initializeBlockchain();
-  }
-
-  async setCreatingToken(name: string, creating: boolean, error?: string) {
-    this.creatingToken = { name, creating, error };
-  }
-
-  async setCreatedToken(name: string, symbol: string, decimals: number, address: string, tx: string, blockNumber: number, gasUsed: number, effectiveGasPrice: number, blockHash: string) {
-    await StorageUtil.setCreatedToken(name, symbol, decimals, address, tx, blockNumber, gasUsed, effectiveGasPrice, blockHash);
-    this.createdToken = { name, symbol, decimals, address, tx, blockNumber, gasUsed, effectiveGasPrice, blockHash };
-  }
-
-  async addToken(token: TokenInterface) {
-    const existingToken = this.tokenList.find(t => t.address.toLowerCase() === token.address.toLowerCase());
-
-    if (!existingToken) {
-      // Token doesn't exist, add it
-      await StorageUtil.updateTokenList([...this.tokenList, token]);
-      this.tokenList = [...this.tokenList, token];
-      return token;
-    }
-
-    // Token exists - check if it's hidden
-    const isHidden = this.hiddenTokens.some(addr => addr.toLowerCase() === token.address.toLowerCase());
-    if (isHidden) {
-      // Unhide the token
-      await this.unhideToken(token.address);
-      return existingToken;
-    }
-
-    // Token exists and is already visible
-    return null;
-  }
-
-  async removeToken(token: TokenInterface) {
-    await StorageUtil.updateTokenList(this.tokenList.filter(t => t.address.toLowerCase() !== token.address.toLowerCase()));
-    this.tokenList = this.tokenList.filter(t => t.address !== token.address);
-  }
-
-  async updateToken(token: TokenInterface) {
-    await StorageUtil.updateTokenList(this.tokenList.map(t => t.address.toLocaleLowerCase() === token.address.toLocaleLowerCase() ? token : t));
-    this.tokenList = this.tokenList.map(t => t.address.toLocaleLowerCase() === token.address.toLocaleLowerCase() ? token : t);
-  }
-
-  async setTokenList(tokenList: TokenInterface[]) {
-    await StorageUtil.updateTokenList(tokenList);
-    this.tokenList = tokenList;
   }
 
   async setCustomRpcUrl(customRpcUrl: string) {
@@ -405,30 +314,9 @@ class QrlStore {
 
       // Explicitly trigger refreshes after setting active account
       await this.fetchAccounts(); // Refresh the full list and balances
-      if (newActiveAccount) {
-        log(`Fetching balances for newly active account: ${newActiveAccount}`);
-        // Clear token list before discovering tokens for the new account
-        // This prevents tokens from inactive accounts showing with 0 balance
-        await StorageUtil.clearTokenList();
-        runInAction(() => {
-          this.tokenList = [];
-        });
-        // Add known tokens back
-        for (const token of KNOWN_TOKEN_LIST) {
-          await this.addToken(token);
-        }
-        // Discover new tokens for this account (runs in background)
-        this.discoverAndAddTokens(newActiveAccount)
-          .then(() => {
-            // Refresh balances after discovery completes
-            void this.refreshTokenBalances();
-          })
-          .catch((error) => {
-            log(`Unexpected error during token discovery: ${error}`);
-          });
-      } else {
-        log("Active account cleared, skipping token refresh.");
-      }
+      // Token-side bookkeeping (clear+re-seed, discover, refresh balances)
+      // is now owned by tokenStore.handleActiveAccountChanged.
+      await this.onActiveAccountChanged?.(newActiveAccount);
     }
   }
 
@@ -759,309 +647,6 @@ class QrlStore {
         log(`Transaction preparation failed: ${error}`);
       });
     }
-  }
-
-  async sendToken(token: TokenInterface, amount: string, mnemonicPhrases: string, toAddress: string, feeLevel: FeeLevel = 'medium') {
-    // Reset transaction state up front (matches signAndSendTransaction).
-    // This also cancels any in-flight receipt poller from a previous tx
-    // so it can't race a stale receipt into this send's status updates
-    // — important now that the worker-derive introduces extra awaits
-    // before the new tx hash is observed.
-    this.resetTransactionStatus();
-    try {
-      const selectedBlockChain = await StorageUtil.getBlockChain();
-      const { url } = QRL_PROVIDER[selectedBlockChain as keyof typeof QRL_PROVIDER];
-      const web3 = new Web3(new Web3.providers.HttpProvider(url));
-      // MLDSA87 derivation on the worker — same reasoning as
-      // signAndSendTransaction (50–300 ms off the main thread).
-      const seed = await deriveHexSeedAsync(mnemonicPhrases);
-      const acc = web3.qrl.accounts.seedToAccount(seed)
-      web3.qrl.wallet?.add(seed);
-      web3.qrl.transactionConfirmationBlocks = 1;
-      const baseGasPrice = (await web3.qrl.getGasPrice()) ?? BigInt(1000000000);
-      const { maxFeePerGas, maxPriorityFeePerGas } = applyFeeLevel(baseGasPrice, feeLevel);
-      const contract = new web3.qrl.Contract(CustomERC20ABI, token.address);
-      const tx = contract.methods.transfer(toAddress, amount).encodeABI();
-      const estimateGas = await contract.methods.transfer(toAddress, amount).estimateGas({ "from": acc.address })
-      const txObj = { type: '0x2', gas: estimateGas, from: acc.address, data: tx, to: token.address, maxFeePerGas, maxPriorityFeePerGas }
-
-      const promiEvent = web3.qrl.sendTransaction(txObj, undefined, {
-        checkRevertBeforeSending: true
-      });
-
-      promiEvent.on('transactionHash', (hash: string | Uint8Array) => {
-        runInAction(() => {
-          const txHash = typeof hash === 'string' ? hash : utils.bytesToHex(hash);
-          this.transactionStatus = {
-            state: 'pending',
-            txHash: txHash,
-            receipt: null,
-            error: null,
-            pendingDetails: null,
-          };
-          log(`Token transfer pending with hash: ${txHash}`);
-          this.fetchPendingTxDetails(txHash);
-        });
-      }).on('receipt', (receipt: TransactionReceipt) => {
-        runInAction(() => {
-          const txHashString = utils.bytesToHex(receipt.transactionHash);
-          this.transactionStatus = {
-            state: 'confirmed',
-            txHash: txHashString,
-            receipt: receipt,
-            error: null,
-            pendingDetails: null,
-          };
-          log(`Token transfer confirmed: ${txHashString}`);
-          this.refreshTokenBalances();
-          this.fetchAccounts();
-        });
-      }).on('error', (error: Error) => {
-        runInAction(() => {
-          const txHash = this.transactionStatus.txHash;
-          this.transactionStatus = {
-            state: 'failed',
-            txHash: txHash,
-            receipt: null,
-            error: error.message || "Token transfer failed",
-            pendingDetails: null,
-          };
-          log(`Token transfer failed: ${error.message}`);
-        });
-      });
-
-      return true;
-    } catch (error: any) {
-      runInAction(() => {
-        this.transactionStatus = {
-          state: 'failed',
-          txHash: null,
-          receipt: null,
-          error: `Token transfer failed: ${error.message || error}`,
-          pendingDetails: null,
-        };
-        log(`Token transfer preparation failed: ${error}`);
-      });
-      return false;
-    }
-  }
-
-  async createToken(
-    tokenName: string,
-    tokenSymbol: string,
-    initialSupply: string,
-    decimals: number,
-    maxSupply: string,
-    receipt: string,
-    maxWalletAmount: string,
-    maxTxLimit: string,
-    mnemonicPhrases: string
-  ) {
-    // Reset transaction state up front (matches signAndSendTransaction /
-    // sendToken). Cancels any in-flight receipt poller from a previous
-    // tx so it can't race into this contract-deploy's status updates.
-    this.resetTransactionStatus();
-    try {
-      this.setCreatingToken(tokenName, true);
-      const selectedBlockChain = await StorageUtil.getBlockChain();
-      const { url } = QRL_PROVIDER[selectedBlockChain as keyof typeof QRL_PROVIDER];
-      // MLDSA87 derivation on the worker (avoids freezing UI during the
-      // 50–300 ms expansion just before deploying a new token contract).
-      const seed = await deriveHexSeedAsync(mnemonicPhrases);
-      const web3 = new Web3(new Web3.providers.HttpProvider(url));
-      const acc = web3.qrl.accounts.seedToAccount(seed)
-      web3.qrl.wallet?.add(seed);
-      web3.qrl.transactionConfirmationBlocks = 1;
-
-      const contractAddress = import.meta.env.VITE_CUSTOMERC20FACTORY_ADDRESS || "";
-
-      // Verify factory contract address is configured
-      if (!contractAddress) {
-        throw new Error("Factory contract address not configured. Please set VITE_CUSTOMERC20FACTORY_ADDRESS.");
-      }
-
-      // Verify factory contract exists before attempting token creation
-      const factoryCode = await web3.qrl.getCode(contractAddress);
-      if (!factoryCode || factoryCode === '0x' || factoryCode === '0x0') {
-        throw new Error(`Factory contract not deployed at address: ${contractAddress}`);
-      }
-
-      const confirmationHandler = () => {
-        // Don't set creating to false here - confirmation can fire before tx is final
-        // Let receiptHandler and errorHandler manage the final state
-      }
-
-      const receiptHandler = async (data: TransactionReceipt) => {
-        const tokenCreatedEventSignature = web3.utils.keccak256("TokenCreated(address,address)");
-
-        // Try to find the TokenCreated event in receipt logs first
-        let tokenCreatedLog = data.logs.find(
-          (log) => log.topics?.[0] === tokenCreatedEventSignature &&
-                   log.address?.toLowerCase() === contractAddress.toLowerCase()
-        );
-
-        // If logs are empty in receipt, fetch them separately using getPastLogs
-        if (!tokenCreatedLog && data.blockNumber) {
-          try {
-            const logs = await web3.qrl.getPastLogs({
-              fromBlock: data.blockNumber,
-              toBlock: data.blockNumber,
-              address: contractAddress,
-              topics: [tokenCreatedEventSignature]
-            });
-            const txHash = data.transactionHash ? web3.utils.bytesToHex(data.transactionHash).toLowerCase() : null;
-            const matchingLog = logs.find(
-              (log) => typeof log !== 'string' && txHash != null && log.transactionHash?.toLowerCase() === txHash
-            );
-            if (matchingLog && typeof matchingLog !== 'string') {
-              tokenCreatedLog = matchingLog;
-            }
-          } catch (err) {
-            console.error("Failed to fetch logs via getPastLogs:", err);
-          }
-        }
-
-        if (!tokenCreatedLog?.topics?.[1]) {
-          console.error("Token address not found in transaction receipt or logs");
-          this.setCreatingToken("", false, "Token address not found in transaction receipt");
-          return;
-        }
-        const tokenTopic = tokenCreatedLog.topics[1];
-        const erc20TokenAddress = `Q${tokenTopic.toString().slice(-40)}`;
-        const tx = data.transactionHash;
-        const blockNumber = Number(data.blockNumber);
-        const gasUsed = Number(data.gasUsed);
-        const effectiveGasPrice = Number(data.effectiveGasPrice);
-        const blockHash = data.blockHash;
-        const { name, symbol, decimals } = await fetchTokenInfo(erc20TokenAddress, url);
-        this.setCreatedToken(name, symbol, parseInt(decimals.toString()), erc20TokenAddress, utils.bytesToHex(tx), blockNumber, gasUsed, effectiveGasPrice, utils.bytesToHex(blockHash));
-        this.setCreatingToken("", false);
-      }
-
-      const errorHandler = (error: Error) => {
-        console.error("Token creation error:", error);
-        this.setCreatingToken("", false, error.message || "Transaction failed");
-      }
-
-      const customERC20Factorycontract = new web3.qrl.Contract(customERC20FactoryABI, contractAddress);
-
-      const contractCreateToken = customERC20Factorycontract.methods.createToken(
-        tokenName,
-        tokenSymbol,
-        initialSupply,
-        decimals,
-        maxSupply,
-        receipt,
-        maxWalletAmount,
-        maxTxLimit
-      );
-
-      const estimatedGas = await contractCreateToken.estimateGas({ from: acc.address })
-      const gas = (estimatedGas * 12n) / 10n
-      const currentGasPrice = await web3.qrl.getGasPrice()
-      const gasPrice = (BigInt(currentGasPrice) * 11n) / 10n
-
-      const txObj = { gas, gasPrice, from: acc.address, data: contractCreateToken.encodeABI(), to: contractAddress }
-
-      await web3.qrl.sendTransaction(txObj, undefined, {
-        checkRevertBeforeSending: true
-      })
-        .on('confirmation', confirmationHandler)
-        .on('receipt', receiptHandler)
-        .on('error', errorHandler)
-    } catch (error) {
-      console.error("Failed to create token:", error);
-      const errorMessage = error instanceof Error ? error.message : "Token creation failed";
-      this.setCreatingToken("", false, errorMessage);
-      throw error;
-    }
-  }
-
-  async refreshTokenBalances() {
-    try {
-      if (!this.activeAccount.accountAddress) return;
-
-      const selectedBlockChain = await StorageUtil.getBlockChain();
-      const updatedTokenList = [...this.tokenList];
-
-      for (let i = 0; i < this.tokenList.length; i++) {
-        const token = this.tokenList[i];
-        try {
-          const balance = await fetchBalance(token.address, this.activeAccount.accountAddress, QRL_PROVIDER[selectedBlockChain as keyof typeof QRL_PROVIDER].url);
-          const balanceStr = formatUnits(balance, token.decimals);
-          updatedTokenList[i] = { ...token, amount: getOptimalTokenBalance(balanceStr, token.symbol) };
-        } catch (err) {
-          console.error(`Error fetching balance for token ${token.symbol}:`, err);
-          updatedTokenList[i] = { ...token, amount: "Error" };
-        }
-      }
-
-      await this.setTokenList(updatedTokenList);
-    } catch (error) {
-      console.error("Error refreshing token balances:", error);
-    }
-  }
-
-  // Discover and add tokens for an address using Explorer API
-  async discoverAndAddTokens(address: string) {
-    try {
-      const blockchain = this.qrlConnection.blockchain;
-      if (!blockchain) {
-        log("Cannot discover tokens: no blockchain selected");
-        return;
-      }
-
-      log(`Starting token discovery for ${address}`);
-      const discoveredTokens = await discoverTokens(address, blockchain);
-
-      if (discoveredTokens.length === 0) {
-        log("No new tokens discovered");
-        return;
-      }
-
-      // Merge with existing tokens, avoiding duplicates
-      const mergedTokens = mergeTokenLists(this.tokenList, discoveredTokens);
-
-      if (mergedTokens.length > this.tokenList.length) {
-        const newCount = mergedTokens.length - this.tokenList.length;
-        log(`Adding ${newCount} newly discovered tokens`);
-        await this.setTokenList(mergedTokens);
-      }
-    } catch (error) {
-      console.error("Error discovering tokens:", error);
-      log(`Token discovery failed: ${error}`);
-    }
-  }
-
-  // Load hidden tokens from storage
-  async loadHiddenTokens() {
-    const hiddenTokens = await StorageUtil.getHiddenTokens();
-    runInAction(() => {
-      this.hiddenTokens = hiddenTokens;
-    });
-  }
-
-  // Hide a token (add to hidden list)
-  async hideToken(tokenAddress: string) {
-    await StorageUtil.hideToken(tokenAddress);
-    runInAction(() => {
-      const lowerCaseAddress = tokenAddress.toLowerCase();
-      if (!this.hiddenTokens.some(addr => addr.toLowerCase() === lowerCaseAddress)) {
-        this.hiddenTokens = [...this.hiddenTokens, lowerCaseAddress];
-      }
-    });
-    log(`Token hidden: ${tokenAddress}`);
-  }
-
-  // Unhide a token (remove from hidden list)
-  async unhideToken(tokenAddress: string) {
-    await StorageUtil.unhideToken(tokenAddress);
-    runInAction(() => {
-      this.hiddenTokens = this.hiddenTokens.filter(
-        (addr) => addr.toLowerCase() !== tokenAddress.toLowerCase()
-      );
-    });
-    log(`Token unhidden: ${tokenAddress}`);
   }
 
   // NEW: Action to set or clear the extension provider

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -1,6 +1,8 @@
 import { createContext, useContext } from "react";
 import SettingsStore from "./settingsStore";
 import QrlStore from "./qrlStore";
+import TokenStore from "./tokenStore";
+import NftStore from "./nftStore";
 import DAppConnectStore from "./dappConnectStore";
 import { configure } from "mobx";
 
@@ -13,12 +15,26 @@ configure({
 class Store {
   settingsStore;
   qrlStore;
+  tokenStore;
+  nftStore;
   dappConnectStore;
 
   constructor() {
     this.settingsStore = new SettingsStore();
     this.qrlStore = new QrlStore();
+    this.tokenStore = new TokenStore(this.qrlStore);
+    this.nftStore = new NftStore(this.qrlStore, this.tokenStore);
     this.dappConnectStore = new DAppConnectStore();
+
+    // Wire qrlStore's post-init/post-account-change hooks to the
+    // domain stores. Keeping qrlStore decoupled from tokenStore/nftStore
+    // avoids circular deps; Store owns the orchestration.
+    this.qrlStore.onBlockchainReady = async () => {
+      await this.tokenStore.initialize();
+    };
+    this.qrlStore.onActiveAccountChanged = async (newActiveAccount?: string) => {
+      await this.tokenStore.handleActiveAccountChanged(newActiveAccount);
+    };
   }
 }
 

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -31,9 +31,11 @@ class Store {
     // avoids circular deps; Store owns the orchestration.
     this.qrlStore.onBlockchainReady = async () => {
       await this.tokenStore.initialize();
+      await this.nftStore.initialize();
     };
     this.qrlStore.onActiveAccountChanged = async (newActiveAccount?: string) => {
       await this.tokenStore.handleActiveAccountChanged(newActiveAccount);
+      await this.nftStore.handleActiveAccountChanged(newActiveAccount);
     };
   }
 }

--- a/src/stores/tokenStore.ts
+++ b/src/stores/tokenStore.ts
@@ -1,0 +1,588 @@
+import { QRL_PROVIDER } from "@/config";
+import { deriveHexSeedAsync } from "@/utils/crypto";
+import { StorageUtil } from "@/utils/storage";
+import { log } from "@/utils";
+import Web3, { TransactionReceipt, utils } from "@theqrl/web3";
+import { action, computed, makeAutoObservable, observable, runInAction } from "mobx";
+import { customERC20FactoryABI } from "@/abi/CustomERC20FactoryABI";
+import { fetchTokenInfo, fetchBalance, discoverTokens, mergeTokenLists } from "@/utils/web3";
+import { TokenInterface, KNOWN_TOKEN_LIST } from "@/constants";
+import { customERC20ABI as CustomERC20ABI } from "@/abi/CustomERC20ABI";
+import { formatUnits } from "ethers";
+import { getOptimalTokenBalance } from "@/utils/formatting";
+import type QrlStore from "./qrlStore";
+import type { FeeLevel } from "./qrlStore";
+import { applyFeeLevel } from "./qrlStore";
+
+type CreatingTokenType = {
+  name: string;
+  creating: boolean;
+  error?: string;
+};
+
+type CreatedTokenType = {
+  name: string;
+  symbol: string;
+  decimals: number;
+  address: string;
+  tx: string;
+  blockNumber: number;
+  gasUsed: number;
+  effectiveGasPrice: number;
+  blockHash: string;
+};
+
+class TokenStore {
+  creatingToken: CreatingTokenType = { name: "", creating: false };
+  createdToken: CreatedTokenType = {
+    name: "",
+    symbol: "",
+    decimals: 0,
+    address: "",
+    tx: "",
+    blockNumber: 0,
+    gasUsed: 0,
+    effectiveGasPrice: 0,
+    blockHash: "",
+  };
+  tokenList: TokenInterface[] = [];
+  hiddenTokens: string[] = [];
+
+  constructor(private qrlStore: QrlStore) {
+    makeAutoObservable(this, {
+      creatingToken: observable.struct,
+      createdToken: observable.struct,
+      tokenList: observable.struct,
+      hiddenTokens: observable,
+      visibleTokenList: computed,
+      setCreatingToken: action.bound,
+      setCreatedToken: action.bound,
+      addToken: action.bound,
+      removeToken: action.bound,
+      updateToken: action.bound,
+      setTokenList: action.bound,
+      sendToken: action.bound,
+      createToken: action.bound,
+      refreshTokenBalances: action.bound,
+      discoverAndAddTokens: action.bound,
+      loadHiddenTokens: action.bound,
+      hideToken: action.bound,
+      unhideToken: action.bound,
+      initialize: action.bound,
+      handleActiveAccountChanged: action.bound,
+    });
+
+    log("TokenStore initialized");
+  }
+
+  get visibleTokenList(): TokenInterface[] {
+    return this.tokenList.filter(
+      (token) =>
+        !this.hiddenTokens.some(
+          (hidden) => hidden.toLowerCase() === token.address.toLowerCase(),
+        ),
+    );
+  }
+
+  // Called by Store after QrlStore.initializeBlockchain finishes (via the
+  // qrlStore.onBlockchainReady hook). Restores the persisted token list and
+  // hidden-token list, then seeds known tokens.
+  async initialize() {
+    const persistedList = await StorageUtil.getTokenList();
+    runInAction(() => {
+      this.tokenList = persistedList;
+    });
+    await this.loadHiddenTokens();
+
+    for (const token of KNOWN_TOKEN_LIST) {
+      await this.addToken(token);
+    }
+  }
+
+  // Called by Store after QrlStore.setActiveAccount finishes (via the
+  // qrlStore.onActiveAccountChanged hook). Mirrors the previous in-place
+  // logic that lived inside setActiveAccount.
+  async handleActiveAccountChanged(newActiveAccount?: string) {
+    if (!newActiveAccount) {
+      log("Active account cleared, skipping token refresh.");
+      return;
+    }
+
+    log(`Fetching balances for newly active account: ${newActiveAccount}`);
+    // Clear token list before discovering tokens for the new account so
+    // tokens from inactive accounts don't show with 0 balance.
+    await StorageUtil.clearTokenList();
+    runInAction(() => {
+      this.tokenList = [];
+    });
+
+    for (const token of KNOWN_TOKEN_LIST) {
+      await this.addToken(token);
+    }
+
+    this.discoverAndAddTokens(newActiveAccount)
+      .then(() => {
+        void this.refreshTokenBalances();
+      })
+      .catch((error) => {
+        log(`Unexpected error during token discovery: ${error}`);
+      });
+  }
+
+  async setCreatingToken(name: string, creating: boolean, error?: string) {
+    this.creatingToken = { name, creating, error };
+  }
+
+  async setCreatedToken(
+    name: string,
+    symbol: string,
+    decimals: number,
+    address: string,
+    tx: string,
+    blockNumber: number,
+    gasUsed: number,
+    effectiveGasPrice: number,
+    blockHash: string,
+  ) {
+    await StorageUtil.setCreatedToken(
+      name,
+      symbol,
+      decimals,
+      address,
+      tx,
+      blockNumber,
+      gasUsed,
+      effectiveGasPrice,
+      blockHash,
+    );
+    this.createdToken = {
+      name,
+      symbol,
+      decimals,
+      address,
+      tx,
+      blockNumber,
+      gasUsed,
+      effectiveGasPrice,
+      blockHash,
+    };
+  }
+
+  async addToken(token: TokenInterface) {
+    const existingToken = this.tokenList.find(
+      (t) => t.address.toLowerCase() === token.address.toLowerCase(),
+    );
+
+    if (!existingToken) {
+      await StorageUtil.updateTokenList([...this.tokenList, token]);
+      this.tokenList = [...this.tokenList, token];
+      return token;
+    }
+
+    const isHidden = this.hiddenTokens.some(
+      (addr) => addr.toLowerCase() === token.address.toLowerCase(),
+    );
+    if (isHidden) {
+      await this.unhideToken(token.address);
+      return existingToken;
+    }
+
+    return null;
+  }
+
+  async removeToken(token: TokenInterface) {
+    await StorageUtil.updateTokenList(
+      this.tokenList.filter(
+        (t) => t.address.toLowerCase() !== token.address.toLowerCase(),
+      ),
+    );
+    this.tokenList = this.tokenList.filter(
+      (t) => t.address !== token.address,
+    );
+  }
+
+  async updateToken(token: TokenInterface) {
+    await StorageUtil.updateTokenList(
+      this.tokenList.map((t) =>
+        t.address.toLocaleLowerCase() === token.address.toLocaleLowerCase()
+          ? token
+          : t,
+      ),
+    );
+    this.tokenList = this.tokenList.map((t) =>
+      t.address.toLocaleLowerCase() === token.address.toLocaleLowerCase()
+        ? token
+        : t,
+    );
+  }
+
+  async setTokenList(tokenList: TokenInterface[]) {
+    await StorageUtil.updateTokenList(tokenList);
+    this.tokenList = tokenList;
+  }
+
+  async sendToken(
+    token: TokenInterface,
+    amount: string,
+    mnemonicPhrases: string,
+    toAddress: string,
+    feeLevel: FeeLevel = "medium",
+  ) {
+    this.qrlStore.resetTransactionStatus();
+    try {
+      const selectedBlockChain = await StorageUtil.getBlockChain();
+      const { url } = QRL_PROVIDER[selectedBlockChain as keyof typeof QRL_PROVIDER];
+      const web3 = new Web3(new Web3.providers.HttpProvider(url));
+      const seed = await deriveHexSeedAsync(mnemonicPhrases);
+      const acc = web3.qrl.accounts.seedToAccount(seed);
+      web3.qrl.wallet?.add(seed);
+      web3.qrl.transactionConfirmationBlocks = 1;
+      const baseGasPrice = (await web3.qrl.getGasPrice()) ?? BigInt(1000000000);
+      const { maxFeePerGas, maxPriorityFeePerGas } = applyFeeLevel(
+        baseGasPrice,
+        feeLevel,
+      );
+      const contract = new web3.qrl.Contract(CustomERC20ABI, token.address);
+      const tx = contract.methods.transfer(toAddress, amount).encodeABI();
+      const estimateGas = await contract.methods
+        .transfer(toAddress, amount)
+        .estimateGas({ from: acc.address });
+      const txObj = {
+        type: "0x2",
+        gas: estimateGas,
+        from: acc.address,
+        data: tx,
+        to: token.address,
+        maxFeePerGas,
+        maxPriorityFeePerGas,
+      };
+
+      const promiEvent = web3.qrl.sendTransaction(txObj, undefined, {
+        checkRevertBeforeSending: true,
+      });
+
+      promiEvent
+        .on("transactionHash", (hash: string | Uint8Array) => {
+          runInAction(() => {
+            const txHash =
+              typeof hash === "string" ? hash : utils.bytesToHex(hash);
+            this.qrlStore.transactionStatus = {
+              state: "pending",
+              txHash: txHash,
+              receipt: null,
+              error: null,
+              pendingDetails: null,
+            };
+            log(`Token transfer pending with hash: ${txHash}`);
+            this.qrlStore.fetchPendingTxDetails(txHash);
+          });
+        })
+        .on("receipt", (receipt: TransactionReceipt) => {
+          runInAction(() => {
+            const txHashString = utils.bytesToHex(receipt.transactionHash);
+            this.qrlStore.transactionStatus = {
+              state: "confirmed",
+              txHash: txHashString,
+              receipt: receipt,
+              error: null,
+              pendingDetails: null,
+            };
+            log(`Token transfer confirmed: ${txHashString}`);
+            this.refreshTokenBalances();
+            this.qrlStore.fetchAccounts();
+          });
+        })
+        .on("error", (error: Error) => {
+          runInAction(() => {
+            const txHash = this.qrlStore.transactionStatus.txHash;
+            this.qrlStore.transactionStatus = {
+              state: "failed",
+              txHash: txHash,
+              receipt: null,
+              error: error.message || "Token transfer failed",
+              pendingDetails: null,
+            };
+            log(`Token transfer failed: ${error.message}`);
+          });
+        });
+
+      return true;
+    } catch (error: any) {
+      runInAction(() => {
+        this.qrlStore.transactionStatus = {
+          state: "failed",
+          txHash: null,
+          receipt: null,
+          error: `Token transfer failed: ${error.message || error}`,
+          pendingDetails: null,
+        };
+        log(`Token transfer preparation failed: ${error}`);
+      });
+      return false;
+    }
+  }
+
+  async createToken(
+    tokenName: string,
+    tokenSymbol: string,
+    initialSupply: string,
+    decimals: number,
+    maxSupply: string,
+    receipt: string,
+    maxWalletAmount: string,
+    maxTxLimit: string,
+    mnemonicPhrases: string,
+  ) {
+    this.qrlStore.resetTransactionStatus();
+    try {
+      this.setCreatingToken(tokenName, true);
+      const selectedBlockChain = await StorageUtil.getBlockChain();
+      const { url } = QRL_PROVIDER[selectedBlockChain as keyof typeof QRL_PROVIDER];
+      const seed = await deriveHexSeedAsync(mnemonicPhrases);
+      const web3 = new Web3(new Web3.providers.HttpProvider(url));
+      const acc = web3.qrl.accounts.seedToAccount(seed);
+      web3.qrl.wallet?.add(seed);
+      web3.qrl.transactionConfirmationBlocks = 1;
+
+      const contractAddress = import.meta.env.VITE_CUSTOMERC20FACTORY_ADDRESS || "";
+
+      if (!contractAddress) {
+        throw new Error(
+          "Factory contract address not configured. Please set VITE_CUSTOMERC20FACTORY_ADDRESS.",
+        );
+      }
+
+      const factoryCode = await web3.qrl.getCode(contractAddress);
+      if (!factoryCode || factoryCode === "0x" || factoryCode === "0x0") {
+        throw new Error(
+          `Factory contract not deployed at address: ${contractAddress}`,
+        );
+      }
+
+      const confirmationHandler = () => {
+        // Don't set creating to false here - confirmation can fire before tx is final.
+        // Let receiptHandler and errorHandler manage the final state.
+      };
+
+      const receiptHandler = async (data: TransactionReceipt) => {
+        const tokenCreatedEventSignature = web3.utils.keccak256(
+          "TokenCreated(address,address)",
+        );
+
+        let tokenCreatedLog = data.logs.find(
+          (logEntry) =>
+            logEntry.topics?.[0] === tokenCreatedEventSignature &&
+            logEntry.address?.toLowerCase() === contractAddress.toLowerCase(),
+        );
+
+        if (!tokenCreatedLog && data.blockNumber) {
+          try {
+            const logs = await web3.qrl.getPastLogs({
+              fromBlock: data.blockNumber,
+              toBlock: data.blockNumber,
+              address: contractAddress,
+              topics: [tokenCreatedEventSignature],
+            });
+            const txHash = data.transactionHash
+              ? web3.utils.bytesToHex(data.transactionHash).toLowerCase()
+              : null;
+            const matchingLog = logs.find(
+              (logEntry) =>
+                typeof logEntry !== "string" &&
+                txHash != null &&
+                logEntry.transactionHash?.toLowerCase() === txHash,
+            );
+            if (matchingLog && typeof matchingLog !== "string") {
+              tokenCreatedLog = matchingLog;
+            }
+          } catch (err) {
+            console.error("Failed to fetch logs via getPastLogs:", err);
+          }
+        }
+
+        if (!tokenCreatedLog?.topics?.[1]) {
+          console.error("Token address not found in transaction receipt or logs");
+          this.setCreatingToken(
+            "",
+            false,
+            "Token address not found in transaction receipt",
+          );
+          return;
+        }
+        const tokenTopic = tokenCreatedLog.topics[1];
+        const erc20TokenAddress = `Q${tokenTopic.toString().slice(-40)}`;
+        const tx = data.transactionHash;
+        const blockNumber = Number(data.blockNumber);
+        const gasUsed = Number(data.gasUsed);
+        const effectiveGasPrice = Number(data.effectiveGasPrice);
+        const blockHash = data.blockHash;
+        const { name, symbol, decimals: tokenDecimals } = await fetchTokenInfo(
+          erc20TokenAddress,
+          url,
+        );
+        this.setCreatedToken(
+          name,
+          symbol,
+          parseInt(tokenDecimals.toString()),
+          erc20TokenAddress,
+          utils.bytesToHex(tx),
+          blockNumber,
+          gasUsed,
+          effectiveGasPrice,
+          utils.bytesToHex(blockHash),
+        );
+        this.setCreatingToken("", false);
+      };
+
+      const errorHandler = (error: Error) => {
+        console.error("Token creation error:", error);
+        this.setCreatingToken("", false, error.message || "Transaction failed");
+      };
+
+      const customERC20Factorycontract = new web3.qrl.Contract(
+        customERC20FactoryABI,
+        contractAddress,
+      );
+
+      const contractCreateToken =
+        customERC20Factorycontract.methods.createToken(
+          tokenName,
+          tokenSymbol,
+          initialSupply,
+          decimals,
+          maxSupply,
+          receipt,
+          maxWalletAmount,
+          maxTxLimit,
+        );
+
+      const estimatedGas = await contractCreateToken.estimateGas({
+        from: acc.address,
+      });
+      const gas = (estimatedGas * 12n) / 10n;
+      const currentGasPrice = await web3.qrl.getGasPrice();
+      const gasPrice = (BigInt(currentGasPrice) * 11n) / 10n;
+
+      const txObj = {
+        gas,
+        gasPrice,
+        from: acc.address,
+        data: contractCreateToken.encodeABI(),
+        to: contractAddress,
+      };
+
+      await web3.qrl
+        .sendTransaction(txObj, undefined, {
+          checkRevertBeforeSending: true,
+        })
+        .on("confirmation", confirmationHandler)
+        .on("receipt", receiptHandler)
+        .on("error", errorHandler);
+    } catch (error) {
+      console.error("Failed to create token:", error);
+      const errorMessage =
+        error instanceof Error ? error.message : "Token creation failed";
+      this.setCreatingToken("", false, errorMessage);
+      throw error;
+    }
+  }
+
+  async refreshTokenBalances() {
+    try {
+      const activeAccountAddress = this.qrlStore.activeAccount.accountAddress;
+      if (!activeAccountAddress) return;
+
+      const selectedBlockChain = await StorageUtil.getBlockChain();
+      const updatedTokenList = [...this.tokenList];
+
+      for (let i = 0; i < this.tokenList.length; i++) {
+        const token = this.tokenList[i];
+        try {
+          const balance = await fetchBalance(
+            token.address,
+            activeAccountAddress,
+            QRL_PROVIDER[selectedBlockChain as keyof typeof QRL_PROVIDER].url,
+          );
+          const balanceStr = formatUnits(balance, token.decimals);
+          updatedTokenList[i] = {
+            ...token,
+            amount: getOptimalTokenBalance(balanceStr, token.symbol),
+          };
+        } catch (err) {
+          console.error(
+            `Error fetching balance for token ${token.symbol}:`,
+            err,
+          );
+          updatedTokenList[i] = { ...token, amount: "Error" };
+        }
+      }
+
+      await this.setTokenList(updatedTokenList);
+    } catch (error) {
+      console.error("Error refreshing token balances:", error);
+    }
+  }
+
+  async discoverAndAddTokens(address: string) {
+    try {
+      const blockchain = this.qrlStore.qrlConnection.blockchain;
+      if (!blockchain) {
+        log("Cannot discover tokens: no blockchain selected");
+        return;
+      }
+
+      log(`Starting token discovery for ${address}`);
+      const discoveredTokens = await discoverTokens(address, blockchain);
+
+      if (discoveredTokens.length === 0) {
+        log("No new tokens discovered");
+        return;
+      }
+
+      const mergedTokens = mergeTokenLists(this.tokenList, discoveredTokens);
+
+      if (mergedTokens.length > this.tokenList.length) {
+        const newCount = mergedTokens.length - this.tokenList.length;
+        log(`Adding ${newCount} newly discovered tokens`);
+        await this.setTokenList(mergedTokens);
+      }
+    } catch (error) {
+      console.error("Error discovering tokens:", error);
+      log(`Token discovery failed: ${error}`);
+    }
+  }
+
+  async loadHiddenTokens() {
+    const hiddenTokens = await StorageUtil.getHiddenTokens();
+    runInAction(() => {
+      this.hiddenTokens = hiddenTokens;
+    });
+  }
+
+  async hideToken(tokenAddress: string) {
+    await StorageUtil.hideToken(tokenAddress);
+    runInAction(() => {
+      const lowerCaseAddress = tokenAddress.toLowerCase();
+      if (
+        !this.hiddenTokens.some(
+          (addr) => addr.toLowerCase() === lowerCaseAddress,
+        )
+      ) {
+        this.hiddenTokens = [...this.hiddenTokens, lowerCaseAddress];
+      }
+    });
+    log(`Token hidden: ${tokenAddress}`);
+  }
+
+  async unhideToken(tokenAddress: string) {
+    await StorageUtil.unhideToken(tokenAddress);
+    runInAction(() => {
+      this.hiddenTokens = this.hiddenTokens.filter(
+        (addr) => addr.toLowerCase() !== tokenAddress.toLowerCase(),
+      );
+    });
+    log(`Token unhidden: ${tokenAddress}`);
+  }
+}
+
+export default TokenStore;

--- a/src/utils/storage/index.ts
+++ b/src/utils/storage/index.ts
@@ -3,6 +3,8 @@ export {
   type AccountSource,
   type AccountListItem,
   type EncryptedSeedData,
+  STORAGE_EVENT_ACTIVE_ACCOUNT,
+  STORAGE_EVENT_WALLET_SETTINGS,
 } from './storage';
 
 export {

--- a/src/utils/storage/storage.ts
+++ b/src/utils/storage/storage.ts
@@ -1,5 +1,5 @@
 import { QRL_PROVIDER } from "@/config";
-import { TokenInterface } from "@/constants";
+import { TokenInterface, NFTInterface } from "@/constants";
 import { isInNativeApp } from "@/utils/nativeApp";
 
 const ACTIVE_PAGE_IDENTIFIER = "ACTIVE_PAGE";
@@ -11,6 +11,8 @@ const ACCOUNT_LIST_IDENTIFIER = "ACCOUNT_LIST";
 const TRANSACTION_VALUES_IDENTIFIER = "TRANSACTION_VALUES";
 const TOKEN_LIST_IDENTIFIER = "TOKEN_LIST";
 const HIDDEN_TOKENS_IDENTIFIER = "HIDDEN_TOKENS";
+const NFT_LIST_IDENTIFIER = "NFT_LIST";
+const HIDDEN_NFTS_IDENTIFIER = "HIDDEN_NFTS";
 const BALANCE_CACHE_IDENTIFIER = "BALANCE_CACHE";
 const STORAGE_VERSION = 'v1';
 const MAX_STORAGE_AGE = 6 * 60 * 60 * 1000; // 6 hours in milliseconds
@@ -50,6 +52,8 @@ interface WalletSettings {
   showTestNetworks: boolean;
   hideSmallBalances: boolean;
   hideUnknownTokens: boolean;
+  showTokensCard: boolean;
+  showNftsCard: boolean;
 }
 
 export interface EncryptedSeedData {
@@ -297,12 +301,19 @@ class StorageUtil {
   }
 
   static async getWalletSettings(): Promise<WalletSettings> {
-    return this.getItem<WalletSettings>(WALLET_SETTINGS_IDENTIFIER) ?? {
+    const defaults: WalletSettings = {
       autoLockTimeout: AUTO_LOCK_TIMEOUT,
       showTestNetworks: false,
       hideSmallBalances: false,
       hideUnknownTokens: true,
+      showTokensCard: true,
+      showNftsCard: true,
     };
+    // Merge defaults so returning users with a stored settings object
+    // that pre-dates the new keys still get the right defaults instead
+    // of `undefined`.
+    const stored = this.getItem<Partial<WalletSettings>>(WALLET_SETTINGS_IDENTIFIER);
+    return { ...defaults, ...(stored ?? {}) };
   }
 
   /**
@@ -473,6 +484,45 @@ class StorageUtil {
    */
   static async clearHiddenTokens() {
     localStorage.removeItem(HIDDEN_TOKENS_IDENTIFIER);
+  }
+
+  /**
+   * NFT list — per-account scoping is intentionally avoided here because
+   * `setActiveAccount` already triggers a clear+rediscover in nftStore;
+   * matches the TokenList behaviour.
+   */
+  static async getNftList(): Promise<NFTInterface[]> {
+    return this.getItem<NFTInterface[]>(NFT_LIST_IDENTIFIER) ?? [];
+  }
+
+  static async updateNftList(list: NFTInterface[]) {
+    this.setItem(NFT_LIST_IDENTIFIER, list);
+  }
+
+  static async clearNftList() {
+    localStorage.removeItem(NFT_LIST_IDENTIFIER);
+  }
+
+  static async getHiddenNfts(): Promise<string[]> {
+    return this.getItem<string[]>(HIDDEN_NFTS_IDENTIFIER) ?? [];
+  }
+
+  static async hideNft(key: string) {
+    const list = await this.getHiddenNfts();
+    if (!list.some(k => k.toLowerCase() === key.toLowerCase())) {
+      list.push(key.toLowerCase());
+      this.setItem(HIDDEN_NFTS_IDENTIFIER, list);
+    }
+  }
+
+  static async unhideNft(key: string) {
+    let list = await this.getHiddenNfts();
+    list = list.filter(k => k.toLowerCase() !== key.toLowerCase());
+    this.setItem(HIDDEN_NFTS_IDENTIFIER, list);
+  }
+
+  static async clearHiddenNfts() {
+    localStorage.removeItem(HIDDEN_NFTS_IDENTIFIER);
   }
 }
 

--- a/src/utils/web3/nft.ts
+++ b/src/utils/web3/nft.ts
@@ -1,0 +1,281 @@
+import Web3 from "@theqrl/web3";
+import { erc165ABI, ERC165_INTERFACE_IDS } from "@/abi/ERC165ABI";
+import { erc721ABI } from "@/abi/ERC721ABI";
+import { erc1155ABI } from "@/abi/ERC1155ABI";
+
+export type NftStandard = "ERC721" | "ERC1155";
+
+export interface NftCollectionInfo {
+  standard: NftStandard;
+  name?: string;
+  symbol?: string;
+  supportsEnumerable: boolean;
+}
+
+export interface NftMetadata {
+  name?: string;
+  description?: string;
+  image?: string;
+  external_url?: string;
+  attributes?: Array<{ trait_type?: string; value: string | number }>;
+}
+
+// IPFS gateway used to resolve `ipfs://` URIs. Public, free, well-trodden;
+// we expose a hook (resolveIpfsUri) so consumers can swap to a backend
+// proxy later if abuse becomes an issue.
+export const IPFS_GATEWAY = "https://ipfs.io/ipfs/";
+
+const METADATA_FETCH_TIMEOUT_MS = 8000;
+
+// Try ERC-165 supportsInterface(0x...). Returns false on any RPC revert
+// (very common — pre-ERC-165 contracts revert instead of returning false).
+async function safeSupportsInterface(
+  web3: Web3,
+  contractAddress: string,
+  interfaceId: string,
+): Promise<boolean> {
+  try {
+    const contract = new web3.qrl.Contract(erc165ABI as any, contractAddress);
+    const result = await (contract.methods as any).supportsInterface(interfaceId).call();
+    return Boolean(result);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Detect whether an address is an ERC-721 or ERC-1155 contract, or
+ * neither (returns null — caller falls through to ERC-20 / unsupported).
+ */
+export async function detectTokenStandard(
+  contractAddress: string,
+  rpcUrl: string,
+): Promise<NftStandard | null> {
+  const web3 = new Web3(new Web3.providers.HttpProvider(rpcUrl));
+
+  // No code at address → not a contract.
+  const code = await web3.qrl.getCode(contractAddress);
+  if (!code || code === "0x" || code === "0x0") {
+    return null;
+  }
+
+  if (await safeSupportsInterface(web3, contractAddress, ERC165_INTERFACE_IDS.ERC721)) {
+    return "ERC721";
+  }
+  if (await safeSupportsInterface(web3, contractAddress, ERC165_INTERFACE_IDS.ERC1155)) {
+    return "ERC1155";
+  }
+  return null;
+}
+
+export async function fetchNftCollectionInfo(
+  contractAddress: string,
+  rpcUrl: string,
+  standard: NftStandard,
+): Promise<NftCollectionInfo> {
+  const web3 = new Web3(new Web3.providers.HttpProvider(rpcUrl));
+
+  if (standard === "ERC721") {
+    const contract = new web3.qrl.Contract(erc721ABI as any, contractAddress);
+    const methods = contract.methods as any;
+    let name: string | undefined;
+    let symbol: string | undefined;
+    try {
+      name = (await methods.name().call()) as string;
+    } catch {
+      // Optional in ERC-721 — some implementations omit it.
+    }
+    try {
+      symbol = (await methods.symbol().call()) as string;
+    } catch {
+      // Optional in ERC-721 — some implementations omit it.
+    }
+    const supportsEnumerable = await safeSupportsInterface(
+      web3,
+      contractAddress,
+      ERC165_INTERFACE_IDS.ERC721_ENUMERABLE,
+    );
+    return { standard, name, symbol, supportsEnumerable };
+  }
+
+  // ERC-1155: no collection-level name/symbol on-chain.
+  return { standard, supportsEnumerable: false };
+}
+
+/**
+ * For ERC-721 contracts that implement Enumerable, list owned token IDs.
+ * Returns null if the contract doesn't support Enumerable — callers
+ * must then prompt the user for a tokenId.
+ */
+export async function fetchOwned721Ids(
+  contractAddress: string,
+  ownerAddress: string,
+  rpcUrl: string,
+): Promise<string[] | null> {
+  const web3 = new Web3(new Web3.providers.HttpProvider(rpcUrl));
+  const supportsEnumerable = await safeSupportsInterface(
+    web3,
+    contractAddress,
+    ERC165_INTERFACE_IDS.ERC721_ENUMERABLE,
+  );
+  if (!supportsEnumerable) return null;
+
+  const contract = new web3.qrl.Contract(erc721ABI as any, contractAddress);
+  const methods = contract.methods as any;
+  const checksum = web3.utils.toChecksumAddress(ownerAddress);
+  const balanceRaw = (await methods.balanceOf(checksum).call()) as bigint | string;
+  const balance = BigInt(balanceRaw);
+  if (balance === 0n) return [];
+
+  const ids: string[] = [];
+  for (let i = 0n; i < balance; i++) {
+    try {
+      const id = (await methods
+        .tokenOfOwnerByIndex(checksum, i)
+        .call()) as bigint | string;
+      ids.push(BigInt(id).toString());
+    } catch (err) {
+      console.error(`tokenOfOwnerByIndex(${i}) failed:`, err);
+      break;
+    }
+  }
+  return ids;
+}
+
+/** Confirm `owner` still holds an ERC-721 tokenId. */
+export async function isErc721Owner(
+  contractAddress: string,
+  ownerAddress: string,
+  tokenId: string,
+  rpcUrl: string,
+): Promise<boolean> {
+  const web3 = new Web3(new Web3.providers.HttpProvider(rpcUrl));
+  try {
+    const contract = new web3.qrl.Contract(erc721ABI as any, contractAddress);
+    const actual = (await (contract.methods as any).ownerOf(tokenId).call()) as string;
+    return actual.toLowerCase() === web3.utils.toChecksumAddress(ownerAddress).toLowerCase();
+  } catch {
+    return false;
+  }
+}
+
+/** Fetch ERC-1155 balance for (owner, id). */
+export async function fetchErc1155Balance(
+  contractAddress: string,
+  ownerAddress: string,
+  tokenId: string,
+  rpcUrl: string,
+): Promise<bigint> {
+  const web3 = new Web3(new Web3.providers.HttpProvider(rpcUrl));
+  const contract = new web3.qrl.Contract(erc1155ABI as any, contractAddress);
+  const checksum = web3.utils.toChecksumAddress(ownerAddress);
+  const raw = (await (contract.methods as any).balanceOf(checksum, tokenId).call()) as bigint | string;
+  return BigInt(raw);
+}
+
+/**
+ * Resolve the on-chain tokenURI (721) or uri (1155) for a token.
+ * Per ERC-1155 spec the URI may contain a `{id}` placeholder that
+ * clients substitute with the 64-char zero-padded hex token id.
+ */
+export async function fetchTokenUri(
+  contractAddress: string,
+  tokenId: string,
+  rpcUrl: string,
+  standard: NftStandard,
+): Promise<string | null> {
+  const web3 = new Web3(new Web3.providers.HttpProvider(rpcUrl));
+  try {
+    if (standard === "ERC721") {
+      const contract = new web3.qrl.Contract(erc721ABI as any, contractAddress);
+      const uri = (await (contract.methods as any).tokenURI(tokenId).call()) as string;
+      return uri || null;
+    }
+    const contract = new web3.qrl.Contract(erc1155ABI as any, contractAddress);
+    let uri = (await (contract.methods as any).uri(tokenId).call()) as string;
+    if (uri && uri.includes("{id}")) {
+      const hexId = BigInt(tokenId).toString(16).padStart(64, "0");
+      uri = uri.replace(/\{id\}/g, hexId);
+    }
+    return uri || null;
+  } catch (err) {
+    console.error("Failed to fetch tokenURI:", err);
+    return null;
+  }
+}
+
+/** Rewrite `ipfs://CID/path` → public gateway URL. */
+export function resolveIpfsUri(uri: string): string {
+  if (uri.startsWith("ipfs://ipfs/")) {
+    return `${IPFS_GATEWAY}${uri.slice("ipfs://ipfs/".length)}`;
+  }
+  if (uri.startsWith("ipfs://")) {
+    return `${IPFS_GATEWAY}${uri.slice("ipfs://".length)}`;
+  }
+  return uri;
+}
+
+/**
+ * Fetch + parse NFT JSON metadata. Returns null on any failure (timeout,
+ * 404, JSON parse error). Sanitizes the `image` field to https/data only
+ * — never javascript: or file: schemes (tokenURI content is attacker-
+ * controlled).
+ */
+export async function fetchNftMetadata(uri: string): Promise<NftMetadata | null> {
+  const resolved = resolveIpfsUri(uri);
+
+  // Only allow http(s) for the metadata document itself. data: URIs are
+  // valid in spec but rare and add a parser surface we don't need yet.
+  if (!resolved.startsWith("http://") && !resolved.startsWith("https://")) {
+    return null;
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), METADATA_FETCH_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(resolved, { signal: controller.signal });
+    if (!res.ok) return null;
+    const json = (await res.json()) as Partial<NftMetadata> & Record<string, unknown>;
+
+    let image = typeof json.image === "string" ? json.image : undefined;
+    if (image) {
+      image = resolveIpfsUri(image);
+      // Reject anything that isn't a safe scheme. data:image/... is
+      // allowed since it's the inline-image idiom and React renders it
+      // as a src attribute without script execution.
+      if (
+        !image.startsWith("http://") &&
+        !image.startsWith("https://") &&
+        !image.startsWith("data:image/")
+      ) {
+        image = undefined;
+      }
+    }
+
+    return {
+      name: typeof json.name === "string" ? json.name : undefined,
+      description:
+        typeof json.description === "string" ? json.description : undefined,
+      image,
+      external_url:
+        typeof json.external_url === "string" ? json.external_url : undefined,
+      attributes: Array.isArray(json.attributes)
+        ? (json.attributes as NftMetadata["attributes"])
+        : undefined,
+    };
+  } catch (err) {
+    console.error("fetchNftMetadata failed:", err);
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Composite key for an NFT (contract + tokenId). Used as the persistence
+ * key in `hiddenNfts` and as the React list key in the gallery.
+ */
+export function nftKey(contractAddress: string, tokenId: string): string {
+  return `${contractAddress.toLowerCase()}:${tokenId}`;
+}


### PR DESCRIPTION
## Summary

Closes the long-standing silent failure when adding non-QRC-20 contracts to the wallet and ships full ERC-721 / ERC-1155 NFT support. Refactors the 1,270-line `qrlStore` into three domain stores along the way, and adds Settings toggles to hide either the Tokens or NFTs card on Home for users who don't want them.

Reported case: K.H. deployed an ERC-721 + ERC-1155 testnet contract; \"Add Token\" silently failed because `AddTokenModal` only knew ERC-20 selectors. This PR makes that flow surface a real error AND adds a dedicated NFT card that handles the contract correctly.

Three commits, walkable individually:

1. **`fix(tokens): surface fetch errors in AddTokenModal`** — replaces the silent `catch { console.error }` with the existing inline `role=\"alert\"` surface; clears stale state on retry. Independent value, 1 file.
2. **`refactor(stores): split qrlStore into qrlStore + tokenStore + nftStore`** — pure mechanical refactor, zero behavior change. `qrlStore` keeps L1/wallet concerns; new `tokenStore` owns fungibles; new `nftStore` (empty shell in this commit) gets populated in commit 3. Decoupled via `onBlockchainReady` / `onActiveAccountChanged` callbacks injected by `Store`. 10 token-member call sites rewired across 9 files. Persistence keys untouched.
3. **`feat(nft): ERC-721/1155 support + Home card visibility toggles`** — `showTokensCard` / `showNftsCard` in `WalletSettings` (default ON) + two new switches in Settings. ERC-165 detection, IPFS-aware metadata fetch with scheme sanitization, owner enumeration with manual-tokenId fallback for non-enumerable 721, ERC-1155 balance handling. `NftGallery` / `NftCard` / `NftImage` / `AddNftModal` / `NftDetail` with PIN-signed transfer reusing the existing crypto worker. New `/nft/:contractAddress/:tokenId` route.

## Out of scope (intentional, flagged for follow-ups)

- Backend `/api/nft/metadata` + IPFS proxy (`myqrlwallet-backend`) — v1 hits public IPFS gateway directly with timeout + fallback.
- ERC Transfer-log auto-discovery — manual add only in v1.
- zondscan NFT indexing — separate explorer-side track.
- Extension-signed NFT writes — `NftDetail` surfaces a clear \"switch to an imported account\" message instead of failing silently. Wire-up is a separate PR.

## Test plan

- [ ] `npm run lint` zero warnings — done.
- [ ] `npx tsc --noEmit` clean — done.
- [ ] `SKIP_DAPP_EXAMPLE=1 npm run build` clean — done.
- [ ] **Phase 0 smoke**: paste an EOA into Add Token → red inline alert (no silent failure); paste a known QRC-20 → preview still works.
- [ ] **Phase 1 smoke (zero behavior change)**: connect → switch network → send native QRL → add/hide a QRC-20 → create a token via factory. All flows that touched `qrlStore.X` must still work end-to-end after the rename to `tokenStore.X`.
- [ ] **Phase 2 smoke**: Settings → toggle off Tokens card → Home stops rendering TokenForm; toggle back on → renders. Same for NFTs card. Toggles persist across reload.
- [ ] **Phase 3 smoke (the reporter's path)**: paste K.H.'s ERC-721 contract into Add NFT → detection succeeds, gallery card with image+metadata; transfer to another address → tx hash links to explorer, gallery refreshes ownership. Repeat for ERC-1155 with explicit tokenId.
- [ ] Returning-user check: pre-set localStorage `WALLET_SETTINGS` to old payload missing the new keys → reload → both cards default to visible (defaults-merge works).
- [ ] Negative paths: random EOA / unsupported contract in AddNftModal → clear inline error.

## Risks

- First dev startup after pulling this branch may need a hard reload because `window.__APP_STORE__` caches the previous Store instance across HMR. Production unaffected.
- IPFS gateway flakiness can blank an image; component falls back to a placeholder.
- 8s fetch timeout on metadata — gateway hangs degrade gracefully.

## Deploy

Will manually deploy this branch on `dev.qrlwallet.com` for live testing before merge.