### PR TITLE
fix(picker): close modal after Add Selected

### DIFF
--- a/src/components/Core/Body/Nfts/AddNftModal.tsx
+++ b/src/components/Core/Body/Nfts/AddNftModal.tsx
@@ -114,6 +114,7 @@ export const AddNftModal = observer(({ isOpen, onClose }: AddNftModalProps) => {
       );
       await nftStore.addDiscoveredNfts(picks);
       setSelectedKeys(new Set());
+      onClose();
     } catch (err) {
       setError(
         err instanceof Error

--- a/src/components/Core/Body/Nfts/NftGallery.tsx
+++ b/src/components/Core/Body/Nfts/NftGallery.tsx
@@ -116,20 +116,22 @@ function EmptyState({
   discoveredCount: number;
 }) {
   return (
-    <div className="flex flex-col items-center justify-center gap-3 py-8 text-center">
-      <Sparkles className="h-10 w-10 text-muted-foreground/50" />
-      <div>
-        <p className="text-sm font-medium">
-          {discoveredCount > 0
-            ? `Explorer found this address to own ${discoveredCount} NFT${discoveredCount === 1 ? "" : "s"}.`
-            : "No collectibles yet"}
-        </p>
-        <p className="text-xs text-muted-foreground">
-          {discoveredCount > 0
-            ? "Pick the ones to add to your gallery, or paste a contract address."
-            : "Paste an ERC-721 or ERC-1155 contract address to add one."}
-        </p>
-      </div>
+    <div className="flex flex-col items-center gap-2 py-4 text-center">
+      {discoveredCount > 0 ? (
+        <div className="flex items-center gap-2 text-sm">
+          <Sparkles className="h-4 w-4 text-muted-foreground/70" />
+          Explorer found this address to own{" "}
+          <span className="font-medium">{discoveredCount}</span> NFT
+          {discoveredCount === 1 ? "" : "s"}.
+        </div>
+      ) : (
+        <div>
+          <p className="text-sm font-medium">No collectibles yet</p>
+          <p className="text-xs text-muted-foreground">
+            Paste an ERC-721 or ERC-1155 contract address to add one.
+          </p>
+        </div>
+      )}
       <Button variant="outline" size="sm" onClick={onAdd}>
         <Plus className="mr-2 h-4 w-4" />
         {discoveredCount > 0 ? "Review and add" : "Add NFT"}

--- a/src/components/Core/Body/Tokens/AddTokenModal/AddTokenModal.tsx
+++ b/src/components/Core/Body/Tokens/AddTokenModal/AddTokenModal.tsx
@@ -76,6 +76,7 @@ export const AddTokenModal = observer(({ isOpen, onClose }: { isOpen: boolean, o
             );
             await tokenStore.addDiscoveredTokens(picks);
             setSelectedAddresses(new Set());
+            onClose();
         } catch (err) {
             setError(
                 err instanceof Error


### PR DESCRIPTION
## Summary

Adding picks via the discovery picker now closes the Add Token / Add NFT modal instead of staying open.

The original \"keep open\" behavior was meant to let a user pick from the discovered list **and then** also paste a manual contract before dismissing. In practice users finish their pick, expect the modal to close, and have to dismiss it manually — felt buggy. Reverting to close-on-add matches the existing manual \"Add Token\" / \"Add NFT\" button behavior.

## Files

- \`src/components/Core/Body/Tokens/AddTokenModal/AddTokenModal.tsx\` — \`addSelected\` calls \`onClose()\` after \`addDiscoveredTokens\` resolves
- \`src/components/Core/Body/Nfts/AddNftModal.tsx\` — same on the NFT side

## Test plan
- [ ] Open Add Existing Token → tick rows → Add Selected → modal closes
- [ ] Open Add NFT → tick rows → Add Selected → modal closes
- [ ] Manual contract entry path still closes on Add Token / Add NFT (no regression)