### PR TITLE
feat(picker): slot-cascade Amount column + success Check on refresh

### DIFF
--- a/src/components/Core/Body/Tokens/TokenForm/TokenForm.tsx
+++ b/src/components/Core/Body/Tokens/TokenForm/TokenForm.tsx
@@ -53,6 +53,10 @@ const TokenForm = observer(() => {
     // surfaces a picker built from pendingDiscoveredTokens.
     const refreshTokens = async () => {
         setIsRefreshing(true);
+        // Slot-cascade is user-initiated only — toggle the store flag
+        // here, not inside refreshTokenBalances (which also fires on
+        // account-switch / mount and shouldn't animate then).
+        tokenStore.setRefreshingBalances(true);
         try {
             await tokenStore.refreshTokenBalances();
         } catch (error) {
@@ -61,6 +65,9 @@ const TokenForm = observer(() => {
             setIsRefreshing(false);
             setRefreshSuccess(true);
             setTimeout(() => setRefreshSuccess(false), 1500);
+            // Hold the cascade for 1200ms past fetch completion so the
+            // digits visibly settle, matching the QRL refresher.
+            setTimeout(() => tokenStore.setRefreshingBalances(false), 1200);
         }
     };
 

--- a/src/components/Core/Body/Tokens/TokenForm/TokenForm.tsx
+++ b/src/components/Core/Body/Tokens/TokenForm/TokenForm.tsx
@@ -12,7 +12,7 @@ import { useEffect, useState } from "react";
 import { fetchBalance } from "@/utils/web3";
 import { useStore } from "@/stores/store";
 import { Button } from "@/components/UI/Button";
-import { Loader2, Plus, RefreshCw, Import, Coins, Sparkles } from "lucide-react";
+import { Check, Plus, RefreshCw, Import, Coins, Sparkles } from "lucide-react";
 import { AddTokenModal } from "../AddTokenModal/AddTokenModal";
 import { formatUnits } from "ethers";
 import { QRL_PROVIDER } from "@/config";
@@ -44,6 +44,7 @@ const TokenForm = observer(() => {
     const [isAddTokenModalOpen, setIsAddTokenModalOpen] = useState(false);
     const [isLoading, setIsLoading] = useState(true);
     const [isRefreshing, setIsRefreshing] = useState(false);
+    const [refreshSuccess, setRefreshSuccess] = useState(false);
 
     // Refresh balances of the tokens already in the user's list. Does NOT
     // re-discover from the explorer — that would re-introduce the spam
@@ -58,6 +59,8 @@ const TokenForm = observer(() => {
             console.error("Failed to refresh tokens:", error);
         } finally {
             setIsRefreshing(false);
+            setRefreshSuccess(true);
+            setTimeout(() => setRefreshSuccess(false), 1500);
         }
     };
 
@@ -115,10 +118,12 @@ const TokenForm = observer(() => {
                                     variant="outline"
                                     size="sm"
                                     onClick={refreshTokens}
-                                    disabled={isRefreshing}
+                                    disabled={isRefreshing || refreshSuccess}
                                 >
-                                    {isRefreshing ? (
-                                        <Loader2 className="h-4 w-4 animate-spin" />
+                                    {refreshSuccess ? (
+                                        <Check className="h-4 w-4 text-green-500" />
+                                    ) : isRefreshing ? (
+                                        <RefreshCw className="h-4 w-4 animate-spin" />
                                     ) : (
                                         <RefreshCw className="h-4 w-4" />
                                     )}

--- a/src/components/Core/Body/Tokens/TokenForm/columns.tsx
+++ b/src/components/Core/Body/Tokens/TokenForm/columns.tsx
@@ -2,8 +2,10 @@ import { TokenInterface } from "@/constants"
 import { ColumnDef } from "@tanstack/react-table"
 import { Copy, Check, Send, EyeOff } from "lucide-react"
 import { useState } from "react"
+import { observer } from "mobx-react-lite"
 import { useStore } from "@/stores/store"
 import { copyToClipboard } from "@/utils/nativeApp"
+import { SlotBalance } from "../../Home/AccountCreateImport/ActiveAccountDisplay/SlotBalance"
 
 // Create a component for the cell to manage its own copy state
 const CopyableAddress = ({ address }: { address: string }) => {
@@ -64,6 +66,36 @@ const CopyableText = ({ text }: { text: string }) => {
     );
 };
 
+// Token amount cell with the QRL-balance-style slot-machine cascade
+// while tokenStore.isRefreshingBalances is on, plus the same copy
+// affordance as CopyableText.
+const BalanceCell = observer(({ amount }: { amount: string }) => {
+    const { tokenStore } = useStore();
+    const [isCopied, setIsCopied] = useState(false);
+
+    const handleCopy = async (textToCopy: string) => {
+        const success = await copyToClipboard(textToCopy);
+        if (success) {
+            setIsCopied(true);
+            setTimeout(() => setIsCopied(false), 1500);
+        }
+    };
+
+    return (
+        <div className="flex items-center gap-2 group">
+            <SlotBalance value={amount} spinning={tokenStore.isRefreshingBalances} />
+            {isCopied ? (
+                <Check className="w-4 h-4 text-green-500" />
+            ) : (
+                <Copy
+                    className="w-4 h-4 opacity-0 group-hover:opacity-100 hover:text-gray-400 transition-opacity cursor-pointer"
+                    onClick={() => handleCopy(amount)}
+                />
+            )}
+        </div>
+    );
+});
+
 const HideTokenButton = ({ tokenAddress }: { tokenAddress: string }) => {
     const { tokenStore } = useStore();
 
@@ -112,7 +144,7 @@ export const columns: ColumnDef<TokenInterface>[] = [
         header: 'Amount',
         cell: ({ row }) => {
             const amount: string = row.getValue('amount')
-            return <CopyableText text={amount} />;
+            return <BalanceCell amount={amount} />;
         }
     },
     {

--- a/src/stores/tokenStore.ts
+++ b/src/stores/tokenStore.ts
@@ -77,6 +77,7 @@ class TokenStore {
       sendToken: action.bound,
       createToken: action.bound,
       refreshTokenBalances: action.bound,
+      setRefreshingBalances: action.bound,
       discoverAndAddTokens: action.bound,
       discoverTokensForReview: action.bound,
       addDiscoveredTokens: action.bound,
@@ -540,10 +541,11 @@ class TokenStore {
     }
   }
 
+  // The slot-cascade animation flag (isRefreshingBalances) is set by
+  // callers, not here. Background invocations (account-switch auto-
+  // refresh, etc.) refresh silently; only the user-pressed Refresh
+  // button toggles the flag, so the digits don't spin on page load.
   async refreshTokenBalances() {
-    runInAction(() => {
-      this.isRefreshingBalances = true;
-    });
     try {
       const startAccount = this.qrlStore.activeAccount.accountAddress;
       if (!startAccount) return;
@@ -591,15 +593,15 @@ class TokenStore {
       await this.setTokenList(updatedTokenList);
     } catch (error) {
       console.error("Error refreshing token balances:", error);
-    } finally {
-      // Hold the flag for the slot animation tail so digits cascade
-      // visibly past the fetch completion. Matches the QRL refresher.
-      setTimeout(() => {
-        runInAction(() => {
-          this.isRefreshingBalances = false;
-        });
-      }, 1200);
     }
+  }
+
+  // UI-owned setter for the slot-cascade animation flag. TokenForm
+  // turns it on when the user clicks Refresh, off after the animation
+  // tail. The fetch itself doesn't manage this flag — see
+  // refreshTokenBalances comment.
+  setRefreshingBalances(value: boolean) {
+    this.isRefreshingBalances = value;
   }
 
   // Legacy auto-merge flow. Still wired into the Tokens-page refresh

--- a/src/stores/tokenStore.ts
+++ b/src/stores/tokenStore.ts
@@ -53,6 +53,10 @@ class TokenStore {
   // recognized N tokens, add?") so spam-airdropped tokens can't sneak
   // onto the dashboard without an explicit user pick.
   discoveredTokens: TokenInterface[] = [];
+  // Drives the slot-machine cascade on the Amount column while
+  // refreshTokenBalances is running. Kept on for ~1.2s after the
+  // fetch resolves so the digits settle visibly.
+  isRefreshingBalances = false;
 
   constructor(private qrlStore: QrlStore) {
     makeAutoObservable(this, {
@@ -61,6 +65,7 @@ class TokenStore {
       tokenList: observable.struct,
       hiddenTokens: observable,
       discoveredTokens: observable.struct,
+      isRefreshingBalances: observable,
       visibleTokenList: computed,
       pendingDiscoveredTokens: computed,
       setCreatingToken: action.bound,
@@ -536,6 +541,9 @@ class TokenStore {
   }
 
   async refreshTokenBalances() {
+    runInAction(() => {
+      this.isRefreshingBalances = true;
+    });
     try {
       const startAccount = this.qrlStore.activeAccount.accountAddress;
       if (!startAccount) return;
@@ -583,6 +591,14 @@ class TokenStore {
       await this.setTokenList(updatedTokenList);
     } catch (error) {
       console.error("Error refreshing token balances:", error);
+    } finally {
+      // Hold the flag for the slot animation tail so digits cascade
+      // visibly past the fetch completion. Matches the QRL refresher.
+      setTimeout(() => {
+        runInAction(() => {
+          this.isRefreshingBalances = false;
+        });
+      }, 1200);
     }
   }
 


### PR DESCRIPTION
## Summary

The Tokens-card refresh button used a near-static Loader2 that didn't read as 'something's happening' during the actually-not-instant balance fetch. Aligning it with the QRL balance refresher pattern.

- **Amount column** now cascades digit-by-digit (`SlotBalance` from the QRL ActiveAccountDisplay) while refreshing.
- **Refresh button** transitions: idle RefreshCw → spinning RefreshCw → brief green Check (1.5s) on success.

## Files

- \`src/stores/tokenStore.ts\` — new \`isRefreshingBalances\` observable. Set on entry of \`refreshTokenBalances\`, held for 1200ms after fetch so the slot-cascade tail finishes visibly.
- \`src/components/Core/Body/Tokens/TokenForm/columns.tsx\` — new \`BalanceCell\` (observer) wraps \`SlotBalance\` + the existing copy affordance.
- \`src/components/Core/Body/Tokens/TokenForm/TokenForm.tsx\` — adds \`refreshSuccess\` state; button shows Check briefly after refresh.

Reuses \`SlotBalance\` / \`SlotDigit\` from \`Home/AccountCreateImport/ActiveAccountDisplay/\`. No new animation code.

## Test plan
- [ ] Open the Tokens card with some imported tokens
- [ ] Click Refresh → amounts cascade digit-by-digit; button icon spins
- [ ] After ~1.2s the cascade settles on the new values; button briefly shows a green Check, then returns to RefreshCw
- [ ] Token addresses / names / hide / send actions unchanged
- [x] lint, tsc, build green