### PR TITLE
feat(security): gate token auto-add on account switch

### DIFF
--- a/src/stores/tokenStore.ts
+++ b/src/stores/tokenStore.ts
@@ -125,17 +125,24 @@ class TokenStore {
   }
 
   // Called by Store after QrlStore.setActiveAccount finishes (via the
-  // qrlStore.onActiveAccountChanged hook). Mirrors the previous in-place
-  // logic that lived inside setActiveAccount.
+  // qrlStore.onActiveAccountChanged hook).
+  //
+  // Anti-spam gate: this method intentionally does NOT call the explorer
+  // to discover and auto-merge tokens. A silent merge would let any
+  // airdropped token (or compromised explorer response) land on the
+  // user's dashboard the moment they switched accounts, and renders the
+  // attacker-supplied name/symbol verbatim. Discovery is now strictly
+  // opt-in via discoverTokensForReview + the picker UI; KNOWN_TOKEN_LIST
+  // stays as the curated allowlist bypass.
   async handleActiveAccountChanged(newActiveAccount?: string) {
     if (!newActiveAccount) {
       log("Active account cleared, skipping token refresh.");
       return;
     }
 
-    log(`Fetching balances for newly active account: ${newActiveAccount}`);
-    // Clear token list before discovering tokens for the new account so
-    // tokens from inactive accounts don't show with 0 balance.
+    log(`Switching token list to account: ${newActiveAccount}`);
+    // Token storage is global (not per-account like NFTs), so we wipe
+    // on switch to prevent account A's tokens leaking into account B.
     await StorageUtil.clearTokenList();
     runInAction(() => {
       this.tokenList = [];
@@ -148,13 +155,9 @@ class TokenStore {
       await this.addToken(token);
     }
 
-    this.discoverAndAddTokens(newActiveAccount)
-      .then(() => {
-        void this.refreshTokenBalances();
-      })
-      .catch((error) => {
-        log(`Unexpected error during token discovery: ${error}`);
-      });
+    // Refresh balances on whatever is in the list now (KNOWN_TOKEN_LIST
+    // entries, or nothing). No explorer call.
+    void this.refreshTokenBalances();
   }
 
   async setCreatingToken(name: string, creating: boolean, error?: string) {


### PR DESCRIPTION
## Summary

Closes the silent auto-merge of explorer-discovered tokens on every account switch. Per the threat model:

- **Spam**: any airdrop landed on the dashboard the moment a user opened the affected account.
- **Phishing**: tokens render the attacker-supplied \`name\`/\`symbol\` verbatim.
- **Explorer trust**: a compromised or hostile explorer response was implicitly treated as \"your assets\".

\`tokenStore.handleActiveAccountChanged\` now wipes the global token list, reseeds \`KNOWN_TOKEN_LIST\` (curated allowlist, empty today), and refreshes balances on whatever remains. **No explorer call.**

Discovery isn't removed - it's just gated. The opt-in surface shipped in #141 (\`discoverTokensForReview\` -> \`pendingDiscoveredTokens\` -> user picks -> \`addDiscoveredTokens\`) is the only path tokens reach \`tokenList\` from the explorer. A picker UI will wire it up in a follow-up PR.

## What's deliberately untouched

- **TokenForm refresh button**: still calls \`discoverAndAddTokens\` (user-initiated; rewired to the picker in the next PR).
- **\`KNOWN_TOKEN_LIST\` seeding**: kept; this is the trusted bypass for curated AAA tokens.
- **Wipe-on-switch**: kept; token storage is global (not per-account like NFTs), so without wiping, account A's tokens follow you into B.
- **NFTs**: no change. \`nftStore\` already had no auto-discover path.

## Trade-off

Account switch produces an empty token list (or just \`KNOWN_TOKEN_LIST\`). The user has to manually add a contract or hit refresh - this is the intended security/UX trade. Per-account token storage scoping would obviate the wipe entirely; that's a larger refactor and a separate PR.

## Test plan

- [ ] Switch accounts in dev: token list goes empty (was: auto-filled). No network call to \`/api/address/.../tokens\` during the switch.
- [ ] Manually add a token via \"Add token\" -> appears in list -> survives a refresh.
- [ ] Press the Tokens-card refresh button -> legacy discoverAndAddTokens still works (out-of-scope sanity check).
- [ ] NFT panel unaffected.
- [x] \`npm run lint\` green
- [x] \`npx tsc --noEmit\` green
- [x] \`npm run build\` green

## Threat model fix

Closes the silent-merge vector. Spam-airdrop tokens can still **exist** on chain, but cannot reach the user's dashboard without an explicit user pick (or being added to the curated \`KNOWN_TOKEN_LIST\`).