### PR TITLE
fix(units): parseUnits rejects non-decimal input (ethers parity) - PR #161 follow-up

### DIFF
--- a/src/utils/web3/__tests__/units.test.ts
+++ b/src/utils/web3/__tests__/units.test.ts
@@ -58,4 +58,15 @@ describe("parseUnits (ethers v6 parity)", () => {
   it("throws on a non-numeric value", () => {
     expect(() => parseUnits("abc", 6)).toThrow(/invalid decimal value/);
   });
+
+  it("rejects non-decimal formats that bignumber.js would otherwise accept (ethers parity)", () => {
+    // bignumber.js silently parses these; ethers v6 (and now we) reject them.
+    expect(() => parseUnits("0x11", 6)).toThrow(/invalid decimal value/);
+    expect(() => parseUnits("0b101", 6)).toThrow(/invalid decimal value/);
+    expect(() => parseUnits("0o17", 6)).toThrow(/invalid decimal value/);
+    expect(() => parseUnits("1e3", 6)).toThrow(/invalid decimal value/);
+    expect(() => parseUnits("", 6)).toThrow(/invalid decimal value/);
+    expect(() => parseUnits("1.2.3", 6)).toThrow(/invalid decimal value/);
+    expect(() => parseUnits("  ", 6)).toThrow(/invalid decimal value/);
+  });
 });

--- a/src/utils/web3/units.ts
+++ b/src/utils/web3/units.ts
@@ -43,7 +43,14 @@ export function formatUnits(value: bigint | string | number, decimals: number = 
  * digits than `decimals` allows.
  */
 export function parseUnits(value: string, decimals: number = 18): bigint {
-  const v = new BN(value);
+  // Strict decimal-string validation. ethers v6 rejects non-decimal formats,
+  // but bignumber.js silently parses hex/binary/octal prefixes (e.g. "0x11" ->
+  // 17). For a transaction-amount parser that would be a dangerous mismatch, so
+  // reject anything that is not an optionally-signed base-10 decimal here.
+  if (typeof value !== 'string' || !/^-?(\d+(\.\d+)?|\.\d+)$/.test(value.trim())) {
+    throw new Error(`parseUnits: invalid decimal value "${value}"`);
+  }
+  const v = new BN(value.trim());
   if (v.isNaN()) {
     throw new Error(`parseUnits: invalid decimal value "${value}"`);
   }


### PR DESCRIPTION
Follow-up to #161 review (Gemini medium). `bignumber.js` silently parses hex/binary/octal/scientific (`parseUnits('0x11', 6)` -> `17000000`), but ethers v6 `parseUnits` strictly rejects non-decimal input. For a **transaction-amount / token-supply parser** that's a real correctness gap (a `0x...` form value would be accepted as a wrong decimal). Adds a strict base-10 decimal regex guard. `formatUnits` is intentionally unchanged - its value is BigNumberish, where ethers also accepts hex. +7 rejection tests (hex/bin/oct/sci/empty/double-dot/whitespace). lint/test/build green.