### PR TITLE
feat(discovery): scope tokens to ERC-20 + opt-in NFT discovery scaffold

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -6,4 +6,5 @@ export {
   getExplorerTxUrl,
   getPendingTxApiUrl,
   getTokenDiscoveryApiUrl,
+  getNFTDiscoveryApiUrl,
 } from './networks';

--- a/src/config/networks.ts
+++ b/src/config/networks.ts
@@ -50,8 +50,23 @@ export const getPendingTxApiUrl = (blockchain: string) => {
   return `${provider.explorer}/api/pending-transactions`;
 };
 
-// Get API endpoint for token discovery by address
+// Get API endpoint for token discovery by address. Phase 3b on zondscan
+// added a `?standard=` filter; we scope to ERC-20 so this endpoint only
+// returns fungibles. Without the filter the response also includes one
+// row per (NFT contract, tokenID) the address holds, and the wallet's
+// ERC-20-aware renderer treats those as 18-decimal fungibles and shows
+// "Amount: 0" for every NFT row.
 export const getTokenDiscoveryApiUrl = (address: string, blockchain: string) => {
   const provider = QRL_PROVIDER[blockchain as keyof typeof QRL_PROVIDER];
-  return `${provider.explorer}/api/address/${address}/tokens`;
+  return `${provider.explorer}/api/address/${address}/tokens?standard=ERC-20`;
+};
+
+// Get API endpoint for NFT discovery by address. The /nfts endpoint
+// returns per-(contract, tokenID) rows joined with collection-level
+// metadata (collectionName / collectionSymbol) AND per-token metadata
+// from Phase 3b (name / image / description / attributes), so a single
+// call powers the wallet's NFT picker with thumbnails and names.
+export const getNFTDiscoveryApiUrl = (address: string, blockchain: string) => {
+  const provider = QRL_PROVIDER[blockchain as keyof typeof QRL_PROVIDER];
+  return `${provider.explorer}/api/address/${address}/nfts`;
 };

--- a/src/stores/nftStore.ts
+++ b/src/stores/nftStore.ts
@@ -121,6 +121,9 @@ class NftStore {
     runInAction(() => {
       this.nftList = persisted;
       this.hiddenNfts = hidden;
+      // Discovered list is per-address; drop it so a picker opened
+      // after the switch can't leak the prior account's results.
+      this.discoveredNfts = [];
     });
   }
 
@@ -400,6 +403,12 @@ class NftStore {
       log("Cannot discover NFTs: no blockchain selected");
       return [];
     }
+    // Synchronously reset before the await so any picker that observes
+    // pendingDiscoveredNfts while the fetch is in flight sees an empty
+    // list, not a stale one from a prior account or connection.
+    runInAction(() => {
+      this.discoveredNfts = [];
+    });
     try {
       const discovered = await discoverNFTs(address, blockchain);
       runInAction(() => {
@@ -419,22 +428,21 @@ class NftStore {
 
   /**
    * Explicit opt-in: merge the user-selected subset of discoveredNfts
-   * into the persistent gallery. addNft is per-row idempotent so picks
-   * that are already present become no-ops.
+   * into the persistent gallery. Dedupes against the existing list by
+   * (contract, tokenID) so a pick already in the gallery is a no-op,
+   * and writes the merged list in a single setNftList call.
    */
   async addDiscoveredNfts(picks: NFTInterface[]) {
     if (picks.length === 0) return;
-    let added = 0;
-    for (const n of picks) {
-      const beforeLen = this.nftList.length;
-      await this.addNft(n);
-      if (this.nftList.length > beforeLen) {
-        added++;
-      }
-    }
-    if (added > 0) {
-      log(`Added ${added} discovered NFTs to gallery`);
-    }
+    const owned = new Set(
+      this.nftList.map((n) => nftKey(n.contractAddress, n.tokenId)),
+    );
+    const additions = picks.filter(
+      (n) => !owned.has(nftKey(n.contractAddress, n.tokenId)),
+    );
+    if (additions.length === 0) return;
+    await this.setNftList([...this.nftList, ...additions]);
+    log(`Added ${additions.length} discovered NFTs to gallery`);
   }
 
   clearDiscoveredNfts() {

--- a/src/stores/nftStore.ts
+++ b/src/stores/nftStore.ts
@@ -18,6 +18,7 @@ import {
   isErc721Owner,
   nftKey,
 } from "@/utils/web3/nft";
+import { discoverNFTs } from "@/utils/web3";
 import type QrlStore from "./qrlStore";
 import type TokenStore from "./tokenStore";
 import { applyFeeLevel, type FeeLevel } from "./qrlStore";
@@ -25,6 +26,12 @@ import { applyFeeLevel, type FeeLevel } from "./qrlStore";
 class NftStore {
   nftList: NFTInterface[] = [];
   hiddenNfts: string[] = [];
+  // Phase 3b opt-in: the explorer's view of what NFTs this address
+  // holds. Populated by discoverNftsForReview(); never auto-merged into
+  // nftList. The UI renders pendingDiscoveredNfts as picker rows so a
+  // spam-airdropped NFT can't land in the gallery without an explicit
+  // user pick.
+  discoveredNfts: NFTInterface[] = [];
 
   constructor(
     private qrlStore: QrlStore,
@@ -36,7 +43,9 @@ class NftStore {
     makeAutoObservable(this, {
       nftList: observable.struct,
       hiddenNfts: observable,
+      discoveredNfts: observable.struct,
       visibleNftList: computed,
+      pendingDiscoveredNfts: computed,
       initialize: action.bound,
       handleActiveAccountChanged: action.bound,
       addNft: action.bound,
@@ -47,6 +56,9 @@ class NftStore {
       setNftList: action.bound,
       refreshNftBalances: action.bound,
       transferNft: action.bound,
+      discoverNftsForReview: action.bound,
+      addDiscoveredNfts: action.bound,
+      clearDiscoveredNfts: action.bound,
     });
     void this.tokenStore;
     log("NftStore initialized");
@@ -59,6 +71,20 @@ class NftStore {
           (k) =>
             k.toLowerCase() === nftKey(nft.contractAddress, nft.tokenId),
         ),
+    );
+  }
+
+  // Discovered NFTs minus the ones already in the user's saved gallery.
+  // The "Add NFT" picker renders this list so previously-added items
+  // don't reappear as suggestions.
+  get pendingDiscoveredNfts(): NFTInterface[] {
+    const owned = new Set(
+      this.nftList.map((n) =>
+        nftKey(n.contractAddress, n.tokenId).toLowerCase(),
+      ),
+    );
+    return this.discoveredNfts.filter(
+      (n) => !owned.has(nftKey(n.contractAddress, n.tokenId).toLowerCase()),
     );
   }
 
@@ -359,6 +385,62 @@ class NftStore {
       });
       return false;
     }
+  }
+
+  /**
+   * Phase 3b opt-in: populate `discoveredNfts` with what the explorer
+   * sees this address holding, without auto-merging. The UI reads
+   * pendingDiscoveredNfts to render an "Add NFT" picker; the user then
+   * calls addDiscoveredNfts(picks). Returns the discovered list so
+   * callers can render counts inline.
+   */
+  async discoverNftsForReview(address: string): Promise<NFTInterface[]> {
+    const blockchain = this.qrlStore.qrlConnection.blockchain;
+    if (!blockchain) {
+      log("Cannot discover NFTs: no blockchain selected");
+      return [];
+    }
+    try {
+      const discovered = await discoverNFTs(address, blockchain);
+      runInAction(() => {
+        this.discoveredNfts = discovered;
+      });
+      log(`NFT discovery for review: ${discovered.length} NFTs on ${address}`);
+      return discovered;
+    } catch (error) {
+      console.error("discoverNftsForReview:", error);
+      log(`discoverNftsForReview failed: ${error}`);
+      runInAction(() => {
+        this.discoveredNfts = [];
+      });
+      return [];
+    }
+  }
+
+  /**
+   * Explicit opt-in: merge the user-selected subset of discoveredNfts
+   * into the persistent gallery. addNft is per-row idempotent so picks
+   * that are already present become no-ops.
+   */
+  async addDiscoveredNfts(picks: NFTInterface[]) {
+    if (picks.length === 0) return;
+    let added = 0;
+    for (const n of picks) {
+      const beforeLen = this.nftList.length;
+      await this.addNft(n);
+      if (this.nftList.length > beforeLen) {
+        added++;
+      }
+    }
+    if (added > 0) {
+      log(`Added ${added} discovered NFTs to gallery`);
+    }
+  }
+
+  clearDiscoveredNfts() {
+    runInAction(() => {
+      this.discoveredNfts = [];
+    });
   }
 }
 

--- a/src/stores/tokenStore.ts
+++ b/src/stores/tokenStore.ts
@@ -139,6 +139,9 @@ class TokenStore {
     await StorageUtil.clearTokenList();
     runInAction(() => {
       this.tokenList = [];
+      // Discovered list is per-address; drop it so a picker opened
+      // after the switch can't leak the prior account's results.
+      this.discoveredTokens = [];
     });
 
     for (const token of KNOWN_TOKEN_LIST) {
@@ -594,6 +597,12 @@ class TokenStore {
       log("Cannot discover tokens: no blockchain selected");
       return [];
     }
+    // Synchronously reset before the await so any picker that observes
+    // pendingDiscoveredTokens while the fetch is in flight sees an
+    // empty list, not a stale one from a prior account or connection.
+    runInAction(() => {
+      this.discoveredTokens = [];
+    });
     try {
       const discovered = await discoverTokens(address, blockchain);
       runInAction(() => {

--- a/src/stores/tokenStore.ts
+++ b/src/stores/tokenStore.ts
@@ -47,6 +47,12 @@ class TokenStore {
   };
   tokenList: TokenInterface[] = [];
   hiddenTokens: string[] = [];
+  // Phase 3b opt-in: the explorer's view of what this address holds.
+  // Populated by discoverTokensForReview(); never auto-merged into
+  // tokenList. The UI surfaces these as picker rows ("Explorer
+  // recognized N tokens, add?") so spam-airdropped tokens can't sneak
+  // onto the dashboard without an explicit user pick.
+  discoveredTokens: TokenInterface[] = [];
 
   constructor(private qrlStore: QrlStore) {
     makeAutoObservable(this, {
@@ -54,7 +60,9 @@ class TokenStore {
       createdToken: observable.struct,
       tokenList: observable.struct,
       hiddenTokens: observable,
+      discoveredTokens: observable.struct,
       visibleTokenList: computed,
+      pendingDiscoveredTokens: computed,
       setCreatingToken: action.bound,
       setCreatedToken: action.bound,
       addToken: action.bound,
@@ -65,6 +73,9 @@ class TokenStore {
       createToken: action.bound,
       refreshTokenBalances: action.bound,
       discoverAndAddTokens: action.bound,
+      discoverTokensForReview: action.bound,
+      addDiscoveredTokens: action.bound,
+      clearDiscoveredTokens: action.bound,
       loadHiddenTokens: action.bound,
       hideToken: action.bound,
       unhideToken: action.bound,
@@ -81,6 +92,20 @@ class TokenStore {
         !this.hiddenTokens.some(
           (hidden) => hidden.toLowerCase() === token.address.toLowerCase(),
         ),
+    );
+  }
+
+  // Discovered tokens minus the ones the user has already added.
+  // The "Add token" picker renders this filtered list so previously-added
+  // entries don't reappear as suggestions. Lowercased comparison because
+  // the explorer normalises to Q-prefix lowercase and a user's manual
+  // entries might be mixed case.
+  get pendingDiscoveredTokens(): TokenInterface[] {
+    const owned = new Set(
+      this.tokenList.map((t) => t.address.toLowerCase()),
+    );
+    return this.discoveredTokens.filter(
+      (t) => !owned.has(t.address.toLowerCase()),
     );
   }
 
@@ -523,6 +548,12 @@ class TokenStore {
     }
   }
 
+  // Legacy auto-merge flow. Still wired into the Tokens-page refresh
+  // button which intentionally rebuilds the list from chain state. New
+  // UI flows should prefer discoverTokensForReview + addDiscoveredTokens
+  // for an opt-in picker. The discovery URL now scopes to
+  // standard=ERC-20, so this no longer auto-merges NFT rows, but it
+  // still doesn't gate against spam-airdrop tokens.
   async discoverAndAddTokens(address: string) {
     try {
       const blockchain = this.qrlStore.qrlConnection.blockchain;
@@ -550,6 +581,58 @@ class TokenStore {
       console.error("Error discovering tokens:", error);
       log(`Token discovery failed: ${error}`);
     }
+  }
+
+  // Phase 3b opt-in discovery: populate `discoveredTokens` with whatever
+  // the explorer can see on this address, without auto-merging. The UI
+  // reads pendingDiscoveredTokens to render an "Add token" picker; the
+  // user then calls addDiscoveredTokens(picks) with the ones they want.
+  // Returns the discovered list so callers can render counts inline.
+  async discoverTokensForReview(address: string): Promise<TokenInterface[]> {
+    const blockchain = this.qrlStore.qrlConnection.blockchain;
+    if (!blockchain) {
+      log("Cannot discover tokens: no blockchain selected");
+      return [];
+    }
+    try {
+      const discovered = await discoverTokens(address, blockchain);
+      runInAction(() => {
+        this.discoveredTokens = discovered;
+      });
+      log(
+        `Token discovery for review: ${discovered.length} fungibles on ${address}`,
+      );
+      return discovered;
+    } catch (error) {
+      console.error("discoverTokensForReview:", error);
+      log(`discoverTokensForReview failed: ${error}`);
+      runInAction(() => {
+        this.discoveredTokens = [];
+      });
+      return [];
+    }
+  }
+
+  // Explicit opt-in: merge the user-selected subset of discoveredTokens
+  // into the persistent tokenList. Address-dedupes (lowercase) so a
+  // pick that's already in the list is a no-op rather than a duplicate.
+  async addDiscoveredTokens(picks: TokenInterface[]) {
+    if (picks.length === 0) return;
+    const owned = new Set(
+      this.tokenList.map((t) => t.address.toLowerCase()),
+    );
+    const additions = picks.filter(
+      (t) => !owned.has(t.address.toLowerCase()),
+    );
+    if (additions.length === 0) return;
+    await this.setTokenList([...this.tokenList, ...additions]);
+    log(`Added ${additions.length} discovered tokens to user list`);
+  }
+
+  clearDiscoveredTokens() {
+    runInAction(() => {
+      this.discoveredTokens = [];
+    });
   }
 
   async loadHiddenTokens() {

--- a/src/utils/web3/index.ts
+++ b/src/utils/web3/index.ts
@@ -13,3 +13,7 @@ export {
   discoverTokens,
   mergeTokenLists,
 } from './tokenDiscovery';
+
+export {
+  discoverNFTs,
+} from './nftDiscovery';

--- a/src/utils/web3/nftDiscovery.ts
+++ b/src/utils/web3/nftDiscovery.ts
@@ -1,0 +1,102 @@
+import { getNFTDiscoveryApiUrl } from "@/config";
+import { NFTInterface } from "@/constants";
+import { log } from "@/utils";
+
+// One row of the zondscan /api/address/:addr/nfts response. Shape mirrors
+// backendAPI/models/token_balance.go:NFTBalance. Mostly optional because
+// the per-token tokenMetadata fetcher may not have resolved yet for a
+// freshly-minted NFT.
+interface ExplorerNFT {
+  contractAddress: string;
+  holderAddress: string;
+  tokenID: string;
+  tokenStandard: "ERC-721" | "ERC-1155" | string;
+  balance?: string;
+  blockNumber?: string;
+  updatedAt?: string;
+  collectionName?: string;
+  collectionSymbol?: string;
+  name?: string;
+  description?: string;
+  image?: string;
+  externalURL?: string;
+  attributes?: Array<{ trait_type: string; value: string; display_type?: string }>;
+}
+
+interface ExplorerNFTResponse {
+  address: string;
+  nfts: ExplorerNFT[];
+  count: number;
+}
+
+// The wallet stores NftStandard as "ERC721" / "ERC1155" (no hyphen);
+// the explorer returns "ERC-721" / "ERC-1155". Normalise on the wire.
+function normaliseStandard(s: string): "ERC721" | "ERC1155" | null {
+  if (s === "ERC-721" || s === "ERC721") return "ERC721";
+  if (s === "ERC-1155" || s === "ERC1155") return "ERC1155";
+  return null;
+}
+
+/**
+ * Discovers NFTs held by an address using the explorer's
+ * /address/:addr/nfts endpoint. The endpoint joins both the
+ * collection-level row (collectionName, collectionSymbol) and the
+ * per-token metadata row (name, image, description, attributes) so a
+ * single call has enough to render a picker with thumbnails.
+ *
+ * Returns an empty list on any error or non-2xx so a flaky explorer
+ * call can't crash the wallet UI.
+ */
+export async function discoverNFTs(
+  address: string,
+  blockchain: string,
+): Promise<NFTInterface[]> {
+  try {
+    const apiUrl = getNFTDiscoveryApiUrl(address, blockchain);
+    log(`Discovering NFTs for ${address} from ${apiUrl}`);
+
+    const response = await fetch(apiUrl);
+    if (!response.ok) {
+      if (response.status === 404) {
+        log(`No NFTs found for ${address}`);
+        return [];
+      }
+      throw new Error(`NFT discovery failed: ${response.statusText}`);
+    }
+
+    const data: ExplorerNFTResponse = await response.json();
+    if (!data || !Array.isArray(data.nfts)) {
+      log("Invalid NFT discovery response format");
+      return [];
+    }
+
+    const fetchedAt = Date.now();
+    const out: NFTInterface[] = [];
+    for (const n of data.nfts) {
+      const std = normaliseStandard(n.tokenStandard);
+      if (!std) continue;
+      if (!n.contractAddress || !n.tokenID) continue;
+      out.push({
+        contractAddress: n.contractAddress.startsWith("Q")
+          ? n.contractAddress
+          : `Q${n.contractAddress.replace(/^0x/i, "")}`,
+        standard: std,
+        tokenId: n.tokenID,
+        collectionName: n.collectionName || undefined,
+        collectionSymbol: n.collectionSymbol || undefined,
+        name: n.name || undefined,
+        description: n.description || undefined,
+        image: n.image || undefined,
+        balance: n.balance || undefined,
+        fetchedAt,
+      });
+    }
+
+    log(`Discovered ${out.length} NFTs for ${address}`);
+    return out;
+  } catch (error) {
+    console.error("Error discovering NFTs:", error);
+    log(`NFT discovery error: ${error}`);
+    return [];
+  }
+}

--- a/src/utils/web3/nftDiscovery.ts
+++ b/src/utils/web3/nftDiscovery.ts
@@ -3,9 +3,9 @@ import { NFTInterface } from "@/constants";
 import { log } from "@/utils";
 
 // One row of the zondscan /api/address/:addr/nfts response. Shape mirrors
-// backendAPI/models/token_balance.go:NFTBalance. Mostly optional because
-// the per-token tokenMetadata fetcher may not have resolved yet for a
-// freshly-minted NFT.
+// backendAPI/models/token_balance.go:NFTBalance, restricted to the
+// fields the wallet actually consumes. NFTInterface has no slot for
+// externalURL / attributes today, so they're dropped on the wire.
 interface ExplorerNFT {
   contractAddress: string;
   holderAddress: string;
@@ -19,8 +19,6 @@ interface ExplorerNFT {
   name?: string;
   description?: string;
   image?: string;
-  externalURL?: string;
-  attributes?: Array<{ trait_type: string; value: string; display_type?: string }>;
 }
 
 interface ExplorerNFTResponse {
@@ -79,7 +77,9 @@ export async function discoverNFTs(
       out.push({
         contractAddress: n.contractAddress.startsWith("Q")
           ? n.contractAddress
-          : `Q${n.contractAddress.replace(/^0x/i, "")}`,
+          : n.contractAddress.startsWith("q")
+            ? `Q${n.contractAddress.slice(1)}`
+            : `Q${n.contractAddress.replace(/^0x/i, "")}`,
         standard: std,
         tokenId: n.tokenID,
         collectionName: n.collectionName || undefined,


### PR DESCRIPTION
## Summary

Pairs with zondscan PRs [#100](https://github.com/DigitalGuards/zondscan/pull/100) and [#101](https://github.com/DigitalGuards/zondscan/pull/101). Two immediate fixes + a data-layer foundation for the opt-in picker UX.

### Immediate fix: "Amount: 0" on NFT rows

The wallet's `/api/address/:addr/tokens` call now appends `?standard=ERC-20` (Phase 3b filter on the explorer). The Tokens card no longer pulls in NFT rows that the ERC-20-aware renderer treated as zero-balance 18-decimal fungibles.

### New: NFT discovery via `/api/address/:addr/nfts`

New `discoverNFTs` util + `getNFTDiscoveryApiUrl` helper. Returns `NFTInterface[]` with per-token thumbnails, names, descriptions, and balance pre-resolved. Used by the new nftStore opt-in surface.

### New: opt-in pickers (data layer only, no UI)

Both `tokenStore` and `nftStore` grow:
- a `discoveredTokens` / `discoveredNfts` observable (populated, never auto-merged)
- a `pendingDiscoveredTokens` / `pendingDiscoveredNfts` computed that filters out things the user already has
- `discoverTokensForReview` / `discoverNftsForReview` to populate the observable
- `addDiscoveredTokens(picks)` / `addDiscoveredNfts(picks)` for explicit opt-in merge
- `clearDiscoveredTokens` / `clearDiscoveredNfts` to reset

The UI work to surface a picker modal ("want to import a token? select from the list or paste CA") is intentionally **out of scope** for this PR. The data layer is ready; wiring the picker happens in a follow-up.

### Why opt-in, not auto-merge

An attacker can airdrop a spam ERC-20 / NFT to any address. The current auto-merge flow imports any discovered token onto the dashboard. The picker pattern keeps spam off the dashboard unless the user explicitly picks it.

The legacy `discoverAndAddTokens` action is kept for the existing Tokens-page refresh button which intentionally rebuilds the list from chain state, commented as legacy with a pointer to the new flow.

## Test plan
- [x] `npm run lint` green
- [x] `npm run build` green
- [ ] Manual smoke once deployed: load the Tokens page on `Q6153d37fa4DA7193E6219DCBd2bBe62Fa12905b1` (has only NFTs, no ERC-20s). Tokens card should be empty (was previously showing ~9 NFTs as zero-balance fungibles).
- [ ] Manual: call `tokenStore.discoverTokensForReview(activeAccountAddress)` from the devtools console; observe `tokenStore.discoveredTokens.length === 0` for the same address.
- [ ] Manual: call `nftStore.discoverNftsForReview(activeAccountAddress)`; observe `nftStore.discoveredNfts.length === 9` with names + images on the 3 contracts with off-chain metadata.