### PR TITLE
chore(deps): upgrade @theqrl/web3 1.0 + wallet.js 6 (+ ws override)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,8 +26,8 @@
         "@tailwindcss/postcss": "^4.1.18",
         "@tailwindcss/typography": "^0.5.19",
         "@tanstack/react-table": "^8.21.2",
-        "@theqrl/wallet.js": "^3.0.1",
-        "@theqrl/web3": "^0.4.0",
+        "@theqrl/wallet.js": "^6.1.0",
+        "@theqrl/web3": "^1.0.0",
         "@types/crypto-js": "^4.2.2",
         "axios": "^1.16.0",
         "bignumber.js": "^9.3.1",
@@ -107,9 +107,9 @@
       "license": "MIT"
     },
     "node_modules/@adraffy/ens-normalize": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
-      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.8.8.tgz",
+      "integrity": "sha512-QbJczL+zOCNUBkfjCww1DfhL+KNYgC/yCBApqT3d8b9BHg7CFw4O3bTY0BOogiMhw/vGnV2FD17bstxXWn61EA==",
       "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
@@ -2822,15 +2822,15 @@
       }
     },
     "node_modules/@ethereumjs/rlp": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-4.0.1.tgz",
-      "integrity": "sha512-tqsQiBQDQdmPWE1xkkBq4rlSW5QZpLOUJ5RJh2/9fug+q9tnUhuZoVLk7s0scUIKTOzEtR72DFBXI4WiZcMpvw==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-10.1.1.tgz",
+      "integrity": "sha512-jbnWTEwcpoY+gE0r+wxfDG9zgiu54DcTcwnc9sX3DsqKR4l5K7x2V8mQL3Et6hURa4DuT9g7z6ukwpBLFchszg==",
       "license": "MPL-2.0",
       "bin": {
-        "rlp": "bin/rlp"
+        "rlp": "bin/rlp.cjs"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=20"
       }
     },
     "node_modules/@ethersproject/abstract-provider": {
@@ -6045,36 +6045,48 @@
       }
     },
     "node_modules/@theqrl/abi": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@theqrl/abi/-/abi-0.4.4.tgz",
-      "integrity": "sha512-3rG8SNF92KUGC1DR95YkFPI+dv7FC0FVEnMKI4oA0VV+wJnEptHySNIOmYFQNEMu+M+wPrPkT9h8jl5uv2/Iag==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/abi/-/abi-1.0.0.tgz",
+      "integrity": "sha512-cZr1gGCRTDCkb6ND7wCKDclj149+nO1YMovVI9z9TBXdlNLLFfG+s90m5g5DyPIpCV4d2SfTxottAdYyJ3TRKA==",
       "license": "MIT",
       "dependencies": {
-        "@ethersproject/address": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/constants": "^5.7.0",
-        "@ethersproject/hash": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0",
-        "@theqrl/web3-utils": "0.4.4"
+        "@ethersproject/address": "5.8.0",
+        "@ethersproject/bignumber": "5.8.0",
+        "@ethersproject/bytes": "5.8.0",
+        "@ethersproject/constants": "5.8.0",
+        "@ethersproject/hash": "5.8.0",
+        "@ethersproject/keccak256": "5.8.0",
+        "@ethersproject/logger": "5.8.0",
+        "@ethersproject/properties": "5.8.0",
+        "@ethersproject/strings": "5.8.0",
+        "@theqrl/web3-utils": "1.0.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theqrl/mldsa87": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@theqrl/mldsa87/-/mldsa87-2.0.1.tgz",
-      "integrity": "sha512-BPEvwrrphkMjyPnDorMzQdfrtICTZsiUxiBnwFkv2SfIcQwTTPQV3kTVfidZXXE7033ZCvhu1u5Aiw6TrjxPPQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/mldsa87/-/mldsa87-2.1.1.tgz",
+      "integrity": "sha512-CwjPRzXjVr19ACuyJLEMITuQrXOsQAIHbkeFrlxIyNqGX67oCipVo6ASvPQOzE5DvJ36hX5amWZtkFJ/RVI18g==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "2.0.1"
+        "@noble/hashes": "2.2.0"
       },
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@theqrl/mldsa87/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@theqrl/qrl-cryptography": {
@@ -6127,180 +6139,204 @@
       }
     },
     "node_modules/@theqrl/wallet.js": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@theqrl/wallet.js/-/wallet.js-3.0.1.tgz",
-      "integrity": "sha512-2kDlvUQAoks6W/pYNcjXEBLXd3v+h0yN1kqx3oz21kBRXIwtDm2EhrMmIAOE44fvapDRmLfypfZipX1W2WIjKg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/wallet.js/-/wallet.js-6.1.0.tgz",
+      "integrity": "sha512-Onsj3rNZHDhzl0rj5RLwr3dWXC4yz/mZV9G8OpZsnmGwQe11mX6+b0uRuXZDA49sGDC1jQ8LDpm7oF048P/v0Q==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "2.0.1",
-        "@theqrl/mldsa87": "2.0.1"
+        "@noble/hashes": "2.2.0",
+        "@theqrl/mldsa87": "2.1.1"
       },
       "engines": {
         "node": ">=20.19"
       }
     },
+    "node_modules/@theqrl/wallet.js/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@theqrl/web3": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3/-/web3-0.4.4.tgz",
-      "integrity": "sha512-5XHHQP2RXB4BzUuvu1iTRxsRhtYqiXKx1TcyfMuKGFCifykP2jxEt0B2AG9cD8DnbRh6JWmavrDeK/aeu10d+A==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3/-/web3-1.0.0.tgz",
+      "integrity": "sha512-KV5H94nmXoZrZqukY9sOg7a8n6sKiPZAxJvMWa7UZqdkJQJmVU1aCp9owHufPE8ZrBCmcZb4+3bo05IRTgbpXQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-core": "0.4.4",
-        "@theqrl/web3-errors": "0.4.3",
-        "@theqrl/web3-net": "0.4.4",
-        "@theqrl/web3-providers-http": "0.4.4",
-        "@theqrl/web3-providers-ws": "0.4.4",
-        "@theqrl/web3-qrl": "0.4.4",
-        "@theqrl/web3-qrl-abi": "0.4.4",
-        "@theqrl/web3-qrl-accounts": "0.4.4",
-        "@theqrl/web3-qrl-contract": "0.4.4",
-        "@theqrl/web3-qrl-iban": "0.4.4",
-        "@theqrl/web3-qrl-qrns": "0.4.4",
-        "@theqrl/web3-rpc-methods": "0.4.4",
-        "@theqrl/web3-types": "0.4.3",
-        "@theqrl/web3-utils": "0.4.4",
-        "@theqrl/web3-validator": "0.4.4"
+        "@theqrl/web3-core": "1.0.0",
+        "@theqrl/web3-errors": "1.0.0",
+        "@theqrl/web3-net": "1.0.0",
+        "@theqrl/web3-providers-http": "1.0.0",
+        "@theqrl/web3-providers-ws": "1.0.0",
+        "@theqrl/web3-qrl": "1.0.0",
+        "@theqrl/web3-qrl-abi": "1.0.0",
+        "@theqrl/web3-qrl-accounts": "1.0.0",
+        "@theqrl/web3-qrl-contract": "1.0.0",
+        "@theqrl/web3-qrl-iban": "1.0.0",
+        "@theqrl/web3-qrl-qrns": "1.0.0",
+        "@theqrl/web3-rpc-methods": "1.0.0",
+        "@theqrl/web3-types": "1.0.0",
+        "@theqrl/web3-utils": "1.0.0",
+        "@theqrl/web3-validator": "1.0.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-core": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-core/-/web3-core-0.4.4.tgz",
-      "integrity": "sha512-GgIe3U/6NhONG7YKlYp1HzjFt8gkGwfbPac6HKDqJVpQo1dd2pNjcWUfP4EFa3YP5748xnatStQrSCBx76gg5w==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-core/-/web3-core-1.0.0.tgz",
+      "integrity": "sha512-oxs4mR4hC3tXWnan+fcWIIQP+/O9Ysb7M47jGj/NWRaix0SF70v2RKELPy57Rn/f5fsdJb8GyUCsJmOaSbDqrw==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-errors": "0.4.3",
-        "@theqrl/web3-providers-http": "0.4.4",
-        "@theqrl/web3-providers-ws": "0.4.4",
-        "@theqrl/web3-qrl-iban": "0.4.4",
-        "@theqrl/web3-types": "0.4.3",
-        "@theqrl/web3-utils": "0.4.4",
-        "@theqrl/web3-validator": "0.4.4"
+        "@theqrl/web3-errors": "1.0.0",
+        "@theqrl/web3-providers-http": "1.0.0",
+        "@theqrl/web3-providers-ws": "1.0.0",
+        "@theqrl/web3-qrl-iban": "1.0.0",
+        "@theqrl/web3-types": "1.0.0",
+        "@theqrl/web3-utils": "1.0.0",
+        "@theqrl/web3-validator": "1.0.0"
       },
       "engines": {
         "node": ">=20"
       },
       "optionalDependencies": {
-        "@theqrl/web3-providers-ipc": "0.4.4"
+        "@theqrl/web3-providers-ipc": "1.0.0"
       }
     },
     "node_modules/@theqrl/web3-errors": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-0.4.3.tgz",
-      "integrity": "sha512-tazXfP8xZdzr3MwaH6o6kLn+64CYhUS+2ybufTanVqL+YoErIwMyPQQaL/t4GBMTHypFDSy4AVRfEQLvCw+Z9w==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-1.0.0.tgz",
+      "integrity": "sha512-WTfkfQ0gnHy7yCXwEBaqgxjiQI6IlnAOeCS3YX76vkz69IJgtooYHM4jx95QMN0NCuKh3bOIyMaTPyzebYfoEg==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-types": "0.4.3"
+        "@theqrl/web3-types": "1.0.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-net": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-net/-/web3-net-0.4.4.tgz",
-      "integrity": "sha512-AeEFBYzYbJI16Iap3Td9GybFj9rAvkqCFbJYKQp4IJSWWgsEJYHcevig57cahTmeiYpNscbrmrL0jPQAI+m3Cg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-net/-/web3-net-1.0.0.tgz",
+      "integrity": "sha512-kMdyX3P3Qb9toGAw8w+tVLvYIWm+ccXHVo4ZjBDJkEyErKd+WtuOdkDLeB0W7rY3wWdIrYP5bq/sp33KfvAjzw==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-core": "0.4.4",
-        "@theqrl/web3-rpc-methods": "0.4.4",
-        "@theqrl/web3-types": "0.4.3",
-        "@theqrl/web3-utils": "0.4.4"
+        "@theqrl/web3-core": "1.0.0",
+        "@theqrl/web3-rpc-methods": "1.0.0",
+        "@theqrl/web3-types": "1.0.0",
+        "@theqrl/web3-utils": "1.0.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-providers-http": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-http/-/web3-providers-http-0.4.4.tgz",
-      "integrity": "sha512-Ol6usX4HWWPStTkfUIhdSmnGX9XZ6RciwG8mOBWkw/A0KL50LE137C+uAOb36NMK7tO/vF2E5xHdFCGM2d705g==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-http/-/web3-providers-http-1.0.0.tgz",
+      "integrity": "sha512-4f6C+zaLidNe8tx4jTS89opf0B1LTHKzNqqkO6tOaBkKAWwhQG4P+YUHxF3bR7FdD1x9cV2MO0ReDo5Mt5sG4Q==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-errors": "0.4.3",
-        "@theqrl/web3-types": "0.4.3",
-        "@theqrl/web3-utils": "0.4.4",
-        "cross-fetch": "^3.1.5"
+        "@theqrl/web3-errors": "1.0.0",
+        "@theqrl/web3-types": "1.0.0",
+        "@theqrl/web3-utils": "1.0.0",
+        "cross-fetch": "4.1.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-providers-ipc": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-ipc/-/web3-providers-ipc-0.4.4.tgz",
-      "integrity": "sha512-Dd4vOKZ3YnoiR5HJHBQse+xbeQ4zc+r9MFHs4mKalh+3oeqB3TCQOfN7NImoB2dUBMmThUlyz0C0uw0mVL7IVw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-ipc/-/web3-providers-ipc-1.0.0.tgz",
+      "integrity": "sha512-8SNNkZkoIyrwk2as45idvOKOPyIMeRxIIIaizz5pZTF4jIVdL7Fay2Xq2AtugzTns9mT/aXEoAlucLM87+Ftdg==",
       "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
-        "@theqrl/web3-errors": "0.4.3",
-        "@theqrl/web3-types": "0.4.3",
-        "@theqrl/web3-utils": "0.4.4"
+        "@theqrl/web3-errors": "1.0.0",
+        "@theqrl/web3-types": "1.0.0",
+        "@theqrl/web3-utils": "1.0.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-providers-ws": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-ws/-/web3-providers-ws-0.4.4.tgz",
-      "integrity": "sha512-AAlNywppRAZcygAro7Q0Vu7b7loCjtKdtH61EIVwKjfcAqpJFDnCCrIZ+qiLlAZO09fFuYHwzx6O4KUgzTqgfA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-ws/-/web3-providers-ws-1.0.0.tgz",
+      "integrity": "sha512-Ja0WD2ettZD1KbkgBmX5of9Xm+m0D0SBfTMKo7md++EIYKE52QLfOX9Qv8FPG90H4rlnNg5OMJDsLK3tzOlwFg==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-errors": "0.4.3",
-        "@theqrl/web3-types": "0.4.3",
-        "@theqrl/web3-utils": "0.4.4",
-        "@types/ws": "8.5.3",
-        "isomorphic-ws": "^5.0.0",
-        "ws": "^8.17.1"
+        "@theqrl/web3-errors": "1.0.0",
+        "@theqrl/web3-types": "1.0.0",
+        "@theqrl/web3-utils": "1.0.0",
+        "@types/ws": "8.18.1",
+        "isomorphic-ws": "5.0.0",
+        "ws": "8.20.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl/-/web3-qrl-0.4.4.tgz",
-      "integrity": "sha512-kBJhW3AJf5wabjuNz3kpo0CJFaO6m2Rayf7YKyYKhbIfX6fzUBOWRaL6gpFj7onR9KlO0vvHO3Lb4pXZFw6Ekw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl/-/web3-qrl-1.0.0.tgz",
+      "integrity": "sha512-sda6prwQMjkzPrommwncCfmkpXWuKg0VZ8JQKHFbbqZiqOmJwZ9sRKqHsag3eEUykDhMYQCu4ztkfom/bc7rTw==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/wallet.js": "^2.0.2",
-        "@theqrl/web3-core": "0.4.4",
-        "@theqrl/web3-errors": "0.4.3",
-        "@theqrl/web3-net": "0.4.4",
-        "@theqrl/web3-providers-ws": "0.4.4",
-        "@theqrl/web3-qrl-abi": "0.4.4",
-        "@theqrl/web3-qrl-accounts": "0.4.4",
-        "@theqrl/web3-rpc-methods": "0.4.4",
-        "@theqrl/web3-types": "0.4.3",
-        "@theqrl/web3-utils": "0.4.4",
-        "@theqrl/web3-validator": "0.4.4",
-        "setimmediate": "^1.0.5"
+        "@theqrl/wallet.js": "2.0.2",
+        "@theqrl/web3-core": "1.0.0",
+        "@theqrl/web3-errors": "1.0.0",
+        "@theqrl/web3-net": "1.0.0",
+        "@theqrl/web3-providers-ws": "1.0.0",
+        "@theqrl/web3-qrl-abi": "1.0.0",
+        "@theqrl/web3-qrl-accounts": "1.0.0",
+        "@theqrl/web3-rpc-methods": "1.0.0",
+        "@theqrl/web3-types": "1.0.0",
+        "@theqrl/web3-utils": "1.0.0",
+        "@theqrl/web3-validator": "1.0.0",
+        "setimmediate": "1.0.5"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl-abi": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-abi/-/web3-qrl-abi-0.4.4.tgz",
-      "integrity": "sha512-aI1vFF+SwDq+dOnq9AHDtAw+zHaJUqAY2PVfCvgAlbseZh26Hl/qSL27YxNN2hCZOJoHVSa3du44TZxO1qrtYA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-abi/-/web3-qrl-abi-1.0.0.tgz",
+      "integrity": "sha512-fd2/u3NBGk3VwKsnsOxT+tGkN3qC7QvZAZaz7LcjHq5N/mwqryUZaTO/kYB0i+SnhuQCiT2pLP/k8zAb8qvWYQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@ethersproject/bignumber": "^5.7.0",
-        "@theqrl/abi": "0.4.4",
-        "@theqrl/wallet.js": "^2.0.2",
-        "@theqrl/web3-errors": "0.4.3",
-        "@theqrl/web3-types": "0.4.3",
-        "@theqrl/web3-utils": "0.4.4",
-        "@theqrl/web3-validator": "0.4.4",
-        "crc-32": "^1.2.2",
-        "sha3": "^2.1.4"
+        "@ethersproject/bignumber": "5.8.0",
+        "@theqrl/abi": "1.0.0",
+        "@theqrl/wallet.js": "2.0.2",
+        "@theqrl/web3-errors": "1.0.0",
+        "@theqrl/web3-types": "1.0.0",
+        "@theqrl/web3-utils": "1.0.0",
+        "@theqrl/web3-validator": "1.0.0",
+        "crc-32": "1.2.2",
+        "sha3": "2.1.4"
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@theqrl/web3-qrl-abi/node_modules/@theqrl/mldsa87": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/mldsa87/-/mldsa87-2.0.1.tgz",
+      "integrity": "sha512-BPEvwrrphkMjyPnDorMzQdfrtICTZsiUxiBnwFkv2SfIcQwTTPQV3kTVfidZXXE7033ZCvhu1u5Aiw6TrjxPPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@theqrl/web3-qrl-abi/node_modules/@theqrl/wallet.js": {
@@ -6314,24 +6350,36 @@
       }
     },
     "node_modules/@theqrl/web3-qrl-accounts": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-accounts/-/web3-qrl-accounts-0.4.4.tgz",
-      "integrity": "sha512-0FpoMl56A+xbjuaNUCWFtpEa59T2bhuUuX+j/2zD6bYvGFO1z/DFVdhWVAFihUxZCjSwuM6p01d+azjqvMkTNg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-accounts/-/web3-qrl-accounts-1.0.0.tgz",
+      "integrity": "sha512-53Rwd3oJT45eE1N1NbTFxMZWE0VelIJ+XWgSIx3HRrcd22TsSTNF7ixSqO++ktkcG4BmZ/edHV0m+OHvkBLMRQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@ethereumjs/rlp": "^4.0.1",
-        "@theqrl/mldsa87": "^2.0.1",
-        "@theqrl/qrl-cryptography": "^0.1.0",
-        "@theqrl/wallet.js": "^2.0.2",
-        "@theqrl/web3-errors": "0.4.3",
-        "@theqrl/web3-types": "0.4.3",
-        "@theqrl/web3-utils": "0.4.4",
-        "@theqrl/web3-validator": "0.4.4",
-        "crc-32": "^1.2.2",
-        "sha3": "^2.1.4"
+        "@ethereumjs/rlp": "10.1.1",
+        "@theqrl/mldsa87": "2.0.4",
+        "@theqrl/qrl-cryptography": "0.1.3",
+        "@theqrl/wallet.js": "2.0.2",
+        "@theqrl/web3-errors": "1.0.0",
+        "@theqrl/web3-types": "1.0.0",
+        "@theqrl/web3-utils": "1.0.0",
+        "@theqrl/web3-validator": "1.0.0",
+        "crc-32": "1.2.2",
+        "sha3": "2.1.4"
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@theqrl/web3-qrl-accounts/node_modules/@theqrl/mldsa87": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/mldsa87/-/mldsa87-2.0.4.tgz",
+      "integrity": "sha512-xUcrFSZ1OeRSyzU5xCd/TuB+dE/z7U9MafNtKZYmPhRwcucNbhobsXHab8GO5w02dy732sdPidOT2Tkn+vjZuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@theqrl/web3-qrl-accounts/node_modules/@theqrl/wallet.js": {
@@ -6344,57 +6392,81 @@
         "@theqrl/mldsa87": "2.0.1"
       }
     },
+    "node_modules/@theqrl/web3-qrl-accounts/node_modules/@theqrl/wallet.js/node_modules/@theqrl/mldsa87": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/mldsa87/-/mldsa87-2.0.1.tgz",
+      "integrity": "sha512-BPEvwrrphkMjyPnDorMzQdfrtICTZsiUxiBnwFkv2SfIcQwTTPQV3kTVfidZXXE7033ZCvhu1u5Aiw6TrjxPPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@theqrl/web3-qrl-contract": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-contract/-/web3-qrl-contract-0.4.4.tgz",
-      "integrity": "sha512-dcsgwPZvV7bZGaUp9o/FDOMPmBd1unWccau/6fa8jYV8fiWcX+dgQrg8kjC0B+Qdr2ePAx9tMYzKCl1AxHVCtw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-contract/-/web3-qrl-contract-1.0.0.tgz",
+      "integrity": "sha512-Fl5tPcmBYnskT5KikmE7QNvterct4vszVWTa5hAgXi+GdBB/CbbhKLg4MBEowuXdD9WYW3llJsdlY/d9HdXpTQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-core": "0.4.4",
-        "@theqrl/web3-errors": "0.4.3",
-        "@theqrl/web3-qrl": "0.4.4",
-        "@theqrl/web3-qrl-abi": "0.4.4",
-        "@theqrl/web3-types": "0.4.3",
-        "@theqrl/web3-utils": "0.4.4",
-        "@theqrl/web3-validator": "0.4.4"
+        "@theqrl/web3-core": "1.0.0",
+        "@theqrl/web3-errors": "1.0.0",
+        "@theqrl/web3-qrl": "1.0.0",
+        "@theqrl/web3-qrl-abi": "1.0.0",
+        "@theqrl/web3-types": "1.0.0",
+        "@theqrl/web3-utils": "1.0.0",
+        "@theqrl/web3-validator": "1.0.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl-iban": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-iban/-/web3-qrl-iban-0.4.4.tgz",
-      "integrity": "sha512-9vg2VELTkA54CeMEEhE79VTVTXULTxFSOKmyl0d9+HL77EDx8hl8FL7FWbwgKYvI5RXJ3osRifNTdugPE2qGNQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-iban/-/web3-qrl-iban-1.0.0.tgz",
+      "integrity": "sha512-ggFrr7A8RVFKhMqhDAnl1c77shAea4vfSuRWvHbOqLkhAxiEakjVhjVhMJxu24epXru4JT4wQiDDNYw9dGTKBQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-errors": "0.4.3",
-        "@theqrl/web3-types": "0.4.3",
-        "@theqrl/web3-utils": "0.4.4",
-        "@theqrl/web3-validator": "0.4.4"
+        "@theqrl/web3-errors": "1.0.0",
+        "@theqrl/web3-types": "1.0.0",
+        "@theqrl/web3-utils": "1.0.0",
+        "@theqrl/web3-validator": "1.0.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl-qrns": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-qrns/-/web3-qrl-qrns-0.4.4.tgz",
-      "integrity": "sha512-lfOkrSWQidwGU2IvSWBTzo6mVFjOieUlyR7/1M0z3HyN0NOgPx8SDy6LNv2EJjBZkWzCS5e6NsLptiXq5it/Dw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-qrns/-/web3-qrl-qrns-1.0.0.tgz",
+      "integrity": "sha512-WV1O9e7VUw/BD5604C9xLU8qG3e04s7aMgpNy/Sz23N9bksZoskRJ/fTyZSWSsITSlzh4W3k4IoAi8pMg6yB5w==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@adraffy/ens-normalize": "^1.8.8",
-        "@theqrl/web3-core": "0.4.4",
-        "@theqrl/web3-errors": "0.4.3",
-        "@theqrl/web3-net": "0.4.4",
-        "@theqrl/web3-qrl": "0.4.4",
-        "@theqrl/web3-qrl-contract": "0.4.4",
-        "@theqrl/web3-types": "0.4.3",
-        "@theqrl/web3-utils": "0.4.4",
-        "@theqrl/web3-validator": "0.4.4"
+        "@adraffy/ens-normalize": "1.8.8",
+        "@theqrl/web3-core": "1.0.0",
+        "@theqrl/web3-errors": "1.0.0",
+        "@theqrl/web3-net": "1.0.0",
+        "@theqrl/web3-qrl": "1.0.0",
+        "@theqrl/web3-qrl-contract": "1.0.0",
+        "@theqrl/web3-types": "1.0.0",
+        "@theqrl/web3-utils": "1.0.0",
+        "@theqrl/web3-validator": "1.0.0"
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@theqrl/web3-qrl/node_modules/@theqrl/mldsa87": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/mldsa87/-/mldsa87-2.0.1.tgz",
+      "integrity": "sha512-BPEvwrrphkMjyPnDorMzQdfrtICTZsiUxiBnwFkv2SfIcQwTTPQV3kTVfidZXXE7033ZCvhu1u5Aiw6TrjxPPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@theqrl/web3-qrl/node_modules/@theqrl/wallet.js": {
@@ -6408,53 +6480,53 @@
       }
     },
     "node_modules/@theqrl/web3-rpc-methods": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-rpc-methods/-/web3-rpc-methods-0.4.4.tgz",
-      "integrity": "sha512-Ris/b0I1LkQhIh/8PBKwR9tONGhlhjV+559vmCZYmsRdyg1RwKI943H6Jk9EBdB6/yPBshGGPhPi2sV3V7i65g==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-rpc-methods/-/web3-rpc-methods-1.0.0.tgz",
+      "integrity": "sha512-iLgor2K+YEQrfzaIE88a63CBZkR8YqecRWUk//g1IVpTwEofhyXhRYsMAk7JjoYClcQD/IEe0VdY5H8xVpdcOQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-core": "0.4.4",
-        "@theqrl/web3-types": "0.4.3",
-        "@theqrl/web3-validator": "0.4.4"
+        "@theqrl/web3-core": "1.0.0",
+        "@theqrl/web3-types": "1.0.0",
+        "@theqrl/web3-validator": "1.0.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-types": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-0.4.3.tgz",
-      "integrity": "sha512-8RV7QN4Qx+4sjrfkNWguJsZ/P8W19zvQWkr35YmzonG+WDdEYBINIfnSt1Lxy0pcNNSpRUQ+EwdomVmMH11vmA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-1.0.0.tgz",
+      "integrity": "sha512-e3RL2TN3UNsvoPe4BVM1DY98YUiuReq5qrqUkSNp7spdFo5snxqUt2FQtRM1QDdv9qJl5tZ3ccbBt0hLHD6TCg==",
       "license": "LGPL-3.0",
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-utils": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-0.4.4.tgz",
-      "integrity": "sha512-3efGY0HhE0selNoawGbnHW/7tm3cHSK0gIedxjvIMDCQeRnhmd6nNfMAWk3GUA0H3CwGc96SHo+XP3yMDw51+Q==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-1.0.0.tgz",
+      "integrity": "sha512-TzTQBaVgCY7ZtgAPohSox5Od9ldqAOPg0JDY3oqnskguODDy7ptiWuzSZ5FYpeJOk+AhMKSJ+B8ejqGmdaZB1Q==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/qrl-cryptography": "^0.1.0",
-        "@theqrl/web3-errors": "0.4.3",
-        "@theqrl/web3-types": "0.4.3",
-        "@theqrl/web3-validator": "0.4.4"
+        "@theqrl/qrl-cryptography": "0.1.3",
+        "@theqrl/web3-errors": "1.0.0",
+        "@theqrl/web3-types": "1.0.0",
+        "@theqrl/web3-validator": "1.0.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-validator": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-0.4.4.tgz",
-      "integrity": "sha512-XhG5bnXDEdhzODDFen1ZBWTkqkeUaotdJWfzWbOHXeWKXHRuqSIPluLYgLt/Ph+s8VyPd0W+frafJi7oBsUXcw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-1.0.0.tgz",
+      "integrity": "sha512-77Jd6nipdVlZw4eBuCBN1zqUwbhp3rWKsakOtqsgsAk7PlnFYYQ+MOVe7HF2G1eH3N6H5XMobo5jZudB3pBlvw==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/qrl-cryptography": "^0.1.0",
-        "@theqrl/web3-errors": "0.4.3",
-        "@theqrl/web3-types": "0.4.3",
-        "util": "^0.12.5",
+        "@theqrl/qrl-cryptography": "0.1.3",
+        "@theqrl/web3-errors": "1.0.0",
+        "@theqrl/web3-types": "1.0.0",
+        "util": "0.12.5",
         "zod": "3.22.3"
       },
       "engines": {
@@ -6734,9 +6806,9 @@
       "license": "MIT"
     },
     "node_modules/@types/ws": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
-      "integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -8301,9 +8373,9 @@
       "license": "MIT"
     },
     "node_modules/cross-fetch": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
-      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^2.7.0"
@@ -15362,9 +15434,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "@tailwindcss/postcss": "^4.1.18",
     "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-table": "^8.21.2",
-    "@theqrl/wallet.js": "^3.0.1",
-    "@theqrl/web3": "^0.4.0",
+    "@theqrl/wallet.js": "^6.1.0",
+    "@theqrl/web3": "^1.0.0",
     "@types/crypto-js": "^4.2.2",
     "axios": "^1.16.0",
     "bignumber.js": "^9.3.1",
@@ -103,5 +103,8 @@
     "typescript": "^5.2.2",
     "typescript-eslint": "^8.48.0",
     "vite": "^7.3.2"
+  },
+  "overrides": {
+    "ws": "^8.21.0"
   }
 }

--- a/src/utils/crypto/__tests__/mnemonic.test.ts
+++ b/src/utils/crypto/__tests__/mnemonic.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Round-trip + strictness coverage for src/utils/crypto/mnemonic.ts under the
+ * upgraded post-quantum stack (@theqrl/wallet.js 6.x + @theqrl/web3 1.x).
+ *
+ * Why this exists: mnemonic.ts had ZERO direct unit coverage and was the one
+ * load-bearing path the @theqrl upgrade validation could only type-check, not
+ * runtime-verify. wallet.js 6 made the `ExtendedSeed` constructor strict (it
+ * now hard-throws on any seed that is not exactly 51 bytes with a valid
+ * ML-DSA-87 descriptor byte), so these tests pin both the happy-path round-trip
+ * and that strictness as a regression guard, and pin that the address derived
+ * via web3 `seedToAccount` equals the signing-path slice-math derivation
+ * (sign.ts: toChecksumAddress('Q' + getAddressStr().slice(1, 41))).
+ *
+ * cryptoWorkerClient is mocked: it touches `navigator` and a Vite `?worker`
+ * import at module load, neither of which exists in jest's node env. The
+ * functions under test are synchronous and never call into the worker.
+ */
+
+jest.mock('../cryptoWorkerClient', () => ({
+  deriveHexSeedAsync: jest.fn(),
+  CryptoErrorCode: {},
+  CryptoOperationError: class extends Error {},
+}));
+
+import { MLDSA87 } from '@theqrl/wallet.js';
+import Web3, { utils as web3Utils } from '@theqrl/web3';
+import {
+  getMnemonicFromHexSeed,
+  getHexSeedFromMnemonic,
+  getAddressFromMnemonic,
+} from '../mnemonic';
+
+// A pinned, well-formed 51-byte ML-DSA-87 extended seed (descriptor 0x01),
+// taken from the cross-repo signing parity fixture (canonical.json). Used to
+// confirm the strict ExtendedSeed ctor accepts a known-good seed.
+const PINNED_HEX_SEED =
+  '0x0100000580a227e1b6d5a89df7723a71e9c03535e9447ec6d160b68c0ba845c68a05c59226cce711eb3db312c022ccf9577be7';
+
+describe('mnemonic.ts under wallet.js 6 + web3 1.0', () => {
+  it('round-trips a freshly generated wallet: mnemonic <-> hexSeed', () => {
+    const wallet = MLDSA87.newWallet();
+    try {
+      const hexSeed = wallet.getHexExtendedSeed();
+      const mnemonic = wallet.getMnemonic();
+      // mnemonic -> hexSeed
+      expect(getHexSeedFromMnemonic(mnemonic)).toBe(hexSeed);
+      // hexSeed -> mnemonic (exercises the strict ExtendedSeed ctor on a good seed)
+      expect(getMnemonicFromHexSeed(hexSeed)).toBe(mnemonic);
+    } finally {
+      // Always wipe key material from memory, even if an assertion throws.
+      wallet.zeroize();
+    }
+  });
+
+  it('accepts the pinned canonical seed and round-trips it deterministically', () => {
+    const mnemonic = getMnemonicFromHexSeed(PINNED_HEX_SEED);
+    // The seed is fixed, so derivation must be deterministic and non-empty (a
+    // truncated/partial derivation would change this) and must round-trip back
+    // to the exact same seed.
+    expect(mnemonic).toBeTruthy();
+    expect(getMnemonicFromHexSeed(PINNED_HEX_SEED)).toBe(mnemonic);
+    expect(getHexSeedFromMnemonic(mnemonic)).toBe(PINNED_HEX_SEED);
+  });
+
+  it('derives the canonical checksummed Q-address, matching the signing-path slice math', () => {
+    const wallet = MLDSA87.newWallet();
+    let mnemonic: string;
+    let viaSliceMath: string;
+    try {
+      mnemonic = wallet.getMnemonic();
+      // signing path (sign.ts): signer = toChecksumAddress('Q' + getAddressStr().slice(1, 41))
+      viaSliceMath = web3Utils.toChecksumAddress('Q' + wallet.getAddressStr().slice(1, 41));
+    } finally {
+      // Wipe key material even if getAddressStr / toChecksumAddress throws.
+      wallet.zeroize();
+    }
+
+    const web3 = new Web3('http://localhost:8545');
+    const viaSeedToAccount = getAddressFromMnemonic(mnemonic, web3.qrl);
+
+    expect(viaSeedToAccount).toBe(viaSliceMath);
+    expect(viaSeedToAccount).toMatch(/^Q[0-9a-fA-F]{40}$/);
+  });
+
+  it('wallet.js 6 ExtendedSeed ctor is strict: rejects malformed seeds (regression pin)', () => {
+    // 50 bytes: one short of the required 51-byte extended seed.
+    expect(() => getMnemonicFromHexSeed('0x' + '00'.repeat(50))).toThrow(/must be 51 bytes/);
+    // 51 bytes but descriptor byte 0x00 != ML_DSA_87 (0x01).
+    expect(() => getMnemonicFromHexSeed('0x' + '00'.repeat(51))).toThrow(
+      /Invalid wallet type in descriptor/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Upgrades the core QRL blockchain libraries to latest on the frontend:
- `@theqrl/web3` `^0.4.0` → `^1.0.0` (whole `@theqrl/web3-*` family → 1.0.0)
- `@theqrl/wallet.js` `^3.0.1` → `^6.1.0`
- adds `overrides: { ws: ^8.20.1 }` → resolves ws to 8.21.0 and **closes dependabot #75** (GHSA-58qx-3vcg-4xpx). Even `web3-providers-ws@1.0` declares `ws 8.20.0` (still in the vuln range), so the override is the durable fix.

The code diff is a **pure dependency bump** — zero changes to the 21 `src` files that import `@theqrl/*`. The only added source is a hardening test (see below).

## Validation (10-agent adversarial workflow + manual gates)
**Verdict: GO, high confidence, zero blocking issues.** Every skeptic returned `holds=true`; no runtime break the type-checker misses.
- **Signing parity preserved** — 24/24 byte-locked cross-repo vectors pass against the upgraded libs (`fixtures.test.ts` asserts exact signature/publicKey/signer/digest bytes, not just round-trip). The signing *core* is `@theqrl/mldsa87` + `@noble/hashes` (byte-unchanged); wallet.js only does key *derivation*, and `sign.ts` bypasses wallet.js's own signing/ctx (`slice(1,41)` signer derivation — first 20 bytes byte-identical across 3.0.1→6.1.0). **SDK `@qrlwallet/connect@3.0.0` cross-verify is intact.**
- **web3 0.4→1.0** — byte-level tarball diff shows compiled output of web3-qrl/web3-utils/web3-qrl-contract/web3-validator/web3-core is **identical** (a stability re-tag). Numeric returns did not flip string↔bigint; `receipt.status` was already boolean.
- **wallet.js 3→6** — exports additive-only for the symbols we import; v4/v5/v6 breaking changes (variable address length, ZOND ctx, 64-byte addresses) are inert here.
- Gates: `lint` 0 warnings · `tsc` clean · **77 tests pass** · `build` green.

## Hardening (the one residual risk → now a gate)
`src/utils/crypto/mnemonic.ts` had **zero** unit coverage and wallet.js 6's `ExtendedSeed` ctor is now strict (hard-throws on non-51-byte / non-ML-DSA-87 seeds). Added `mnemonic.test.ts` pinning: fresh + canonical-seed `mnemonic↔hexSeed` round-trips, `seedToAccount` address == signing-path slice-math, and the strict-ctor rejection (regression guard).

## ⚠️ Before merge — runtime smoke test on dev (tsc/unit can't cover RPC wire)
This is a metadata bump; the residual risk is RPC/transport, not the JS API. On `dev.qrlwallet.com` (testnet v2, chainId `0x539`):
- [ ] Build on the actual Linux deploy host (`npm install && npm run build`) — a local WSL build had a Rollup case-sensitivity hiccup on `@/components/UI/Loading` (file exists, import unchanged vs dev, tsc resolves it; clean build passes here, but confirm on host).
- [ ] Balance load (getBalance → fromPlanck) shows full precision.
- [ ] **Send native tx** → fee estimate, broadcast, receipt event, txHash, gas-cost display (#1 gate — proves the RPC round-trips on web3 1.0).
- [ ] Account **create** + **import via mnemonic AND hex seed** → same Q-address, no `ExtendedSeed` throw (mnemonic.ts path).
- [ ] dApp connect + **qrl_signMessage** and **qrl_signTypedData** round-trip verify on the dApp (zondscan.com/dapp-example) via SDK 3.0.0.
- [ ] Token create via factory + token transfer; NFT view (contract `.call()` reads).

## Notes / out of scope
- The **react-router 2× HIGH** advisories are **pre-existing on `dev`** (not introduced here) — fixed on a separate branch `fix/react-router-security`.
- Non-blocking nits for a later cleanup: stale `sign.ts` comment ("97-char", actually 129); `tokenStore.ts:484 Number(effectiveGasPrice)` display-only precision loss (pre-existing).

**Do not auto-merge** — merge after the dev smoke test above.
