### PR TITLE
feat(footer): add Explorer link to footer nav

### DIFF
--- a/src/components/Core/Layout/Footer.tsx
+++ b/src/components/Core/Layout/Footer.tsx
@@ -1,3 +1,4 @@
+import { EXPLORER_BASE } from "@/config";
 import { ROUTES } from "@/router/router";
 import { useNavigate } from "react-router-dom";
 
@@ -16,6 +17,14 @@ export default function Footer() {
                 </a>
                 <a onClick={() => navigate(ROUTES.TERMS)} className="text-xs md:text-sm cursor-pointer text-muted-foreground hover:text-foreground transition-colors">
                     Terms
+                </a>
+                <a
+                    href={EXPLORER_BASE}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-xs md:text-sm cursor-pointer text-muted-foreground hover:text-foreground transition-colors"
+                >
+                    Explorer
                 </a>
             </div>
         </footer>


### PR DESCRIPTION
## Summary
- Adds an **Explorer** entry to the fixed bottom footer alongside Home/Privacy/Terms.
- Links to `EXPLORER_BASE` from `@/config` (resolves to `https://zondscan.com` by default, or whatever `VITE_EXPLORER_URL_*` is set to in the env).
- Opens in a new tab with `rel="noopener noreferrer"`.

## Test plan
- [ ] `npm run dev` — Explorer link visible in footer on desktop + mobile widths
- [ ] Clicking Explorer opens `zondscan.com` (or env-configured URL) in a new tab
- [ ] Home/Privacy/Terms still navigate within the app (no regression)
- [ ] `npm run lint` + `tsc --noEmit` + `npm run build` clean (verified locally)