### PR TITLE
feat(dapp-connect): wider rejoin grace + relay tombstone + peer-redirect

### DIFF
--- a/src/components/NativeAppBridge.tsx
+++ b/src/components/NativeAppBridge.tsx
@@ -148,7 +148,9 @@ const NativeAppBridge: React.FC = () => {
           // Check if this is a qrlconnect:// URI (dApp connection)
           if (DAppConnectService.isConnectionURI(address)) {
             logToNative(`DApp connection URI detected, routing to DAppConnectService`);
-            dappConnectService.handleConnectionURI(address);
+            // QR scan => the dApp is on another device; no same-device
+            // return-to-dApp redirect after approval.
+            dappConnectService.handleConnectionURI(address, 'qr');
             return;
           }
 
@@ -197,7 +199,8 @@ const NativeAppBridge: React.FC = () => {
             return;
           }
           logToNative(`DApp URI received via deep link: ${uri}`);
-          dappConnectService.handleConnectionURI(uri);
+          // Deep link => same-device flow; enable the return-to-dApp redirect.
+          dappConnectService.handleConnectionURI(uri, 'deeplink');
           break;
         }
 

--- a/src/components/NativeAppBridge.tsx
+++ b/src/components/NativeAppBridge.tsx
@@ -149,8 +149,17 @@ const NativeAppBridge: React.FC = () => {
           if (DAppConnectService.isConnectionURI(address)) {
             logToNative(`DApp connection URI detected, routing to DAppConnectService`);
             // QR scan => the dApp is on another device; no same-device
-            // return-to-dApp redirect after approval.
-            dappConnectService.handleConnectionURI(address, 'qr');
+            // return-to-dApp redirect after approval. handleConnectionURI
+            // resolves with {success:false} rather than throwing, so log the
+            // reason instead of letting a failed connect die silently.
+            void dappConnectService
+              .handleConnectionURI(address, 'qr')
+              .then((r) => {
+                if (!r.success) logToNative(`DApp connect failed: ${r.error ?? 'unknown'}`);
+              })
+              .catch((err) =>
+                logToNative(`DApp connect error: ${err instanceof Error ? err.message : String(err)}`)
+              );
             return;
           }
 
@@ -200,7 +209,14 @@ const NativeAppBridge: React.FC = () => {
           }
           logToNative(`DApp URI received via deep link: ${uri}`);
           // Deep link => same-device flow; enable the return-to-dApp redirect.
-          dappConnectService.handleConnectionURI(uri, 'deeplink');
+          void dappConnectService
+            .handleConnectionURI(uri, 'deeplink')
+            .then((r) => {
+              if (!r.success) logToNative(`DApp connect failed: ${r.error ?? 'unknown'}`);
+            })
+            .catch((err) =>
+              logToNative(`DApp connect error: ${err instanceof Error ? err.message : String(err)}`)
+            );
           break;
         }
 

--- a/src/services/dappConnect/DAppConnectService.ts
+++ b/src/services/dappConnect/DAppConnectService.ts
@@ -34,7 +34,14 @@ function dlog(msg: string): void {
 }
 
 const DEFAULT_RELAY_URL = 'https://qrlwallet.com';
-const DAPP_REJOIN_GRACE_MS = 30000;
+// Grace period before a dApp that left the relay channel is torn down. On a
+// same-device deep-link round trip the dApp's browser tab is suspended while
+// the wallet is foregrounded, so its relay socket drops; the relay buffer
+// (5 min) and channel (30 min) easily outlive that, and the SDK re-joins the
+// same channel on resume. 30s was shorter than a real browser-to-wallet-and-
+// back round trip and tore down recoverable sessions; 90s comfortably covers
+// it without leaving a genuinely-gone dApp "active" for long.
+const DAPP_REJOIN_GRACE_MS = 90000;
 const TERMINATE_SEND_TIMEOUT_MS = 800;
 
 interface ActiveConnection {
@@ -379,6 +386,7 @@ export class DAppConnectService {
             url: info.url || conn.dappInfo.url,
             icon: info.icon || conn.dappInfo.icon,
             chainId: info.chainId || conn.dappInfo.chainId,
+            redirectUrl: info.redirectUrl || conn.dappInfo.redirectUrl,
           };
           const firstTime = !conn.originatorInfoReceived;
           conn.originatorInfoReceived = true;
@@ -487,6 +495,7 @@ export class DAppConnectService {
       result,
     });
     if (isInNativeApp()) triggerHaptic('success');
+    this.maybeReturnToDApp(sessionId);
   }
 
   rejectRequest(
@@ -500,6 +509,22 @@ export class DAppConnectService {
       error: { code: 4001, message },
     });
     if (isInNativeApp()) triggerHaptic('error');
+    this.maybeReturnToDApp(sessionId);
+  }
+
+  /**
+   * After resolving a restricted request, bounce the user back to the dApp
+   * (WalletConnect-style peer redirect) if it advertised a return URL in
+   * ORIGINATOR_INFO. Native opens the URL; on a same-device deep-link flow
+   * this returns focus to the browser/dApp instead of stranding the user in
+   * the wallet. No-op outside the native app or when no redirect was given.
+   */
+  private maybeReturnToDApp(channelId: string): void {
+    if (!isInNativeApp()) return;
+    const redirectUrl = this.connections.get(channelId)?.dappInfo.redirectUrl;
+    if (redirectUrl) {
+      sendToNative('DAPP_RETURN' as never, { channelId, redirectUrl });
+    }
   }
 
   async disconnectSession(channelId: string, explicit = true): Promise<void> {
@@ -518,7 +543,14 @@ export class DAppConnectService {
 
       const activeConn = this.connections.get(channelId);
       if (activeConn) {
-        activeConn.socketClient.leaveChannel();
+        // An explicit disconnect ("forget" / user-initiated) marks a durable
+        // relay tombstone so an absent dApp learns the session is dead on its
+        // next join; a grace-timeout leave is transient and must not.
+        if (explicit) {
+          activeConn.socketClient.closeChannel();
+        } else {
+          activeConn.socketClient.leaveChannel();
+        }
         activeConn.socketClient.disconnect();
         this.connections.delete(channelId);
       }

--- a/src/services/dappConnect/DAppConnectService.ts
+++ b/src/services/dappConnect/DAppConnectService.ts
@@ -489,13 +489,18 @@ export class DAppConnectService {
   }
 
   approveRequest(sessionId: string, requestId: string | number, result: unknown): void {
-    void this.sendJsonRpcResponse(sessionId, {
+    // Send the response FIRST, and only bounce back to the dApp once it has
+    // left the relay. maybeReturnToDApp backgrounds the wallet (the OS may
+    // then suspend it); if we redirected before the response was transmitted,
+    // the dApp would never receive the approval.
+    this.sendJsonRpcResponse(sessionId, {
       jsonrpc: '2.0',
       id: requestId,
       result,
-    });
+    })
+      .catch((err) => console.error('[DAppConnect] Failed to send approve response:', err))
+      .finally(() => this.maybeReturnToDApp(sessionId));
     if (isInNativeApp()) triggerHaptic('success');
-    this.maybeReturnToDApp(sessionId);
   }
 
   rejectRequest(
@@ -503,13 +508,14 @@ export class DAppConnectService {
     requestId: string | number,
     message = 'User rejected the request'
   ): void {
-    void this.sendJsonRpcResponse(sessionId, {
+    this.sendJsonRpcResponse(sessionId, {
       jsonrpc: '2.0',
       id: requestId,
       error: { code: 4001, message },
-    });
+    })
+      .catch((err) => console.error('[DAppConnect] Failed to send reject response:', err))
+      .finally(() => this.maybeReturnToDApp(sessionId));
     if (isInNativeApp()) triggerHaptic('error');
-    this.maybeReturnToDApp(sessionId);
   }
 
   /**
@@ -523,7 +529,7 @@ export class DAppConnectService {
     if (!isInNativeApp()) return;
     const redirectUrl = this.connections.get(channelId)?.dappInfo.redirectUrl;
     if (redirectUrl) {
-      sendToNative('DAPP_RETURN' as never, { channelId, redirectUrl });
+      sendToNative('DAPP_RETURN', { channelId, redirectUrl });
     }
   }
 

--- a/src/services/dappConnect/DAppConnectService.ts
+++ b/src/services/dappConnect/DAppConnectService.ts
@@ -62,6 +62,11 @@ interface ActiveConnection {
   // short-circuited as "already connected". Not persisted — rehydrated
   // sessions skip the fp check since the AEAD key is already established.
   dappPublicKey?: Uint8Array;
+  // True only when the connection was opened from a same-device deep link
+  // (qrlconnect:// tapped in the phone browser), not a QR scan. Gates the
+  // return-to-dApp peer redirect: bouncing to the dApp URL only makes sense
+  // on the same device. A QR scan means the dApp is on another device.
+  originatedViaDeepLink: boolean;
 }
 
 type ServiceEventHandler = {
@@ -97,7 +102,10 @@ export class DAppConnectService {
    * For v2: the URI carries the dApp's ML-KEM public key; the wallet runs
    * Encaps → emits SYNACK → awaits ACK.
    */
-  async handleConnectionURI(uri: string): Promise<{ success: boolean; error?: string }> {
+  async handleConnectionURI(
+    uri: string,
+    origin: 'qr' | 'deeplink' = 'qr'
+  ): Promise<{ success: boolean; error?: string }> {
     let parsed;
     try {
       parsed = await parseConnectionURI(uri);
@@ -185,6 +193,7 @@ export class DAppConnectService {
       originatorInfoReceived: false,
       messageQueue: Promise.resolve(),
       relayUrl,
+      originatedViaDeepLink: origin === 'deeplink',
     };
     this.connections.set(channelId, connection);
     this.handlers?.onSessionsChanged();
@@ -527,7 +536,12 @@ export class DAppConnectService {
    */
   private maybeReturnToDApp(channelId: string): void {
     if (!isInNativeApp()) return;
-    const redirectUrl = this.connections.get(channelId)?.dappInfo.redirectUrl;
+    const conn = this.connections.get(channelId);
+    // Only bounce back for a same-device deep-link session. A QR-scanned
+    // session means the dApp is on another device, so opening its URL on the
+    // phone is wrong (e.g. a desktop dApp's http://localhost:5174).
+    if (!conn?.originatedViaDeepLink) return;
+    const redirectUrl = conn.dappInfo.redirectUrl;
     if (redirectUrl) {
       sendToNative('DAPP_RETURN', { channelId, redirectUrl });
     }
@@ -658,6 +672,10 @@ export class DAppConnectService {
           originatorInfoReceived: true,
           messageQueue: Promise.resolve(),
           relayUrl: reconnectRelayUrl,
+          // The connect origin isn't persisted, so a rehydrated session does
+          // not auto-redirect. Safe default: a wrong-device redirect never
+          // fires; a fresh same-device deep-link approval still does.
+          originatedViaDeepLink: false,
         });
 
         socketClient.connect();

--- a/src/services/dappConnect/DAppConnectService.ts
+++ b/src/services/dappConnect/DAppConnectService.ts
@@ -91,6 +91,11 @@ function getRequestProvider(web3: unknown): RpcRequestProvider | null {
 export class DAppConnectService {
   private connections = new Map<string, ActiveConnection>();
   private dappLeaveTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  // Channels with an in-flight teardown, so concurrent disconnectSession()
+  // calls for the same channel collapse to one run (the per-call guard alone
+  // does not dedup across invocations). Value carries the effective `explicit`
+  // so a racing user "forget" can upgrade a non-explicit teardown.
+  private finalizing = new Map<string, { explicit: boolean }>();
   private handlers: ServiceEventHandler | null = null;
 
   setHandlers(handlers: ServiceEventHandler): void {
@@ -461,8 +466,11 @@ export class DAppConnectService {
         // Await the teardown: the message queue is per-channel, so
         // halting it while we finalize this same channel is the correct
         // behaviour — any further buffered messages for a channel that's
-        // being torn down are meaningless.
-        await this.disconnectSession(channelId).catch((err) =>
+        // being torn down are meaningless. explicit=false: a dApp-initiated
+        // TERMINATE is a remote close (the dApp already left on its side), so
+        // it should emit leave_channel and record a non-explicit disconnect,
+        // matching the relay 'close' path — not a redundant durable tombstone.
+        await this.disconnectSession(channelId, false).catch((err) =>
           console.error('[DAppConnect] disconnect-on-terminate failed:', err)
         );
         break;
@@ -502,19 +510,20 @@ export class DAppConnectService {
   }
 
   approveRequest(sessionId: string, requestId: string | number, result: unknown): void {
-    // Send the response FIRST, and only bounce back to the dApp once it has
-    // actually been transmitted. maybeReturnToDApp backgrounds the wallet (the
-    // OS may then suspend it); redirecting before/without a successful send
-    // would strand the dApp on a request it never received. Hence .then (on
-    // success) rather than .finally (which also fires on send failure).
-    this.sendJsonRpcResponse(sessionId, {
+    // Send the response FIRST, and only bounce back to the dApp once it was
+    // actually transmitted. maybeReturnToDApp backgrounds the wallet (the OS
+    // may then suspend it); redirecting before/without a successful send would
+    // strand the dApp on a request it never received. sendJsonRpcResponse
+    // resolves true only on a real send (sendEncrypted no longer swallows the
+    // failure into an always-resolved void), so gate the redirect on it.
+    void this.sendJsonRpcResponse(sessionId, {
       jsonrpc: '2.0',
       id: requestId,
       result,
-    }).then(
-      () => this.maybeReturnToDApp(sessionId),
-      (err) => console.error('[DAppConnect] Failed to send approve response:', err)
-    );
+    }).then((sent) => {
+      if (sent) this.maybeReturnToDApp(sessionId);
+      else console.error('[DAppConnect] approve response not sent; skipping return-to-dApp');
+    });
     if (isInNativeApp()) triggerHaptic('success');
   }
 
@@ -523,14 +532,14 @@ export class DAppConnectService {
     requestId: string | number,
     message = 'User rejected the request'
   ): void {
-    this.sendJsonRpcResponse(sessionId, {
+    void this.sendJsonRpcResponse(sessionId, {
       jsonrpc: '2.0',
       id: requestId,
       error: { code: 4001, message },
-    }).then(
-      () => this.maybeReturnToDApp(sessionId),
-      (err) => console.error('[DAppConnect] Failed to send reject response:', err)
-    );
+    }).then((sent) => {
+      if (sent) this.maybeReturnToDApp(sessionId);
+      else console.error('[DAppConnect] reject response not sent; skipping return-to-dApp');
+    });
     if (isInNativeApp()) triggerHaptic('error');
   }
 
@@ -565,21 +574,34 @@ export class DAppConnectService {
   async disconnectSession(channelId: string, explicit = true): Promise<void> {
     dlog(`disconnectSession called for ${channelId}`);
     this.clearDappLeaveTimeout(channelId);
+
+    // Collapse concurrent teardowns of the same channel to a single run. A
+    // per-call flag cannot do this (each invocation has its own), so a user
+    // tap racing an inbound TERMINATE / relay 'close' / grace timeout would
+    // otherwise each reach finalize and fire DAPP_DISCONNECTED +
+    // onSessionDisconnected twice (CLAUDE.md 4.6), with a conflicting
+    // `explicit` that corrupts the persisted flag. First caller wins; a later
+    // explicit=true upgrades the shared decision so a user "forget" still
+    // produces the durable tombstone rather than a transient leave.
+    const inflight = this.finalizing.get(channelId);
+    if (inflight) {
+      if (explicit) inflight.explicit = true;
+      return;
+    }
+    const teardown = { explicit };
+    this.finalizing.set(channelId, teardown);
+
     const conn = this.connections.get(channelId);
 
-    // Idempotence guard: concurrent callers (e.g. the user tapping
-    // Disconnect at the same moment an inbound TERMINATE arrives from the
-    // dApp) must not each run the full teardown and fire a second
-    // DAPP_DISCONNECTED bridge message / onSessionDisconnected callback.
     let finalized = false;
     const finalize = async () => {
       if (finalized) return;
       finalized = true;
 
+      const useExplicit = teardown.explicit;
       const activeConn = this.connections.get(channelId);
       if (activeConn) {
-        // Drop the map entry synchronously so a concurrent disconnectSession
-        // for the same channel no-ops the socket teardown below.
+        // Drop the map entry synchronously so nothing else can re-enter.
         this.connections.delete(channelId);
         // An explicit disconnect ("forget" / user-initiated) marks a durable
         // relay tombstone so an absent dApp learns the session is dead on its
@@ -587,7 +609,7 @@ export class DAppConnectService {
         // flush before disconnect() so the close/leave packet actually reaches
         // the relay instead of being dropped with the torn-down socket.
         try {
-          if (explicit) {
+          if (useExplicit) {
             await activeConn.socketClient.closeChannel();
           } else {
             await activeConn.socketClient.leaveChannel();
@@ -602,16 +624,12 @@ export class DAppConnectService {
       this.handlers?.onSessionsChanged();
 
       if (isInNativeApp()) {
-        sendToNative('DAPP_DISCONNECTED' as never, { channelId, explicit });
+        sendToNative('DAPP_DISCONNECTED' as never, { channelId, explicit: useExplicit });
       }
     };
 
-    if (!conn || !conn.keyExchange.areKeysExchanged()) {
-      await finalize();
-      return;
-    }
-
     const sendTerminate = async () => {
+      if (!conn) return;
       try {
         const encrypted = await conn.keyExchange.encryptMessage(
           JSON.stringify({ type: MessageType.TERMINATE })
@@ -627,12 +645,17 @@ export class DAppConnectService {
     };
 
     try {
-      await Promise.race([
-        sendTerminate(),
-        new Promise((resolve) => setTimeout(resolve, TERMINATE_SEND_TIMEOUT_MS)),
-      ]);
+      // Only attempt the encrypted TERMINATE when there's a live, keyed
+      // session; otherwise go straight to teardown.
+      if (conn && conn.keyExchange.areKeysExchanged()) {
+        await Promise.race([
+          sendTerminate(),
+          new Promise((resolve) => setTimeout(resolve, TERMINATE_SEND_TIMEOUT_MS)),
+        ]);
+      }
     } finally {
       await finalize();
+      this.finalizing.delete(channelId);
     }
   }
 
@@ -811,9 +834,15 @@ export class DAppConnectService {
     }
   }
 
-  private async sendEncrypted(channelId: string, message: object): Promise<void> {
+  /**
+   * Encrypt + send a message to the dApp. Resolves true if it was actually
+   * transmitted, false if there was no connection or the send failed. The
+   * boolean lets callers (approve/reject) gate the return-to-dApp redirect on
+   * a real successful send rather than assuming success.
+   */
+  private async sendEncrypted(channelId: string, message: object): Promise<boolean> {
     const conn = this.connections.get(channelId);
-    if (!conn) return;
+    if (!conn) return false;
     try {
       const encrypted = await conn.keyExchange.encryptMessage(
         JSON.stringify(message)
@@ -823,15 +852,17 @@ export class DAppConnectService {
         clientType: 'wallet',
         message: encrypted,
       });
+      return true;
     } catch (err) {
       console.error('[DAppConnect] Failed to send encrypted:', err);
+      return false;
     }
   }
 
   private sendJsonRpcResponse(
     channelId: string,
     response: JsonRpcResponse
-  ): Promise<void> {
+  ): Promise<boolean> {
     return this.sendEncrypted(channelId, {
       type: MessageType.JSONRPC,
       ...response,

--- a/src/services/dappConnect/DAppConnectService.ts
+++ b/src/services/dappConnect/DAppConnectService.ts
@@ -260,7 +260,7 @@ export class DAppConnectService {
       // joined to the relay channel and keeps firing onMessage handlers
       // for a channel whose ActiveConnection we've already dropped.
       try {
-        socketClient.leaveChannel();
+        await socketClient.leaveChannel();
       } catch {
         // ignore — we're already in the error path
       }
@@ -549,9 +549,17 @@ export class DAppConnectService {
     // phone is wrong (e.g. a desktop dApp's http://localhost:5174).
     if (!conn?.originatedViaDeepLink) return;
     const redirectUrl = conn.dappInfo.redirectUrl;
-    if (redirectUrl) {
-      sendToNative('DAPP_RETURN', { channelId, redirectUrl });
+    if (!redirectUrl) return;
+    // The redirectUrl comes from the dApp's ORIGINATOR_INFO (attacker
+    // controllable). Validate the scheme before crossing the bridge. The
+    // native side also allowlists, but stopping it here keeps a dangerous
+    // scheme (javascript:, tel:, etc.) from ever reaching native.
+    const scheme = /^([a-z][a-z0-9.+-]*):/i.exec(redirectUrl)?.[1]?.toLowerCase();
+    if (!scheme || !['https', 'http', 'qrlconnect'].includes(scheme)) {
+      dlog(`Ignoring dApp redirectUrl with unsupported scheme: ${redirectUrl}`);
+      return;
     }
+    sendToNative('DAPP_RETURN', { channelId, redirectUrl });
   }
 
   async disconnectSession(channelId: string, explicit = true): Promise<void> {
@@ -564,22 +572,29 @@ export class DAppConnectService {
     // dApp) must not each run the full teardown and fire a second
     // DAPP_DISCONNECTED bridge message / onSessionDisconnected callback.
     let finalized = false;
-    const finalize = () => {
+    const finalize = async () => {
       if (finalized) return;
       finalized = true;
 
       const activeConn = this.connections.get(channelId);
       if (activeConn) {
+        // Drop the map entry synchronously so a concurrent disconnectSession
+        // for the same channel no-ops the socket teardown below.
+        this.connections.delete(channelId);
         // An explicit disconnect ("forget" / user-initiated) marks a durable
         // relay tombstone so an absent dApp learns the session is dead on its
-        // next join; a grace-timeout leave is transient and must not.
-        if (explicit) {
-          activeConn.socketClient.closeChannel();
-        } else {
-          activeConn.socketClient.leaveChannel();
+        // next join; a grace-timeout leave is transient and must not. Await the
+        // flush before disconnect() so the close/leave packet actually reaches
+        // the relay instead of being dropped with the torn-down socket.
+        try {
+          if (explicit) {
+            await activeConn.socketClient.closeChannel();
+          } else {
+            await activeConn.socketClient.leaveChannel();
+          }
+        } finally {
+          activeConn.socketClient.disconnect();
         }
-        activeConn.socketClient.disconnect();
-        this.connections.delete(channelId);
       }
 
       SessionStore.remove(channelId);
@@ -592,7 +607,7 @@ export class DAppConnectService {
     };
 
     if (!conn || !conn.keyExchange.areKeysExchanged()) {
-      finalize();
+      await finalize();
       return;
     }
 
@@ -617,7 +632,7 @@ export class DAppConnectService {
         new Promise((resolve) => setTimeout(resolve, TERMINATE_SEND_TIMEOUT_MS)),
       ]);
     } finally {
-      finalize();
+      await finalize();
     }
   }
 
@@ -714,6 +729,15 @@ export class DAppConnectService {
         }
       } catch (err) {
         console.error('[DAppConnect] Failed to reconnect session:', session.id, err);
+        // The connection was added to this.connections before the join; if the
+        // join failed (e.g. transient network), tear it down so a later
+        // reconnectAll can retry. Left in place it would be skipped on every
+        // retry (has() is true) and never auto-rejoin (hasJoinedOnce is false).
+        const failed = this.connections.get(session.id);
+        if (failed) {
+          failed.socketClient.disconnect();
+          this.connections.delete(session.id);
+        }
         SessionStore.updateStatus(session.id, SessionStatus.DISCONNECTED);
       }
     }

--- a/src/services/dappConnect/DAppConnectService.ts
+++ b/src/services/dappConnect/DAppConnectService.ts
@@ -183,6 +183,10 @@ export class DAppConnectService {
       onParticipantsChanged: (data) => {
         this.handleParticipantsChanged(channelId, data);
       },
+      onTerminated: () => {
+        // Auto-rejoin saw the channel tombstoned (dApp closed it). Tear down.
+        void this.disconnectSession(channelId, false);
+      },
     });
 
     const connection: ActiveConnection = {
@@ -499,16 +503,18 @@ export class DAppConnectService {
 
   approveRequest(sessionId: string, requestId: string | number, result: unknown): void {
     // Send the response FIRST, and only bounce back to the dApp once it has
-    // left the relay. maybeReturnToDApp backgrounds the wallet (the OS may
-    // then suspend it); if we redirected before the response was transmitted,
-    // the dApp would never receive the approval.
+    // actually been transmitted. maybeReturnToDApp backgrounds the wallet (the
+    // OS may then suspend it); redirecting before/without a successful send
+    // would strand the dApp on a request it never received. Hence .then (on
+    // success) rather than .finally (which also fires on send failure).
     this.sendJsonRpcResponse(sessionId, {
       jsonrpc: '2.0',
       id: requestId,
       result,
-    })
-      .catch((err) => console.error('[DAppConnect] Failed to send approve response:', err))
-      .finally(() => this.maybeReturnToDApp(sessionId));
+    }).then(
+      () => this.maybeReturnToDApp(sessionId),
+      (err) => console.error('[DAppConnect] Failed to send approve response:', err)
+    );
     if (isInNativeApp()) triggerHaptic('success');
   }
 
@@ -521,9 +527,10 @@ export class DAppConnectService {
       jsonrpc: '2.0',
       id: requestId,
       error: { code: 4001, message },
-    })
-      .catch((err) => console.error('[DAppConnect] Failed to send reject response:', err))
-      .finally(() => this.maybeReturnToDApp(sessionId));
+    }).then(
+      () => this.maybeReturnToDApp(sessionId),
+      (err) => console.error('[DAppConnect] Failed to send reject response:', err)
+    );
     if (isInNativeApp()) triggerHaptic('error');
   }
 
@@ -661,6 +668,11 @@ export class DAppConnectService {
             onParticipantsChanged: (data) => {
               this.handleParticipantsChanged(session.id, data);
             },
+            onTerminated: () => {
+              // The dApp closed the channel while we were transiently away
+              // (auto-rejoin saw the tombstone). Drop the dead session.
+              void this.disconnectSession(session.id, false);
+            },
           }
         );
 
@@ -679,7 +691,19 @@ export class DAppConnectService {
         });
 
         socketClient.connect();
-        const { bufferedMessages } = await socketClient.joinChannel(session.id);
+        const { bufferedMessages, terminated } = await socketClient.joinChannel(session.id);
+
+        if (terminated) {
+          // The dApp explicitly closed this channel while the wallet was
+          // offline. Drop the dead session instead of resurrecting a ghost
+          // that shows active but can never reach the gone dApp.
+          dlog(`Stored session ${session.id} was terminated by the dApp; dropping`);
+          socketClient.disconnect();
+          this.connections.delete(session.id);
+          SessionStore.remove(session.id);
+          this.handlers?.onSessionDisconnected(session.id);
+          continue;
+        }
 
         for (const msg of bufferedMessages) {
           this.enqueueRelayMessage(session.id, msg as RelayMessage);
@@ -715,6 +739,18 @@ export class DAppConnectService {
     data: { event: string; clientType?: string }
   ): void {
     dlog(`Participants changed: ${data.event} (${data.clientType || 'unknown'})`);
+
+    // The dApp (or relay) explicitly terminated the channel via close_channel.
+    // This is durable, not a transient backgrounding leave, so tear down now
+    // instead of arming the rejoin grace, otherwise the session lingers as a
+    // ghost (shown active) until the socket drops or the channel TTL expires.
+    // explicit=false makes teardown emit leave_channel rather than
+    // close_channel, so we do not bounce a redundant close back to the relay.
+    if (data.event === 'close') {
+      this.clearDappLeaveTimeout(channelId);
+      void this.disconnectSession(channelId, false);
+      return;
+    }
 
     if (data.event === 'join' && data.clientType === 'dapp') {
       this.clearDappLeaveTimeout(channelId);

--- a/src/services/dappConnect/SocketClient.ts
+++ b/src/services/dappConnect/SocketClient.ts
@@ -14,6 +14,8 @@ type SocketEventHandler = {
   onDisconnected: (reason: string) => void;
   onReconnected: () => void;
   onParticipantsChanged: (data: { event: string; clientType?: string }) => void;
+  /** The relay reported a terminated (tombstoned) channel on (re)join. */
+  onTerminated?: () => void;
 };
 
 export class SocketClient {
@@ -51,7 +53,14 @@ export class SocketClient {
       // with it here and emit join_channel twice on the first connect.
       if (this.channelId && this.hasJoinedOnce) {
         this.emitJoinChannel(this.channelId)
-          .then(({ bufferedMessages }) => {
+          .then(({ bufferedMessages, terminated }) => {
+            if (terminated) {
+              // The dApp explicitly closed the channel while we were away.
+              // Don't deliver stale buffered messages or flip back to
+              // CONNECTED; surface the termination so the session is dropped.
+              this.handlers.onTerminated?.();
+              return;
+            }
             for (const msg of bufferedMessages) {
               this.handlers.onMessage(msg as RelayMessage);
             }
@@ -83,7 +92,7 @@ export class SocketClient {
 
   async joinChannel(
     channelId: string
-  ): Promise<{ bufferedMessages: unknown[]; channelPublicKey: string | null }> {
+  ): Promise<{ bufferedMessages: unknown[]; channelPublicKey: string | null; terminated: boolean }> {
     this.channelId = channelId;
     if (!this.socket) {
       throw new Error('Socket not initialised; call connect() before joinChannel()');
@@ -126,7 +135,7 @@ export class SocketClient {
 
   private emitJoinChannel(
     channelId: string
-  ): Promise<{ bufferedMessages: unknown[]; channelPublicKey: string | null }> {
+  ): Promise<{ bufferedMessages: unknown[]; channelPublicKey: string | null; terminated: boolean }> {
     return new Promise((resolve, reject) => {
       this.socket!.emit(
         'join_channel',
@@ -136,11 +145,13 @@ export class SocketClient {
           error?: string;
           bufferedMessages?: unknown[];
           channelPublicKey?: string | null;
+          terminated?: boolean;
         }) => {
           if (response?.success) {
             resolve({
               bufferedMessages: response.bufferedMessages || [],
               channelPublicKey: response.channelPublicKey ?? null,
+              terminated: response.terminated === true,
             });
           } else {
             reject(new Error(response?.error || 'Failed to join channel'));

--- a/src/services/dappConnect/SocketClient.ts
+++ b/src/services/dappConnect/SocketClient.ts
@@ -7,6 +7,10 @@ import type { RelayMessage } from './types';
 import { logToNative } from '@/utils/nativeApp';
 
 const RELAY_PATH = '/relay';
+// Give an outbound leave/close packet a bounded window to reach the relay
+// (resolving on its ack) before the socket is torn down, so disconnect() can't
+// drop the unflushed packet and lose the tombstone / leave notification.
+const SEND_FLUSH_TIMEOUT_MS = 600;
 
 type SocketEventHandler = {
   onMessage: (data: RelayMessage) => void;
@@ -178,24 +182,50 @@ export class SocketClient {
     });
   }
 
-  leaveChannel(): void {
-    if (this.socket?.connected && this.channelId) {
-      this.socket.emit('leave_channel', { channelId: this.channelId });
-    }
+  /**
+   * Emit an event and resolve once the relay acks it, or after a bounded
+   * flush window. Lets a caller await transmission before tearing the socket
+   * down (socket.io buffers emits, and disconnect() drops anything unflushed).
+   */
+  private flushEmit(event: string, payload: object): Promise<void> {
+    return new Promise((resolve) => {
+      if (!this.socket?.connected) {
+        resolve();
+        return;
+      }
+      let settled = false;
+      const done = (): void => {
+        if (settled) return;
+        settled = true;
+        resolve();
+      };
+      const timer = setTimeout(done, SEND_FLUSH_TIMEOUT_MS);
+      this.socket.emit(event, payload, () => {
+        clearTimeout(timer);
+        done();
+      });
+    });
+  }
+
+  leaveChannel(): Promise<void> {
+    const channelId = this.channelId;
     this.channelId = null;
+    if (!this.socket?.connected || !channelId) return Promise.resolve();
+    return this.flushEmit('leave_channel', { channelId });
   }
 
   /**
    * Explicitly terminate the channel on the relay (intentional disconnect /
    * "forget"), as opposed to a transient leave. The relay marks a durable
    * tombstone so the dApp learns the session is dead even if it is not
-   * currently joined and only re-joins later.
+   * currently joined and only re-joins later. Resolves once the close is
+   * flushed (or times out) so the caller can safely disconnect afterwards.
    */
-  closeChannel(): void {
-    if (this.socket?.connected && this.channelId) {
-      this.socket.emit('close_channel', { channelId: this.channelId });
-    }
+  closeChannel(): Promise<void> {
+    const channelId = this.channelId;
     this.channelId = null;
+    if (!this.socket?.connected || !channelId) return Promise.resolve();
+    return this.flushEmit('close_channel', { channelId });
   }
 
   disconnect(): void {

--- a/src/services/dappConnect/SocketClient.ts
+++ b/src/services/dappConnect/SocketClient.ts
@@ -174,6 +174,19 @@ export class SocketClient {
     this.channelId = null;
   }
 
+  /**
+   * Explicitly terminate the channel on the relay (intentional disconnect /
+   * "forget"), as opposed to a transient leave. The relay marks a durable
+   * tombstone so the dApp learns the session is dead even if it is not
+   * currently joined and only re-joins later.
+   */
+  closeChannel(): void {
+    if (this.socket?.connected && this.channelId) {
+      this.socket.emit('close_channel', { channelId: this.channelId });
+    }
+    this.channelId = null;
+  }
+
   disconnect(): void {
     this.channelId = null;
     if (this.socket) {

--- a/src/services/dappConnect/types.ts
+++ b/src/services/dappConnect/types.ts
@@ -6,6 +6,12 @@ export interface DAppInfo {
   url: string;
   icon?: string;
   chainId: string;
+  /**
+   * Optional return-to-dApp target sent by the dApp in ORIGINATOR_INFO.
+   * After the wallet resolves a restricted request, the native app opens
+   * this so a same-device deep-link user is bounced back to the dApp.
+   */
+  redirectUrl?: string;
 }
 
 /**

--- a/src/utils/nativeApp.ts
+++ b/src/utils/nativeApp.ts
@@ -29,7 +29,8 @@ export type WebToNativeMessageType =
   | 'DAPP_SHOW_WEBVIEW'     // Request native to show/focus WebView (for approval modal)
   | 'DAPP_CONNECTED'        // Notify native that a dApp connected
   | 'DAPP_DISCONNECTED'     // Notify native that a dApp disconnected
-  | 'DAPP_HAPTIC';          // Trigger haptic for dApp approve/reject
+  | 'DAPP_HAPTIC'           // Trigger haptic for dApp approve/reject
+  | 'DAPP_RETURN';          // Bounce back to the dApp after approval (peer redirect)
 
 /**
  * Message types that can be received from the native app


### PR DESCRIPTION
Wallet-side connection-resilience (see review). **Stacked on `feat/post-quantum-signing` (PR #148)**; retarget to the integration branch once that merges.

## Changes
- **`DAPP_REJOIN_GRACE_MS` 30s -> 90s.** A same-device deep-link round trip suspends the dApp's browser tab while the wallet is foregrounded, dropping its relay socket; 30s was shorter than the real round trip and tore down sessions the relay buffer/channel would otherwise preserve. 90s covers it without leaving a genuinely-gone dApp active for long.
- **Explicit disconnect emits the relay `close_channel`** (new `SocketClient.closeChannel`) so an absent dApp learns the session was terminated on its next join. A grace-timeout leave stays transient.
- **`DAPP_RETURN` bridge after approve/reject**: if the dApp advertised `redirectUrl` in ORIGINATOR_INFO (new `DAppInfo.redirectUrl`), the wallet tells native to bounce the user back to the dApp on a same-device flow.

## Gates
`lint`, `build`, `jest` -> 23 passing.