### PR TITLE
feat(discovery): empty-state picker + hide-as-rediscoverable + race guards

### DIFF
--- a/src/components/Core/Body/Nfts/AddNftModal.tsx
+++ b/src/components/Core/Body/Nfts/AddNftModal.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from "react";
-import { Loader2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { observer } from "mobx-react-lite";
+import { Loader2, Sparkles } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -9,6 +10,7 @@ import {
   DialogTitle,
 } from "@/components/UI/Dialog";
 import { Button } from "@/components/UI/Button";
+import { Checkbox } from "@/components/UI/CheckBox";
 import { Input } from "@/components/UI/Input";
 import { Label } from "@/components/UI/Label";
 import { useStore } from "@/stores/store";
@@ -22,6 +24,7 @@ import {
   fetchErc1155Balance,
   fetchTokenUri,
   isErc721Owner,
+  nftKey,
   type NftCollectionInfo,
   type NftStandard,
 } from "@/utils/web3/nft";
@@ -33,9 +36,10 @@ interface AddNftModalProps {
   onClose: () => void;
 }
 
-export function AddNftModal({ isOpen, onClose }: AddNftModalProps) {
+export const AddNftModal = observer(({ isOpen, onClose }: AddNftModalProps) => {
   const { qrlStore, nftStore } = useStore();
   const { accountAddress } = qrlStore.activeAccount;
+  const { pendingDiscoveredNfts } = nftStore;
 
   const [contractAddress, setContractAddress] = useState("");
   const [tokenId, setTokenId] = useState("");
@@ -45,7 +49,9 @@ export function AddNftModal({ isOpen, onClose }: AddNftModalProps) {
   } | null>(null);
   const [isDetecting, setIsDetecting] = useState(false);
   const [isAdding, setIsAdding] = useState(false);
+  const [isAddingPicks, setIsAddingPicks] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     if (!isOpen) {
@@ -56,8 +62,68 @@ export function AddNftModal({ isOpen, onClose }: AddNftModalProps) {
       setError(null);
       setIsDetecting(false);
       setIsAdding(false);
+      setIsAddingPicks(false);
+      setSelectedKeys(new Set());
     }
   }, [isOpen]);
+
+  // Re-fire discovery on modal open so the picker is fresh even if the
+  // NftGallery card mounted long ago.
+  useEffect(() => {
+    if (!isOpen || !accountAddress) return;
+    void nftStore.discoverNftsForReview(accountAddress);
+  }, [isOpen, accountAddress, nftStore]);
+
+  // Lower-cased composite keys for the selection set, matching the
+  // store's dedupe.
+  const selectableKeys = useMemo(
+    () =>
+      pendingDiscoveredNfts.map((n) =>
+        nftKey(n.contractAddress, n.tokenId).toLowerCase(),
+      ),
+    [pendingDiscoveredNfts],
+  );
+
+  // Prune selections if a discovered NFT has since been added elsewhere.
+  useEffect(() => {
+    setSelectedKeys((prev) => {
+      const allow = new Set(selectableKeys);
+      const next = new Set<string>();
+      for (const k of prev) if (allow.has(k)) next.add(k);
+      return next.size === prev.size ? prev : next;
+    });
+  }, [selectableKeys]);
+
+  const toggleSelection = (n: NFTInterface) => {
+    const key = nftKey(n.contractAddress, n.tokenId).toLowerCase();
+    setSelectedKeys((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  const addSelected = async () => {
+    if (selectedKeys.size === 0) return;
+    setIsAddingPicks(true);
+    setError(null);
+    try {
+      const picks = pendingDiscoveredNfts.filter((n) =>
+        selectedKeys.has(nftKey(n.contractAddress, n.tokenId).toLowerCase()),
+      );
+      await nftStore.addDiscoveredNfts(picks);
+      setSelectedKeys(new Set());
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? `Failed to add picks: ${err.message}`
+          : "Failed to add picks.",
+      );
+    } finally {
+      setIsAddingPicks(false);
+    }
+  };
 
   // Re-run detection on contract-address change once the format looks valid.
   useEffect(() => {
@@ -241,7 +307,7 @@ export function AddNftModal({ isOpen, onClose }: AddNftModalProps) {
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="sm:max-w-[600px]">
+      <DialogContent className="sm:max-w-[600px] max-h-[85vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Add NFT</DialogTitle>
           <DialogDescription>
@@ -255,6 +321,84 @@ export function AddNftModal({ isOpen, onClose }: AddNftModalProps) {
             className="rounded-md bg-destructive/15 p-3 text-sm text-destructive"
           >
             {error}
+          </div>
+        )}
+
+        {pendingDiscoveredNfts.length > 0 && (
+          <div className="rounded-md border bg-muted/30 p-3">
+            <div className="mb-2 flex items-center gap-2 text-sm font-medium">
+              <Sparkles className="h-4 w-4 text-muted-foreground/70" />
+              Discovered NFTs ({pendingDiscoveredNfts.length})
+            </div>
+            <p className="mb-3 text-xs text-muted-foreground">
+              The explorer sees these on this address. Pick the ones to add;
+              the rest stay off your gallery.
+            </p>
+            <ul className="flex max-h-72 flex-col gap-2 overflow-y-auto">
+              {pendingDiscoveredNfts.map((n) => {
+                const key = nftKey(
+                  n.contractAddress,
+                  n.tokenId,
+                ).toLowerCase();
+                const checked = selectedKeys.has(key);
+                const titleLine =
+                  n.name ||
+                  `${n.collectionName || "Unknown collection"} #${n.tokenId}`;
+                return (
+                  <li
+                    key={key}
+                    className="flex items-center gap-3 rounded-md border bg-background p-2"
+                  >
+                    <Checkbox
+                      id={`discovered-nft-${key}`}
+                      checked={checked}
+                      onCheckedChange={() => toggleSelection(n)}
+                      disabled={isAddingPicks}
+                    />
+                    {n.image ? (
+                      <img
+                        src={n.image}
+                        alt=""
+                        className="h-10 w-10 shrink-0 rounded object-cover"
+                        loading="lazy"
+                      />
+                    ) : (
+                      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded bg-muted text-muted-foreground">
+                        <Sparkles className="h-4 w-4" />
+                      </div>
+                    )}
+                    <Label
+                      htmlFor={`discovered-nft-${key}`}
+                      className="flex flex-1 cursor-pointer flex-col gap-0.5"
+                    >
+                      <span className="text-sm font-medium">{titleLine}</span>
+                      <span className="text-xs text-muted-foreground">
+                        {n.standard} · #{n.tokenId}
+                        {n.balance && n.standard === "ERC1155"
+                          ? ` · ×${n.balance}`
+                          : ""}
+                      </span>
+                    </Label>
+                  </li>
+                );
+              })}
+            </ul>
+            <Button
+              type="button"
+              size="sm"
+              className="mt-3 w-full"
+              disabled={selectedKeys.size === 0 || isAddingPicks}
+              onClick={addSelected}
+            >
+              {isAddingPicks ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Adding…
+                </>
+              ) : (
+                <>Add Selected ({selectedKeys.size})</>
+              )}
+            </Button>
           </div>
         )}
 
@@ -343,4 +487,4 @@ export function AddNftModal({ isOpen, onClose }: AddNftModalProps) {
       </DialogContent>
     </Dialog>
   );
-}
+});

--- a/src/components/Core/Body/Nfts/NftGallery.tsx
+++ b/src/components/Core/Body/Nfts/NftGallery.tsx
@@ -19,7 +19,8 @@ import { NftCard } from "./NftCard";
 import { AddNftModal } from "./AddNftModal";
 
 const NftGallery = observer(() => {
-  const { nftStore } = useStore();
+  const { qrlStore, nftStore } = useStore();
+  const { accountAddress: activeAccountAddress } = qrlStore.activeAccount;
   const [isAddOpen, setIsAddOpen] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
 
@@ -28,6 +29,14 @@ const NftGallery = observer(() => {
   useEffect(() => {
     void nftStore.refreshNftBalances();
   }, [nftStore]);
+
+  // Populate the discovery cache so the empty-state can say "Explorer
+  // found N NFTs" and the AddNftModal can offer a picker. Does NOT
+  // auto-merge into nftList — the user has to explicitly pick.
+  useEffect(() => {
+    if (!activeAccountAddress) return;
+    void nftStore.discoverNftsForReview(activeAccountAddress);
+  }, [activeAccountAddress, nftStore]);
 
   const onRefresh = async () => {
     setIsRefreshing(true);
@@ -79,7 +88,10 @@ const NftGallery = observer(() => {
       </CardHeader>
       <CardContent>
         {nfts.length === 0 ? (
-          <EmptyState onAdd={() => setIsAddOpen(true)} />
+          <EmptyState
+            onAdd={() => setIsAddOpen(true)}
+            discoveredCount={nftStore.pendingDiscoveredNfts.length}
+          />
         ) : (
           <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4">
             {nfts.map((nft) => (
@@ -96,19 +108,31 @@ const NftGallery = observer(() => {
   );
 });
 
-function EmptyState({ onAdd }: { onAdd: () => void }) {
+function EmptyState({
+  onAdd,
+  discoveredCount,
+}: {
+  onAdd: () => void;
+  discoveredCount: number;
+}) {
   return (
     <div className="flex flex-col items-center justify-center gap-3 py-8 text-center">
       <Sparkles className="h-10 w-10 text-muted-foreground/50" />
       <div>
-        <p className="text-sm font-medium">No collectibles yet</p>
+        <p className="text-sm font-medium">
+          {discoveredCount > 0
+            ? `Explorer found this address to own ${discoveredCount} NFT${discoveredCount === 1 ? "" : "s"}.`
+            : "No collectibles yet"}
+        </p>
         <p className="text-xs text-muted-foreground">
-          Paste an ERC-721 or ERC-1155 contract address to add one.
+          {discoveredCount > 0
+            ? "Pick the ones to add to your gallery, or paste a contract address."
+            : "Paste an ERC-721 or ERC-1155 contract address to add one."}
         </p>
       </div>
       <Button variant="outline" size="sm" onClick={onAdd}>
         <Plus className="mr-2 h-4 w-4" />
-        Add NFT
+        {discoveredCount > 0 ? "Review and add" : "Add NFT"}
       </Button>
     </div>
   );

--- a/src/components/Core/Body/Tokens/AddTokenModal/AddTokenModal.tsx
+++ b/src/components/Core/Body/Tokens/AddTokenModal/AddTokenModal.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/UI/Button"
+import { Checkbox } from "@/components/UI/CheckBox"
 import {
     Dialog,
     DialogContent,
@@ -9,21 +10,82 @@ import {
 } from "@/components/UI/Dialog"
 import { Input } from "@/components/UI/Input"
 import { Label } from "@/components/UI/Label"
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { observer } from "mobx-react-lite";
+import { Loader2, Sparkles } from "lucide-react";
 import { useStore } from "@/stores/store";
 import { fetchTokenInfo, fetchBalance } from "@/utils/web3";
 import { TokenInterface } from "@/constants";
 import { QRL_PROVIDER } from "@/config";
 import { StorageUtil } from "@/utils/storage";
 
-export function AddTokenModal({ isOpen, onClose }: { isOpen: boolean, onClose: () => void }) {
+export const AddTokenModal = observer(({ isOpen, onClose }: { isOpen: boolean, onClose: () => void }) => {
     const { qrlStore, tokenStore } = useStore();
-    const { addToken: addTokenToStore } = tokenStore;
+    const { addToken: addTokenToStore, pendingDiscoveredTokens } = tokenStore;
     const { accountAddress: activeAccountAddress } = qrlStore.activeAccount;
     const [tokenAddress, setTokenAddress] = useState("");
     const [tokenInfo, setTokenInfo] = useState<TokenInterface | null>(null);
     const [isLoading, setIsLoading] = useState(false);
+    const [isAddingPicks, setIsAddingPicks] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const [selectedAddresses, setSelectedAddresses] = useState<Set<string>>(new Set());
+
+    // Re-fire discovery whenever the modal opens so the picker can't go
+    // stale if the card mounted long ago. Drops selection state on reopen.
+    useEffect(() => {
+        if (!isOpen || !activeAccountAddress) return;
+        setSelectedAddresses(new Set());
+        void tokenStore.discoverTokensForReview(activeAccountAddress);
+    }, [isOpen, activeAccountAddress, tokenStore]);
+
+    // pendingDiscoveredTokens filters out already-added tokens. Lower-cased
+    // address keys for selection so the picker matches the store's dedupe.
+    const selectableAddresses = useMemo(
+        () => pendingDiscoveredTokens.map((t) => t.address.toLowerCase()),
+        [pendingDiscoveredTokens],
+    );
+
+    // Prune selectedAddresses if a discovered token has since been added
+    // elsewhere — keeps the "Add Selected (n)" count honest.
+    useEffect(() => {
+        setSelectedAddresses((prev) => {
+            const allow = new Set(selectableAddresses);
+            const next = new Set<string>();
+            for (const a of prev) if (allow.has(a)) next.add(a);
+            return next.size === prev.size ? prev : next;
+        });
+    }, [selectableAddresses]);
+
+    const toggleSelection = (address: string) => {
+        const key = address.toLowerCase();
+        setSelectedAddresses((prev) => {
+            const next = new Set(prev);
+            if (next.has(key)) next.delete(key);
+            else next.add(key);
+            return next;
+        });
+    };
+
+    const addSelected = async () => {
+        if (selectedAddresses.size === 0) return;
+        setIsAddingPicks(true);
+        setError(null);
+        try {
+            const picks = pendingDiscoveredTokens.filter((t) =>
+                selectedAddresses.has(t.address.toLowerCase()),
+            );
+            await tokenStore.addDiscoveredTokens(picks);
+            setSelectedAddresses(new Set());
+        } catch (err) {
+            setError(
+                err instanceof Error
+                    ? `Failed to add picks: ${err.message}`
+                    : "Failed to add picks.",
+            );
+        } finally {
+            setIsAddingPicks(false);
+        }
+    };
 
     const addToken = async () => {
         setError(null);
@@ -68,7 +130,7 @@ export function AddTokenModal({ isOpen, onClose }: { isOpen: boolean, onClose: (
 
     return (
         <Dialog open={isOpen} onOpenChange={onClose}>
-            <DialogContent className="sm:max-w-[600px]">
+            <DialogContent className="sm:max-w-[600px] max-h-[85vh] overflow-y-auto">
                 <DialogHeader>
                     <DialogTitle>Add Token</DialogTitle>
                     <DialogDescription>
@@ -80,6 +142,68 @@ export function AddTokenModal({ isOpen, onClose }: { isOpen: boolean, onClose: (
                         {error}
                     </div>
                 )}
+
+                {pendingDiscoveredTokens.length > 0 && (
+                    <div className="rounded-md border bg-muted/30 p-3">
+                        <div className="mb-2 flex items-center gap-2 text-sm font-medium">
+                            <Sparkles className="h-4 w-4 text-muted-foreground/70" />
+                            Discovered tokens ({pendingDiscoveredTokens.length})
+                        </div>
+                        <p className="mb-3 text-xs text-muted-foreground">
+                            The explorer sees these on this address. Pick the ones you trust; the rest stay off your dashboard.
+                        </p>
+                        <ul className="flex max-h-60 flex-col gap-2 overflow-y-auto">
+                            {pendingDiscoveredTokens.map((t) => {
+                                const key = t.address.toLowerCase();
+                                const checked = selectedAddresses.has(key);
+                                return (
+                                    <li
+                                        key={key}
+                                        className="flex items-center gap-3 rounded-md border bg-background p-2"
+                                    >
+                                        <Checkbox
+                                            id={`discovered-${key}`}
+                                            checked={checked}
+                                            onCheckedChange={() => toggleSelection(t.address)}
+                                            disabled={isAddingPicks}
+                                        />
+                                        <Label
+                                            htmlFor={`discovered-${key}`}
+                                            className="flex flex-1 cursor-pointer flex-col gap-0.5"
+                                        >
+                                            <span className="text-sm font-medium">
+                                                {t.name || "Unknown"}{" "}
+                                                <span className="text-muted-foreground">
+                                                    ({t.symbol || "UNK"})
+                                                </span>
+                                            </span>
+                                            <span className="break-all font-mono text-xs text-muted-foreground">
+                                                {t.address}
+                                            </span>
+                                        </Label>
+                                    </li>
+                                );
+                            })}
+                        </ul>
+                        <Button
+                            type="button"
+                            size="sm"
+                            className="mt-3 w-full"
+                            disabled={selectedAddresses.size === 0 || isAddingPicks}
+                            onClick={addSelected}
+                        >
+                            {isAddingPicks ? (
+                                <>
+                                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                    Adding…
+                                </>
+                            ) : (
+                                <>Add Selected ({selectedAddresses.size})</>
+                            )}
+                        </Button>
+                    </div>
+                )}
+
                 <div className="flex flex-col">
                     <Label htmlFor="name" className="mb-2">
                         Token Contract Address
@@ -121,4 +245,4 @@ export function AddTokenModal({ isOpen, onClose }: { isOpen: boolean, onClose: (
             </DialogContent>
         </Dialog>
     )
-}
+});

--- a/src/components/Core/Body/Tokens/TokenForm/TokenForm.tsx
+++ b/src/components/Core/Body/Tokens/TokenForm/TokenForm.tsx
@@ -12,7 +12,7 @@ import { useEffect, useState } from "react";
 import { fetchBalance } from "@/utils/web3";
 import { useStore } from "@/stores/store";
 import { Button } from "@/components/UI/Button";
-import { Loader2, Plus, RefreshCw, Import, Coins } from "lucide-react";
+import { Loader2, Plus, RefreshCw, Import, Coins, Sparkles } from "lucide-react";
 import { AddTokenModal } from "../AddTokenModal/AddTokenModal";
 import { formatUnits } from "ethers";
 import { QRL_PROVIDER } from "@/config";
@@ -38,28 +38,21 @@ const TokenForm = observer(() => {
     const { qrlStore, tokenStore } = useStore();
     const navigate = useNavigate();
     const { accountAddress: activeAccountAddress } = qrlStore.activeAccount;
-    const { visibleTokenList } = tokenStore;
+    const { visibleTokenList, pendingDiscoveredTokens } = tokenStore;
 
     const [tokenList, setTokenList] = useState<TokenInterface[]>(visibleTokenList);
     const [isAddTokenModalOpen, setIsAddTokenModalOpen] = useState(false);
     const [isLoading, setIsLoading] = useState(true);
     const [isRefreshing, setIsRefreshing] = useState(false);
 
+    // Refresh balances of the tokens already in the user's list. Does NOT
+    // re-discover from the explorer — that would re-introduce the spam
+    // vector the gate (PR #142) closes. To find tokens the explorer sees
+    // but the user hasn't added, open "Add Existing Token" — the modal
+    // surfaces a picker built from pendingDiscoveredTokens.
     const refreshTokens = async () => {
         setIsRefreshing(true);
         try {
-            // Clear hidden tokens so they reappear
-            await StorageUtil.clearHiddenTokens();
-            await tokenStore.loadHiddenTokens();
-
-            // Clear existing token list to prevent tokens from other accounts showing
-            await StorageUtil.clearTokenList();
-            await tokenStore.setTokenList([]);
-
-            // Discover tokens for the active account only
-            await tokenStore.discoverAndAddTokens(activeAccountAddress);
-
-            // Then refresh all balances
             await tokenStore.refreshTokenBalances();
         } catch (error) {
             console.error("Failed to refresh tokens:", error);
@@ -67,6 +60,16 @@ const TokenForm = observer(() => {
             setIsRefreshing(false);
         }
     };
+
+    // Populate the discovery cache so the empty-state ("Explorer found N
+    // tokens") and the AddTokenModal picker have data without any user
+    // gesture. The result lands in tokenStore.discoveredTokens, NOT
+    // tokenList — adding to the live list still requires an explicit
+    // pick.
+    useEffect(() => {
+        if (!activeAccountAddress) return;
+        void tokenStore.discoverTokensForReview(activeAccountAddress);
+    }, [activeAccountAddress, tokenStore]);
 
     useEffect(() => {
         const init = async () => {
@@ -122,7 +125,7 @@ const TokenForm = observer(() => {
                                 </Button>
                             </TooltipTrigger>
                             <TooltipContent>
-                                <p>Refresh balances and show hidden tokens</p>
+                                <p>Refresh balances of imported tokens</p>
                             </TooltipContent>
                         </Tooltip>
                     </TooltipProvider>
@@ -146,7 +149,34 @@ const TokenForm = observer(() => {
                 </div>
             </CardHeader>
             <CardContent>
-                <DataTable columns={columns} data={tokenList} isLoading={isLoading} />
+                <DataTable
+                    columns={columns}
+                    data={tokenList}
+                    isLoading={isLoading}
+                    emptyMessage={
+                        pendingDiscoveredTokens.length > 0 ? (
+                            <div className="flex flex-col items-center gap-2 py-2">
+                                <div className="flex items-center gap-2 text-sm">
+                                    <Sparkles className="h-4 w-4 text-muted-foreground/70" />
+                                    Explorer found this address to own{" "}
+                                    <span className="font-medium">
+                                        {pendingDiscoveredTokens.length}
+                                    </span>{" "}
+                                    token
+                                    {pendingDiscoveredTokens.length === 1 ? "" : "s"}.
+                                </div>
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() => setIsAddTokenModalOpen(true)}
+                                >
+                                    <Plus className="mr-2 h-4 w-4" />
+                                    Review and add
+                                </Button>
+                            </div>
+                        ) : undefined
+                    }
+                />
             </CardContent>
             <AddTokenModal isOpen={isAddTokenModalOpen} onClose={() => setIsAddTokenModalOpen(false)} />
         </Card>

--- a/src/components/Core/Body/Tokens/TokenForm/data-table.tsx
+++ b/src/components/Core/Body/Tokens/TokenForm/data-table.tsx
@@ -13,7 +13,7 @@ import {
     TableHeader,
     TableRow,
 } from "@/components/UI/table"
-import { useEffect } from "react";
+import { useEffect, type ReactNode } from "react";
 import { TokenInterface } from "@/constants";
 import { Loader2 } from "lucide-react";
 import { useNavigate } from "react-router-dom";
@@ -23,12 +23,14 @@ interface DataTableProps<TData, TValue> {
     columns: ColumnDef<TData, TValue>[]
     data: TData[]
     isLoading?: boolean
+    emptyMessage?: ReactNode
 }
 
 export function DataTable<TData, TValue>({
     columns,
     data,
     isLoading = false,
+    emptyMessage,
 }: DataTableProps<TData, TValue>) {
     const navigate = useNavigate();
     const table = useReactTable({
@@ -110,7 +112,7 @@ export function DataTable<TData, TValue>({
                     ) : (
                         <TableRow>
                             <TableCell colSpan={columns.length} className="h-24 text-center">
-                                No tokens currently added or created.
+                                {emptyMessage ?? "No tokens currently added or created."}
                             </TableCell>
                         </TableRow>
                     )}

--- a/src/stores/nftStore.ts
+++ b/src/stores/nftStore.ts
@@ -74,17 +74,19 @@ class NftStore {
     );
   }
 
-  // Discovered NFTs minus the ones already in the user's saved gallery.
-  // The "Add NFT" picker renders this list so previously-added items
-  // don't reappear as suggestions.
+  // Discovered NFTs minus the ones already visible in the gallery.
+  // Hidden NFTs are still eligible — picking a hidden NFT in the picker
+  // unhides it. Previously-visible items stay filtered so they don't
+  // reappear as suggestions.
   get pendingDiscoveredNfts(): NFTInterface[] {
-    const owned = new Set(
-      this.nftList.map((n) =>
+    const visible = new Set(
+      this.visibleNftList.map((n) =>
         nftKey(n.contractAddress, n.tokenId).toLowerCase(),
       ),
     );
     return this.discoveredNfts.filter(
-      (n) => !owned.has(nftKey(n.contractAddress, n.tokenId).toLowerCase()),
+      (n) =>
+        !visible.has(nftKey(n.contractAddress, n.tokenId).toLowerCase()),
     );
   }
 
@@ -434,15 +436,57 @@ class NftStore {
    */
   async addDiscoveredNfts(picks: NFTInterface[]) {
     if (picks.length === 0) return;
+    const startAccount = this.qrlStore.activeAccount.accountAddress;
     const owned = new Set(
       this.nftList.map((n) => nftKey(n.contractAddress, n.tokenId)),
     );
-    const additions = picks.filter(
-      (n) => !owned.has(nftKey(n.contractAddress, n.tokenId)),
+    const hidden = new Set(this.hiddenNfts.map((k) => k.toLowerCase()));
+    const additions: NFTInterface[] = [];
+    const unhides: string[] = [];
+    for (const pick of picks) {
+      // nftKey lowercases the contract but not the tokenId. owned is
+      // built from the same helper so equality holds. hidden is fully
+      // lowercased, so use the lowercased key for that check only.
+      const key = nftKey(pick.contractAddress, pick.tokenId);
+      if (!owned.has(key)) {
+        additions.push(pick);
+      } else if (hidden.has(key.toLowerCase())) {
+        unhides.push(key.toLowerCase());
+      }
+      // else: already visible — skip
+    }
+    if (additions.length === 0 && unhides.length === 0) return;
+    // Stale-write guard: NFT storage is per-account-scoped, so the
+    // write lands in the right key even after a switch, but the
+    // in-memory append would still mix the prior account's discovered
+    // picks into the new account's nftList.
+    if (this.qrlStore.activeAccount.accountAddress !== startAccount) {
+      log(
+        "addDiscoveredNfts: active account changed before write, abandoning picks",
+      );
+      return;
+    }
+    if (additions.length > 0) {
+      await this.setNftList([...this.nftList, ...additions]);
+    }
+    if (unhides.length > 0) {
+      // Persist each unhide (StorageUtil.unhideNft is O(read+write) per
+      // call but the lists are small) and then update observable state
+      // once so the UI re-renders a single time.
+      const { blockchain, account } = this.scope;
+      for (const key of unhides) {
+        await StorageUtil.unhideNft(blockchain, account, key);
+      }
+      const drop = new Set(unhides);
+      runInAction(() => {
+        this.hiddenNfts = this.hiddenNfts.filter(
+          (k) => !drop.has(k.toLowerCase()),
+        );
+      });
+    }
+    log(
+      `addDiscoveredNfts: added ${additions.length}, unhid ${unhides.length}`,
     );
-    if (additions.length === 0) return;
-    await this.setNftList([...this.nftList, ...additions]);
-    log(`Added ${additions.length} discovered NFTs to gallery`);
   }
 
   clearDiscoveredNfts() {

--- a/src/stores/tokenStore.ts
+++ b/src/stores/tokenStore.ts
@@ -97,15 +97,16 @@ class TokenStore {
 
   // Discovered tokens minus the ones the user has already added.
   // The "Add token" picker renders this filtered list so previously-added
-  // entries don't reappear as suggestions. Lowercased comparison because
-  // the explorer normalises to Q-prefix lowercase and a user's manual
-  // entries might be mixed case.
+  // entries don't reappear as suggestions, but hidden ones do — a hidden
+  // token should be re-discoverable so the user can pick it again to
+  // unhide. Lowercased comparison because the explorer normalises to
+  // Q-prefix lowercase and a user's manual entries might be mixed case.
   get pendingDiscoveredTokens(): TokenInterface[] {
-    const owned = new Set(
-      this.tokenList.map((t) => t.address.toLowerCase()),
+    const visible = new Set(
+      this.visibleTokenList.map((t) => t.address.toLowerCase()),
     );
     return this.discoveredTokens.filter(
-      (t) => !owned.has(t.address.toLowerCase()),
+      (t) => !visible.has(t.address.toLowerCase()),
     );
   }
 
@@ -520,18 +521,23 @@ class TokenStore {
 
   async refreshTokenBalances() {
     try {
-      const activeAccountAddress = this.qrlStore.activeAccount.accountAddress;
-      if (!activeAccountAddress) return;
+      const startAccount = this.qrlStore.activeAccount.accountAddress;
+      if (!startAccount) return;
 
+      // Freeze the list at entry and iterate the snapshot, not the
+      // observable. If the user switches accounts mid-fetch, the
+      // observable list will be wiped under us; the snapshot still
+      // reflects what we set out to refresh.
+      const snapshot = [...this.tokenList];
       const selectedBlockChain = await StorageUtil.getBlockChain();
-      const updatedTokenList = [...this.tokenList];
+      const updatedTokenList = [...snapshot];
 
-      for (let i = 0; i < this.tokenList.length; i++) {
-        const token = this.tokenList[i];
+      for (let i = 0; i < snapshot.length; i++) {
+        const token = snapshot[i];
         try {
           const balance = await fetchBalance(
             token.address,
-            activeAccountAddress,
+            startAccount,
             QRL_PROVIDER[selectedBlockChain as keyof typeof QRL_PROVIDER].url,
           );
           const balanceStr = formatUnits(balance, token.decimals);
@@ -546,6 +552,16 @@ class TokenStore {
           );
           updatedTokenList[i] = { ...token, amount: "Error" };
         }
+      }
+
+      // Stale-write guard: if the active account changed under us,
+      // abandon the result. Writing it back would clobber the new
+      // account's list (token storage is global, not per-account).
+      if (this.qrlStore.activeAccount.accountAddress !== startAccount) {
+        log(
+          "refreshTokenBalances: active account changed mid-refresh, abandoning stale results",
+        );
+        return;
       }
 
       await this.setTokenList(updatedTokenList);
@@ -626,19 +642,56 @@ class TokenStore {
   }
 
   // Explicit opt-in: merge the user-selected subset of discoveredTokens
-  // into the persistent tokenList. Address-dedupes (lowercase) so a
-  // pick that's already in the list is a no-op rather than a duplicate.
+  // into the persistent tokenList. For picks already in the list-but-
+  // hidden, this unhides them; for picks not in the list, this appends
+  // them. Picks already visible are a no-op.
   async addDiscoveredTokens(picks: TokenInterface[]) {
     if (picks.length === 0) return;
+    const startAccount = this.qrlStore.activeAccount.accountAddress;
     const owned = new Set(
       this.tokenList.map((t) => t.address.toLowerCase()),
     );
-    const additions = picks.filter(
-      (t) => !owned.has(t.address.toLowerCase()),
+    const hidden = new Set(this.hiddenTokens.map((a) => a.toLowerCase()));
+    const additions: TokenInterface[] = [];
+    const unhides: string[] = [];
+    for (const pick of picks) {
+      const lower = pick.address.toLowerCase();
+      if (!owned.has(lower)) {
+        additions.push(pick);
+      } else if (hidden.has(lower)) {
+        unhides.push(pick.address);
+      }
+      // else: already visible — skip
+    }
+    if (additions.length === 0 && unhides.length === 0) return;
+    // Stale-write guard: token storage is global, so a write here after
+    // an account switch would land in the new account's view.
+    if (this.qrlStore.activeAccount.accountAddress !== startAccount) {
+      log(
+        "addDiscoveredTokens: active account changed before write, abandoning picks",
+      );
+      return;
+    }
+    if (additions.length > 0) {
+      await this.setTokenList([...this.tokenList, ...additions]);
+    }
+    if (unhides.length > 0) {
+      // Persist each unhide (StorageUtil.unhideToken is small) and
+      // collapse the observable update into a single runInAction so the
+      // UI re-renders once instead of N times.
+      for (const addr of unhides) {
+        await StorageUtil.unhideToken(addr);
+      }
+      const drop = new Set(unhides.map((a) => a.toLowerCase()));
+      runInAction(() => {
+        this.hiddenTokens = this.hiddenTokens.filter(
+          (addr) => !drop.has(addr.toLowerCase()),
+        );
+      });
+    }
+    log(
+      `addDiscoveredTokens: added ${additions.length}, unhid ${unhides.length}`,
     );
-    if (additions.length === 0) return;
-    await this.setTokenList([...this.tokenList, ...additions]);
-    log(`Added ${additions.length} discovered tokens to user list`);
   }
 
   clearDiscoveredTokens() {

--- a/src/stores/tokenStore.ts
+++ b/src/stores/tokenStore.ts
@@ -114,6 +114,7 @@ class TokenStore {
   // qrlStore.onBlockchainReady hook). Restores the persisted token list and
   // hidden-token list, then seeds known tokens.
   async initialize() {
+    await this.migrateLegacyAutoAddedTokens();
     const persistedList = await StorageUtil.getTokenList();
     runInAction(() => {
       this.tokenList = persistedList;
@@ -123,6 +124,21 @@ class TokenStore {
     for (const token of KNOWN_TOKEN_LIST) {
       await this.addToken(token);
     }
+  }
+
+  // One-shot migration: pre-gate (before PR #142), the wallet auto-merged
+  // every token the explorer attributed to the active account into
+  // tokenList, and persisted that to localStorage. After the gate, those
+  // legacy entries can't be distinguished from user-curated picks — so we
+  // wipe TOKEN_LIST once on first load post-migration. The discovery
+  // picker (PR #143) repopulates legitimate holdings on the user's
+  // explicit say-so.
+  private async migrateLegacyAutoAddedTokens() {
+    const FLAG = "TOKEN_LIST_GATE_MIGRATED_V1";
+    if (localStorage.getItem(FLAG)) return;
+    await StorageUtil.clearTokenList();
+    localStorage.setItem(FLAG, "1");
+    log("Migration: wiped pre-gate tokenList; flag set");
   }
 
   // Called by Store after QrlStore.setActiveAccount finishes (via the


### PR DESCRIPTION
## Summary

UX layer for the opt-in discovery from #141 + the anti-spam gate from #142. Surfaces what the explorer sees on the active address without re-introducing silent merges; lets the user pick what to add.

### What the user sees now

**Tokens card, empty state**
- Before: \`\"No tokens currently added or created.\"\`
- After (when the explorer reports N): \`\"Explorer found this address to own N tokens.\"\` + a **Review and add** button that opens the picker.

**NFTs card, empty state**
- Before: \`\"No collectibles yet — Paste an ERC-721 or ERC-1155 contract address to add one.\"\`
- After (when the explorer reports N): \`\"Explorer found this address to own N NFTs.\"\` + **Review and add**.

**Add Existing Token / Add NFT modals**
- Keep the existing manual-entry input (contract address ± token ID).
- Now also render a **\"Discovered tokens (n)\"** / **\"Discovered NFTs (n)\"** section with one checkbox row per discovered item: name + symbol + address for tokens; thumbnail + name + standard + token ID for NFTs.
- Footer of the section: **\"Add Selected (n)\"** button calls \`addDiscoveredTokens(picks)\` / \`addDiscoveredNfts(picks)\`.
- Modals re-fire discovery on open so the picker stays fresh.
- Picks land live; the picker shrinks as items move to the live list.

**Refresh button**
- Tokens card: previously cleared hidden tokens + wiped the list + called the legacy auto-merge discovery + refreshed balances. Now it **only** refreshes balances of imported tokens.
- NFTs card: already only refreshed balances. No change.

### Hide-as-rediscoverable

Per user request: if the user hides an added token (or NFT), it goes back into the picker so they can re-add it later.

- \`pendingDiscoveredTokens\` / \`pendingDiscoveredNfts\` now filter by the **visible** list, not the raw stored list.
- \`addDiscoveredTokens\` / \`addDiscoveredNfts\` distinguish per pick: not-in-list -> append, in-list-but-hidden -> unhide.

### Race guards (addresses Gemini comment on #142)

Three methods got the same fix: snapshot at entry, re-check active account before write, abandon if it changed.

- \`tokenStore.refreshTokenBalances\` (the one Gemini flagged)
- \`tokenStore.addDiscoveredTokens\`
- \`nftStore.addDiscoveredNfts\`

Token storage is global, so without the guard a stale A-pick could land in the B-view after an account switch. NFT storage is per-account but the in-memory \`nftList\` would still mix.

## Files

- \`src/stores/tokenStore.ts\` — race guard, hide-as-rediscoverable in \`pendingDiscoveredTokens\` + \`addDiscoveredTokens\`
- \`src/stores/nftStore.ts\` — race guard, hide-as-rediscoverable on the NFT side
- \`src/components/Core/Body/Tokens/TokenForm/TokenForm.tsx\` — gut \`refreshTokens\`, fire \`discoverTokensForReview\` on mount, dynamic empty-state copy
- \`src/components/Core/Body/Tokens/TokenForm/data-table.tsx\` — accept \`emptyMessage\` prop
- \`src/components/Core/Body/Tokens/AddTokenModal/AddTokenModal.tsx\` — discovered-tokens picker section
- \`src/components/Core/Body/Nfts/NftGallery.tsx\` — fire \`discoverNftsForReview\` on mount, EmptyState reads \`pendingDiscoveredNfts.length\`
- \`src/components/Core/Body/Nfts/AddNftModal.tsx\` — discovered-NFTs picker section

## Test plan

Against \`Q79b662Ce3d663643dF4454A8Ba3f532C0DE6887f\` on testnet v2 (already holds 6 QRC-20 + the Zondscan-721 #2 fixture).

- [ ] Tokens card empty state shows \`\"Explorer found this address to own 6 tokens.\"\`
- [ ] Open Add Existing Token → modal shows the picker section with 6 rows above the contract-address input
- [ ] Tick 2 → \"Add Selected (2)\" → modal stays open, picker shrinks to 4, tokens appear on the dashboard
- [ ] Press the Tokens refresh button → DevTools Network panel shows \`qrl_call\` for \`balanceOf\` only, NOT \`GET /api/address/.../tokens\`
- [ ] Hide one of the added tokens → reopen the picker → it reappears in the discovered list → tick it → it goes back to visible
- [ ] NFTs card empty state shows \`\"Explorer found this address to own 1 NFT.\"\` (the Zondscan-721 fixture)
- [ ] Open Add NFT → discovered section shows the fixture with its thumbnail → pick → it lands in the gallery with the image rendered
- [ ] Race guard: in DevTools console, \`store.qrlStore.setActiveAccount(otherAccount)\` immediately after pressing refresh → confirm \`refreshTokenBalances: active account changed mid-refresh, abandoning stale results\` log
- [x] \`npm run lint\` green
- [x] \`npx tsc --noEmit\` green
- [x] \`npm run build\` green

## Sequencing

This PR is independent of #142 (different methods in tokenStore.ts; no overlap with the gate's \`handleActiveAccountChanged\`). Either can merge first. Recommend merging #142 first so the gate is in dev, then this on top to bring the picker.