### PR TITLE
sec(nft): close image IP-leak + scope NFT storage per chain/account

### DIFF
--- a/deploy/nginx.conf.example
+++ b/deploy/nginx.conf.example
@@ -46,7 +46,7 @@ server {
     # both variants (or use a wildcard like *.yourdomain.com) so CSP doesn't
     # flag the other variant as cross-origin when a user lands on one but
     # the API / relay answers on the other.
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://yourdomain.com/api/* wss://yourdomain.com https://zondscan.com; img-src 'self' data: https:; font-src 'self' data:;" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://yourdomain.com/api/* wss://yourdomain.com https://zondscan.com; img-src 'self' data:; font-src 'self' data:;" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "DENY" always;
     add_header X-XSS-Protection "1; mode=block" always;
@@ -146,7 +146,7 @@ server {
         expires 1y;
         # IMPORTANT: Must repeat security headers since this block has add_header
         add_header Cache-Control "public, no-transform";
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://yourdomain.com/api/* wss://yourdomain.com https://zondscan.com; img-src 'self' data: https:; font-src 'self' data:;" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://yourdomain.com/api/* wss://yourdomain.com https://zondscan.com; img-src 'self' data:; font-src 'self' data:;" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-Frame-Options "DENY" always;
         add_header X-XSS-Protection "1; mode=block" always;
@@ -159,7 +159,7 @@ server {
         try_files $uri $uri/ /index.html?$args;
 
         # Security Headers (must be repeated here because add_header clears parent headers)
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://yourdomain.com/api/* wss://yourdomain.com https://zondscan.com; img-src 'self' data: https:; font-src 'self' data:;" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://yourdomain.com/api/* wss://yourdomain.com https://zondscan.com; img-src 'self' data:; font-src 'self' data:;" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-Frame-Options "DENY" always;
         add_header X-XSS-Protection "1; mode=block" always;
@@ -168,7 +168,7 @@ server {
         # Prevent caching of index.html for instant updates
         # IMPORTANT: Must repeat security headers since this block has add_header
         add_header Cache-Control "no-store, no-cache, must-revalidate" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://yourdomain.com/api/* wss://yourdomain.com https://zondscan.com; img-src 'self' data: https:; font-src 'self' data:;" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://yourdomain.com/api/* wss://yourdomain.com https://zondscan.com; img-src 'self' data:; font-src 'self' data:;" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-Frame-Options "DENY" always;
         add_header X-XSS-Protection "1; mode=block" always;

--- a/src/stores/nftStore.ts
+++ b/src/stores/nftStore.ts
@@ -62,8 +62,19 @@ class NftStore {
     );
   }
 
+  // Storage is now keyed by `${blockchain}_${account}` (see StorageUtil)
+  // so reads from the wrong scope are impossible — but we still need the
+  // scope to write. Pulls live values from qrlStore at the call site.
+  private get scope(): { blockchain: string; account: string } {
+    return {
+      blockchain: this.qrlStore.qrlConnection.blockchain,
+      account: this.qrlStore.activeAccount.accountAddress,
+    };
+  }
+
   async initialize() {
-    const persisted = await StorageUtil.getNftList();
+    const { blockchain, account } = this.scope;
+    const persisted = await StorageUtil.getNftList(blockchain, account);
     runInAction(() => {
       this.nftList = persisted;
     });
@@ -74,17 +85,22 @@ class NftStore {
     if (!newActiveAccount) {
       return;
     }
-    // Mirror the token-store policy: clear list on account change so
-    // collectibles from a prior account don't leak into the new one. The
-    // user re-adds them manually (or via future auto-discovery).
-    await StorageUtil.clearNftList();
+    // Storage is per-account-scoped, so an account switch just means
+    // reloading from the new scope's key. No cross-account clearing
+    // needed — the old account's list stays under its own key for when
+    // the user switches back.
+    const blockchain = this.qrlStore.qrlConnection.blockchain;
+    const persisted = await StorageUtil.getNftList(blockchain, newActiveAccount);
+    const hidden = await StorageUtil.getHiddenNfts(blockchain, newActiveAccount);
     runInAction(() => {
-      this.nftList = [];
+      this.nftList = persisted;
+      this.hiddenNfts = hidden;
     });
   }
 
   async setNftList(list: NFTInterface[]) {
-    await StorageUtil.updateNftList(list);
+    const { blockchain, account } = this.scope;
+    await StorageUtil.updateNftList(blockchain, account, list);
     runInAction(() => {
       this.nftList = list;
     });
@@ -118,14 +134,16 @@ class NftStore {
   }
 
   async loadHiddenNfts() {
-    const list = await StorageUtil.getHiddenNfts();
+    const { blockchain, account } = this.scope;
+    const list = await StorageUtil.getHiddenNfts(blockchain, account);
     runInAction(() => {
       this.hiddenNfts = list;
     });
   }
 
   async hideNft(key: string) {
-    await StorageUtil.hideNft(key);
+    const { blockchain, account } = this.scope;
+    await StorageUtil.hideNft(blockchain, account, key);
     runInAction(() => {
       const lower = key.toLowerCase();
       if (!this.hiddenNfts.some((k) => k.toLowerCase() === lower)) {
@@ -135,7 +153,8 @@ class NftStore {
   }
 
   async unhideNft(key: string) {
-    await StorageUtil.unhideNft(key);
+    const { blockchain, account } = this.scope;
+    await StorageUtil.unhideNft(blockchain, account, key);
     runInAction(() => {
       this.hiddenNfts = this.hiddenNfts.filter(
         (k) => k.toLowerCase() !== key.toLowerCase(),

--- a/src/utils/storage/storage.ts
+++ b/src/utils/storage/storage.ts
@@ -487,42 +487,59 @@ class StorageUtil {
   }
 
   /**
-   * NFT list — per-account scoping is intentionally avoided here because
-   * `setActiveAccount` already triggers a clear+rediscover in nftStore;
-   * matches the TokenList behaviour.
+   * NFT list — keyed by `${blockchain}_${account}` so collectibles from
+   * one wallet/chain never bleed into another. Returns `[]` when either
+   * scope component is empty (caller's bootstrap typically races init).
+   * Replaces the older global key which leaked across accounts on
+   * re-import and across networks on chain switch.
    */
-  static async getNftList(): Promise<NFTInterface[]> {
-    return this.getItem<NFTInterface[]>(NFT_LIST_IDENTIFIER) ?? [];
+  private static nftListKey(blockchain: string, account: string) {
+    return `${blockchain}_${account.toLowerCase()}_${NFT_LIST_IDENTIFIER}`;
   }
 
-  static async updateNftList(list: NFTInterface[]) {
-    this.setItem(NFT_LIST_IDENTIFIER, list);
+  private static hiddenNftsKey(blockchain: string, account: string) {
+    return `${blockchain}_${account.toLowerCase()}_${HIDDEN_NFTS_IDENTIFIER}`;
   }
 
-  static async clearNftList() {
-    localStorage.removeItem(NFT_LIST_IDENTIFIER);
+  static async getNftList(blockchain: string, account: string): Promise<NFTInterface[]> {
+    if (!blockchain || !account) return [];
+    return this.getItem<NFTInterface[]>(this.nftListKey(blockchain, account)) ?? [];
   }
 
-  static async getHiddenNfts(): Promise<string[]> {
-    return this.getItem<string[]>(HIDDEN_NFTS_IDENTIFIER) ?? [];
+  static async updateNftList(blockchain: string, account: string, list: NFTInterface[]) {
+    if (!blockchain || !account) return;
+    this.setItem(this.nftListKey(blockchain, account), list);
   }
 
-  static async hideNft(key: string) {
-    const list = await this.getHiddenNfts();
+  static async clearNftList(blockchain: string, account: string) {
+    if (!blockchain || !account) return;
+    localStorage.removeItem(this.nftListKey(blockchain, account));
+  }
+
+  static async getHiddenNfts(blockchain: string, account: string): Promise<string[]> {
+    if (!blockchain || !account) return [];
+    return this.getItem<string[]>(this.hiddenNftsKey(blockchain, account)) ?? [];
+  }
+
+  static async hideNft(blockchain: string, account: string, key: string) {
+    if (!blockchain || !account) return;
+    const list = await this.getHiddenNfts(blockchain, account);
     if (!list.some(k => k.toLowerCase() === key.toLowerCase())) {
       list.push(key.toLowerCase());
-      this.setItem(HIDDEN_NFTS_IDENTIFIER, list);
+      this.setItem(this.hiddenNftsKey(blockchain, account), list);
     }
   }
 
-  static async unhideNft(key: string) {
-    let list = await this.getHiddenNfts();
+  static async unhideNft(blockchain: string, account: string, key: string) {
+    if (!blockchain || !account) return;
+    let list = await this.getHiddenNfts(blockchain, account);
     list = list.filter(k => k.toLowerCase() !== key.toLowerCase());
-    this.setItem(HIDDEN_NFTS_IDENTIFIER, list);
+    this.setItem(this.hiddenNftsKey(blockchain, account), list);
   }
 
-  static async clearHiddenNfts() {
-    localStorage.removeItem(HIDDEN_NFTS_IDENTIFIER);
+  static async clearHiddenNfts(blockchain: string, account: string) {
+    if (!blockchain || !account) return;
+    localStorage.removeItem(this.hiddenNftsKey(blockchain, account));
   }
 }
 

--- a/src/utils/web3/nft.ts
+++ b/src/utils/web3/nft.ts
@@ -225,9 +225,11 @@ export function resolveIpfsUri(uri: string): string {
 
 /**
  * Fetch + parse NFT JSON metadata. Returns null on any failure (timeout,
- * 404, JSON parse error). Sanitizes the `image` field to https/data only
- * — never javascript: or file: schemes (tokenURI content is attacker-
- * controlled).
+ * 404, JSON parse error). Sanitizes the `image` field to proxied IPFS
+ * (same-origin via `/api/ipfs/...`) or inline `data:image/...` only.
+ * Raw http(s):// image URLs are dropped on purpose — tokenURI content
+ * is attacker-controlled and would otherwise leak the wallet user's IP
+ * to any host the JSON points at.
  */
 export async function fetchNftMetadata(uri: string): Promise<NftMetadata | null> {
   const resolved = resolveIpfsUri(uri);
@@ -248,17 +250,21 @@ export async function fetchNftMetadata(uri: string): Promise<NftMetadata | null>
 
     let image = typeof json.image === "string" ? json.image : undefined;
     if (image) {
-      image = resolveIpfsUri(image);
-      // Reject anything that isn't a safe scheme. data:image/... is
-      // allowed since it's the inline-image idiom and React renders it
-      // as a src attribute without script execution.
-      if (
-        !image.startsWith("http://") &&
-        !image.startsWith("https://") &&
-        !image.startsWith("data:image/")
-      ) {
-        image = undefined;
-      }
+      const rawImage = image;
+      const resolvedImage = resolveIpfsUri(image);
+      // Only allow images that are either (a) proxied IPFS — `ipfs://`
+      // resolves to same-origin `/api/ipfs/...` so the browser fetches
+      // through the wallet backend and CSP `img-src 'self'` permits it,
+      // or (b) inline `data:image/...`. Reject raw http(s):// images:
+      // attacker-controlled tokenURI JSON could otherwise point `image`
+      // at a tracker host and leak the user's IP + a per-wallet
+      // correlation token on render. Widening `img-src` to `https:` to
+      // accommodate that case was the original cause of the leak.
+      const isProxiedIpfs =
+        rawImage.startsWith("ipfs://") &&
+        resolvedImage.startsWith(IPFS_GATEWAY);
+      const isInlineImage = resolvedImage.startsWith("data:image/");
+      image = isProxiedIpfs || isInlineImage ? resolvedImage : undefined;
     }
 
     return {

--- a/src/utils/web3/nft.ts
+++ b/src/utils/web3/nft.ts
@@ -212,12 +212,15 @@ export async function fetchTokenUri(
   }
 }
 
-/** Rewrite `ipfs://CID/path` → public gateway URL. */
+/** Rewrite `ipfs://CID/path` → public gateway URL.
+ * Scheme match is case-insensitive (RFC 3986 §3.1) so `IPFS://...` and
+ * mixed-case variants from older metadata producers also resolve. */
 export function resolveIpfsUri(uri: string): string {
-  if (uri.startsWith("ipfs://ipfs/")) {
+  const lower = uri.toLowerCase();
+  if (lower.startsWith("ipfs://ipfs/")) {
     return `${IPFS_GATEWAY}${uri.slice("ipfs://ipfs/".length)}`;
   }
-  if (uri.startsWith("ipfs://")) {
+  if (lower.startsWith("ipfs://")) {
     return `${IPFS_GATEWAY}${uri.slice("ipfs://".length)}`;
   }
   return uri;
@@ -260,10 +263,11 @@ export async function fetchNftMetadata(uri: string): Promise<NftMetadata | null>
       // at a tracker host and leak the user's IP + a per-wallet
       // correlation token on render. Widening `img-src` to `https:` to
       // accommodate that case was the original cause of the leak.
+      const rawLower = rawImage.toLowerCase();
       const isProxiedIpfs =
-        rawImage.startsWith("ipfs://") &&
+        rawLower.startsWith("ipfs://") &&
         resolvedImage.startsWith(IPFS_GATEWAY);
-      const isInlineImage = resolvedImage.startsWith("data:image/");
+      const isInlineImage = rawLower.startsWith("data:image/");
       image = isProxiedIpfs || isInlineImage ? resolvedImage : undefined;
     }
 


### PR DESCRIPTION
## Summary

Two HIGH-severity fixes from today's audit of the NFT work merged in #136 and #137.

### 1. Image IP-leak via attacker-controlled metadata
`img-src 'self' data: https:` in the nginx CSP example combined with `fetchNftMetadata` accepting any http(s) `image` URL meant a malicious tokenURI JSON could embed `image: "https://tracker.example.com/<wallet-address>.png"` and the browser would fetch it directly on gallery render — leaking the user's IP plus a per-wallet correlation token to any host the JSON points at.

- `deploy/nginx.conf.example`: tighten `img-src` back to `'self' data:` in all four CSP headers. The new `/api/ipfs` proxy makes the widening unnecessary.
- `src/utils/web3/nft.ts` (`fetchNftMetadata`): accept only **proxied IPFS** images (`ipfs://...` → `/api/ipfs/...`) and inline `data:image/...`. Raw http(s) image URLs are dropped; gallery shows the placeholder instead of firing a third-party request.

### 2. NFT list bled across wallets and chains
`NFT_LIST` / `HIDDEN_NFTS` were single global localStorage keys. Re-importing wallet A after browsing wallet B showed B's NFTs until an account change cleared them; switching chains never cleared at all (phantom NFTs from another network would fail ownership checks).

- `src/utils/storage/storage.ts`: scope both keys as `${blockchain}_${account}_NFT_LIST` / `${blockchain}_${account}_HIDDEN_NFTS` — same pattern as `ACTIVE_ACCOUNT` / `TRANSACTION_VALUES`. Methods now take blockchain + account; return `[]` when either is empty.
- `src/stores/nftStore.ts`: pull scope from `qrlStore` at each call. Account-change handler reloads from the new scope's key instead of clearing — the old account's list survives under its own key for round-tripping.

No schema migration: the old global keys are ignored on first read in the new code. Feature is days old, very few users have pinned NFTs to lose.

## Test plan

- [ ] CI green (typecheck + lint + build + docker)
- [ ] Manual: add an NFT on wallet A → switch to wallet B → list is empty → switch back → list reappears
- [ ] Manual: add an NFT on Testnet → switch to Mainnet → list is empty (no phantom)
- [ ] Manual: NFT with `image: ipfs://...` renders via `/api/ipfs/...` (CSP `img-src 'self'` allows it)
- [ ] Manual: NFT with `image: "https://example.com/foo.png"` shows the placeholder, no network request to example.com
- [ ] Manual: NFT with `image: "data:image/png;base64,..."` renders inline

## Related

- Audit findings #1, #2, #3 from today's review
- Builds on #136 (NFT support) and #137 (IPFS proxy)