### PR TITLE
refactor(deps): drop ethers, fix ws in-range (no override) - closes #75

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "crypto-js": "^4.2.0",
-        "ethers": "^6.13.5",
         "lucide-react": "^0.562.0",
         "mobx": "^6.13.0",
         "mobx-react-lite": "^4.0.7",
@@ -7447,12 +7446,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/aes-js": {
-      "version": "4.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
-      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
-      "license": "MIT"
-    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -8811,15 +8804,15 @@
       "license": "MIT"
     },
     "node_modules/engine.io-client": {
-      "version": "6.6.4",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.4.tgz",
-      "integrity": "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==",
+      "version": "6.6.5",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.5.tgz",
+      "integrity": "sha512-QCwxUDULPlXv8F6tqMMKx5dNkTe6OaBYRMPYeXKBlyOoKvAmE0ac6pW7fFhSscJ/5SI7666/U/B+MElbsrJlIg==",
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.4.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.18.3",
+        "ws": "~8.20.1",
         "xmlhttprequest-ssl": "~2.1.1"
       }
     },
@@ -9463,106 +9456,6 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/ethers": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.16.0.tgz",
-      "integrity": "sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/ethers-io/"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@adraffy/ens-normalize": "1.10.1",
-        "@noble/curves": "1.2.0",
-        "@noble/hashes": "1.3.2",
-        "@types/node": "22.7.5",
-        "aes-js": "4.0.0-beta.5",
-        "tslib": "2.7.0",
-        "ws": "8.17.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/ethers/node_modules/@adraffy/ens-normalize": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
-      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
-      "license": "MIT"
-    },
-    "node_modules/ethers/node_modules/@noble/curves": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
-      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.3.2"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/ethers/node_modules/@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/ethers/node_modules/@types/node": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
-      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.19.2"
-      }
-    },
-    "node_modules/ethers/node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-      "license": "0BSD"
-    },
-    "node_modules/ethers/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "license": "MIT"
-    },
-    "node_modules/ethers/node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/exit-x": {
@@ -15594,9 +15487,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "crypto-js": "^4.2.0",
-    "ethers": "^6.13.5",
     "lucide-react": "^0.562.0",
     "mobx": "^6.13.0",
     "mobx-react-lite": "^4.0.7",

--- a/src/components/Core/Body/CreateToken/TokenCreationForm/TokenCreationForm.tsx
+++ b/src/components/Core/Body/CreateToken/TokenCreationForm/TokenCreationForm.tsx
@@ -24,7 +24,7 @@ import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { useEffect, useState } from "react";
 import { useStore } from "@/stores/store";
-import { ethers } from "ethers";
+import { formatUnits, parseUnits } from "@/utils/web3/units";
 import { useNavigate } from "react-router-dom";
 import { ROUTES } from "@/router/router";
 import { PinInput } from "@/components/UI/PinInput/PinInput";
@@ -105,7 +105,7 @@ export const TokenCreationForm = observer(
 
         const formatRealValue = (supply: string, decimals: number) => {
             try {
-                return ethers.formatUnits(supply, decimals);
+                return formatUnits(supply, decimals);
             } catch {
                 return "Invalid value";
             }
@@ -170,12 +170,12 @@ export const TokenCreationForm = observer(
 
                 const tokenName = formData.tokenName;
                 const tokenSymbol = formData.tokenSymbol;
-                const initialSupply = ethers.parseUnits(formData.initialSupply, formData.decimals).toString();
+                const initialSupply = parseUnits(formData.initialSupply, formData.decimals).toString();
                 const decimals = formData.decimals;
-                const maxSupply = formData.maxSupply ? ethers.parseUnits(formData.maxSupply, decimals).toString() : undefined;
+                const maxSupply = formData.maxSupply ? parseUnits(formData.maxSupply, decimals).toString() : undefined;
                 const recipientAddress = formData.recipientAddress;
-                const maxWalletAmount = formData.maxWalletAmount ? ethers.parseUnits(formData.maxWalletAmount, decimals).toString() : undefined;
-                const maxTransactionLimit = formData.maxTransactionLimit ? ethers.parseUnits(formData.maxTransactionLimit, decimals).toString() : undefined;
+                const maxWalletAmount = formData.maxWalletAmount ? parseUnits(formData.maxWalletAmount, decimals).toString() : undefined;
+                const maxTransactionLimit = formData.maxTransactionLimit ? parseUnits(formData.maxTransactionLimit, decimals).toString() : undefined;
 
                 // Navigate immediately to show loading state, then start creation
                 tokenStore.setCreatingToken(tokenName, true);

--- a/src/components/Core/Body/Tokens/TokenForm/TokenForm.tsx
+++ b/src/components/Core/Body/Tokens/TokenForm/TokenForm.tsx
@@ -14,7 +14,7 @@ import { useStore } from "@/stores/store";
 import { Button } from "@/components/UI/Button";
 import { Check, Plus, RefreshCw, Import, Coins, Sparkles } from "lucide-react";
 import { AddTokenModal } from "../AddTokenModal/AddTokenModal";
-import { formatUnits } from "ethers";
+import { formatUnits } from "@/utils/web3/units";
 import { QRL_PROVIDER } from "@/config";
 import { StorageUtil } from "@/utils/storage";
 

--- a/src/components/Core/Body/Transfer/Transfer.tsx
+++ b/src/components/Core/Body/Transfer/Transfer.tsx
@@ -48,7 +48,7 @@ import { FeeLevel } from "@/stores/qrlStore";
 import { SEO } from "@/components/SEO/SEO";
 import { getOptimalTokenBalance, formatAddressShort } from "@/utils/formatting";
 import { fetchBalance } from "@/utils/web3";
-import { formatUnits, parseUnits } from "ethers";
+import { formatUnits, parseUnits } from "@/utils/web3/units";
 import { BigNumber } from "bignumber.js";
 
 const Transfer = observer(() => {

--- a/src/utils/web3/__tests__/units.test.ts
+++ b/src/utils/web3/__tests__/units.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Coverage for the ethers-free fixed-point unit conversion (src/utils/web3/units.ts).
+ * Expected values were verified byte-for-byte against ethers v6
+ * formatUnits/parseUnits before ethers was removed from the project.
+ */
+import { formatUnits, parseUnits } from "../units";
+
+describe("formatUnits (ethers v6 parity)", () => {
+  it.each([
+    [1500000n, 6, "1.5"],
+    [1000000n, 6, "1.0"],
+    [1230000n, 6, "1.23"],
+    [0n, 18, "0.0"],
+    [10n ** 18n, 18, "1.0"],
+    [123456789012345678n, 18, "0.123456789012345678"],
+    [999999999999999999n, 18, "0.999999999999999999"],
+    [1n, 18, "0.000000000000000001"],
+    [42n, 0, "42"],
+    [1000000n, 0, "1000000"],
+    [100000000n, 8, "1.0"],
+  ])("formatUnits(%s, %s) = %s", (value, decimals, expected) => {
+    expect(formatUnits(value, decimals)).toBe(expected);
+  });
+
+  it("accepts string and number inputs", () => {
+    expect(formatUnits("1500000", 6)).toBe("1.5");
+    expect(formatUnits(1500000, 6)).toBe("1.5");
+  });
+
+  it("throws on a non-numeric value", () => {
+    expect(() => formatUnits("not-a-number", 6)).toThrow(/invalid value/);
+  });
+});
+
+describe("parseUnits (ethers v6 parity)", () => {
+  it.each([
+    ["1.5", 6, 1500000n],
+    ["1", 6, 1000000n],
+    ["0.000001", 6, 1n],
+    ["123.456", 18, 123456000000000000000n],
+    ["0", 18, 0n],
+    ["1000000", 0, 1000000n],
+    ["999999999999.999999", 6, 999999999999999999n],
+  ])("parseUnits(%s, %s) = %s", (value, decimals, expected) => {
+    expect(parseUnits(value, decimals)).toBe(expected);
+  });
+
+  it("round-trips with formatUnits", () => {
+    const raw = parseUnits("1234.567891", 8);
+    expect(formatUnits(raw, 8)).toBe("1234.567891");
+  });
+
+  it("throws on more fractional digits than decimals allows", () => {
+    expect(() => parseUnits("1.5", 0)).toThrow(/more than 0 decimal places/);
+    expect(() => parseUnits("0.0000001", 6)).toThrow(/more than 6 decimal places/);
+  });
+
+  it("throws on a non-numeric value", () => {
+    expect(() => parseUnits("abc", 6)).toThrow(/invalid decimal value/);
+  });
+});

--- a/src/utils/web3/units.ts
+++ b/src/utils/web3/units.ts
@@ -1,0 +1,55 @@
+/**
+ * ERC20 fixed-point unit conversion, drop-in compatible with ethers v6
+ * `formatUnits` / `parseUnits`.
+ *
+ * These replace the only two `ethers` imports left in the app (token amount
+ * display + transaction amount parsing). `ethers` was otherwise unused, and its
+ * exact-pinned transitive `ws@8.17.1` was the sole reason the app needed a `ws`
+ * dependency override; removing ethers lets `ws` resolve to a patched version
+ * in-range with no override.
+ *
+ * Implemented on bignumber.js (already a dependency) with a self-contained
+ * config clone, so behavior is exact and independent of any global
+ * BigNumber.config() set elsewhere in the app.
+ */
+import { BigNumber } from "bignumber.js";
+
+// EXPONENTIAL_AT high so large/small magnitudes never render in scientific
+// notation; DECIMAL_PLACES high so no value is ever rounded.
+const BN = BigNumber.clone({ EXPONENTIAL_AT: 1e9, DECIMAL_PLACES: 100 });
+
+/**
+ * Convert a base-unit integer amount to a human-readable decimal string.
+ * Matches ethers v6: full precision, trailing zeros stripped, but always at
+ * least one fractional digit (e.g. `1.0`).
+ */
+export function formatUnits(value: bigint | string | number, decimals: number = 18): string {
+  const v = new BN(typeof value === "bigint" ? value.toString() : value);
+  if (v.isNaN()) {
+    throw new Error(`formatUnits: invalid value "${String(value)}"`);
+  }
+  let s = v.shiftedBy(-decimals).toFixed();
+  // ethers keeps at least one fractional digit when decimals > 0 (e.g. "1.0"),
+  // but renders a plain integer when decimals === 0 (e.g. "42").
+  if (decimals > 0 && !s.includes(".")) {
+    s += ".0";
+  }
+  return s;
+}
+
+/**
+ * Convert a human-readable decimal string to a base-unit BigInt.
+ * Matches ethers v6: throws on a non-numeric value or on more fractional
+ * digits than `decimals` allows.
+ */
+export function parseUnits(value: string, decimals: number = 18): bigint {
+  const v = new BN(value);
+  if (v.isNaN()) {
+    throw new Error(`parseUnits: invalid decimal value "${value}"`);
+  }
+  const scaled = v.shiftedBy(decimals);
+  if (!scaled.isInteger()) {
+    throw new Error(`parseUnits: "${value}" has more than ${decimals} decimal places`);
+  }
+  return BigInt(scaled.toFixed(0));
+}


### PR DESCRIPTION
## Summary
Removes `ethers` from the wallet and fixes the `ws` vulnerability **without an `overrides` block** (per review feedback that overrides are a band-aid).

**Why ethers was the problem:** `ethers` was used *only* for `formatUnits`/`parseUnits` in 3 files, but it **exact-pins a nested `ws@8.17.1`** (and the latest `ethers@6.16.0` still does). That exact pin was the *sole* reason the app needed a `ws` override — npm can't dedupe a nested exact-pin, and no ethers release bumps it.

**The fix:**
- New `src/utils/web3/units.ts` — `formatUnits`/`parseUnits` on `bignumber.js` (already a dep), **proven byte-identical to ethers v6** across a value × decimals matrix *before* ethers was removed (temp parity test; now a standalone test with the verified expected values).
- `ethers` removed from `package.json`.
- With ethers gone, `ws` resolves to **8.20.1 in-range** (the CVE-patched version for GHSA-58qx-3vcg-4xpx) via `npm update` — **no `overrides` block**. The remaining consumers (`@theqrl/web3-providers-ws ^8.8.1`, `socket.io-client`→`engine.io-client`, `jsdom`) all permit it. **Closes dependabot #75.**

## Validation
`lint` 0 warnings · **`test` 96 passing** (incl. 23 new `units` tests parity-verified vs ethers) · `build` green. Financial-grade: `parseUnits` (transaction amounts) is byte-exact; round-trip tested.

## Scope note
This does **not** touch react-router (that's the separate security PR #160) — the 2 HIGH react-router advisories still show here because this branch is based on `dev`. This PR's job is ethers/ws only.

**Smoke on dev:** token balance display, send-token amount, and create-token supply/limits all flow through `formatUnits`/`parseUnits` — worth a quick check that amounts render and parse correctly.
