### PR TITLE
perf(tx): tune web3 receipt polling for QRL 60s block (~100 RPC calls/tx -> ~10)

### DIFF
--- a/src/stores/qrlStore.ts
+++ b/src/stores/qrlStore.ts
@@ -3,6 +3,7 @@ import { deriveHexSeedAsync } from "@/utils/crypto";
 import { StorageUtil, AccountListItem, AccountSource } from "@/utils/storage";
 import { log } from "@/utils";
 import { getQrlWeb3 } from "@/utils/web3";
+import { QRL_TX_POLLING_CONFIG } from "@/utils/web3/txPolling";
 import type { TransactionReceipt, Web3QRLInterface } from "@theqrl/web3";
 import { action, computed, makeAutoObservable, observable, runInAction } from "mobx";
 
@@ -241,7 +242,9 @@ class QrlStore {
       }
       const Web3 = this._Web3;
       const httpProvider = new Web3.providers.HttpProvider(url);
-      const { qrl } = new Web3({ provider: httpProvider });
+      // QRL blocks are ~60s; web3's default 1s receipt polling + 24-confirmation
+      // watch fires ~100 RPC calls per tx. QRL_TX_POLLING_CONFIG slows it to ~10.
+      const { qrl } = new Web3({ provider: httpProvider, config: QRL_TX_POLLING_CONFIG });
 
 
       runInAction(() => {

--- a/src/utils/web3/__tests__/txPolling.test.ts
+++ b/src/utils/web3/__tests__/txPolling.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Guards the QRL transaction-polling config: that it stays sane for a ~60s block
+ * time, that the installed web3 actually honors it (catches a config-API change
+ * on a future web3 upgrade), and that it genuinely improves on the web3 defaults.
+ */
+import Web3 from '@theqrl/web3';
+import { QRL_TX_POLLING_CONFIG } from '../txPolling';
+
+const PROVIDER = () => new Web3.providers.HttpProvider('http://localhost:8545');
+
+describe('QRL_TX_POLLING_CONFIG', () => {
+  it('polls slowly enough for a ~60s block time and waits on a single confirmation', () => {
+    expect(QRL_TX_POLLING_CONFIG.transactionPollingInterval).toBeGreaterThanOrEqual(5000);
+    expect(QRL_TX_POLLING_CONFIG.transactionConfirmationBlocks).toBeLessThanOrEqual(2);
+    expect(QRL_TX_POLLING_CONFIG.transactionPollingTimeout).toBeGreaterThanOrEqual(QRL_TX_POLLING_CONFIG.transactionPollingInterval);
+  });
+
+  it('is actually applied by the installed @theqrl/web3 (guards against a config-API change on upgrade)', () => {
+    const { qrl } = new Web3({ provider: PROVIDER(), config: QRL_TX_POLLING_CONFIG });
+    expect(qrl.transactionPollingInterval).toBe(QRL_TX_POLLING_CONFIG.transactionPollingInterval);
+    expect(qrl.transactionConfirmationBlocks).toBe(QRL_TX_POLLING_CONFIG.transactionConfirmationBlocks);
+    expect(qrl.transactionPollingTimeout).toBe(QRL_TX_POLLING_CONFIG.transactionPollingTimeout);
+  });
+
+  it('improves drastically over the web3 4.x defaults it replaces', () => {
+    // Documents the defaults that caused ~100 RPC calls/tx; if a web3 upgrade
+    // changes these, this test flags that our override math needs review.
+    const { qrl } = new Web3(PROVIDER());
+    expect(qrl.transactionPollingInterval).toBe(1000);
+    expect(qrl.transactionConfirmationBlocks).toBe(24);
+    expect(QRL_TX_POLLING_CONFIG.transactionPollingInterval).toBeGreaterThan(qrl.transactionPollingInterval);
+    expect(QRL_TX_POLLING_CONFIG.transactionConfirmationBlocks).toBeLessThan(qrl.transactionConfirmationBlocks);
+  });
+});

--- a/src/utils/web3/txPolling.ts
+++ b/src/utils/web3/txPolling.ts
@@ -1,0 +1,20 @@
+/**
+ * web3.js transaction-polling config tuned for QRL's ~60-second block time.
+ *
+ * web3.js 4.x defaults are `transactionPollingInterval: 1000` (poll the receipt
+ * every 1s) and `transactionConfirmationBlocks: 24` (keep polling for 24
+ * confirmations after the receipt). On a 1-minute-block chain that fires ~100+
+ * `getTransactionReceipt` / block RPC calls per transaction (~60 just to see
+ * the receipt, then ~24 blocks ≈ 24 minutes of confirmation polling).
+ *
+ * These values poll every 7s and require a single confirmation, cutting it to
+ * roughly ~10 RPC calls per tx. The user-facing "confirmed" state fires on the
+ * `receipt` event (first inclusion), which is unaffected by
+ * `transactionConfirmationBlocks` — that only controls how long web3 keeps
+ * watching for additional confirmations afterward.
+ */
+export const QRL_TX_POLLING_CONFIG = {
+  transactionPollingInterval: 7000,
+  transactionConfirmationBlocks: 1,
+  transactionPollingTimeout: 7 * 60 * 1000, // ~7 blocks before giving up
+};

--- a/src/utils/web3/txPolling.ts
+++ b/src/utils/web3/txPolling.ts
@@ -12,9 +12,15 @@
  * `receipt` event (first inclusion), which is unaffected by
  * `transactionConfirmationBlocks` — that only controls how long web3 keeps
  * watching for additional confirmations afterward.
+ *
+ * NOTE on units: in web3.js 4.x BOTH `transactionPollingInterval` and
+ * `transactionPollingTimeout` are MILLISECONDS (the default timeout is
+ * `750 * 1000`, and web3 divides it by 1000 only to render the seconds in its
+ * timeout error). This differs from web3.js 1.x where the timeout was seconds —
+ * do not "convert" the timeout to seconds.
  */
 export const QRL_TX_POLLING_CONFIG = {
-  transactionPollingInterval: 7000,
+  transactionPollingInterval: 7000, // ms
   transactionConfirmationBlocks: 1,
-  transactionPollingTimeout: 7 * 60 * 1000, // ~7 blocks before giving up
+  transactionPollingTimeout: 7 * 60 * 1000, // ms (7 min, ~7 blocks) — NOT seconds
 };


### PR DESCRIPTION
## Problem
On dev, sending one tx fired ~100 `getTransactionReceipt` RPC calls (observed in DevTools) against a chain with a ~60s block time.

## Cause
web3.js 4.x defaults: `transactionPollingInterval: 1000ms` + `transactionConfirmationBlocks: 24`. So the `.send().on('receipt')` path polls the receipt every 1s (~60 polls/block) and then keeps polling for **24 confirmations** (~24 blocks ≈ 24 min) afterward. (Verified: `new Web3(provider).qrl.transactionPollingInterval === 1000`, `...ConfirmationBlocks === 24`.)

## Fix
New `src/utils/web3/txPolling.ts` -> `QRL_TX_POLLING_CONFIG` (interval 7s, 1 confirmation, 7-min timeout), passed to the `Web3` constructor in `qrlStore`. Cuts it to ~10 RPC calls/tx. The user-facing 'confirmed' state fires on the `receipt` event (first inclusion), unaffected by `transactionConfirmationBlocks`, so **UX is unchanged**.

## Tests (per the request to cover 'that sort of stuff')
`txPolling.test.ts`: asserts sane values, that the **installed web3 actually honors the config** (guards a future web3 upgrade silently changing the API), and that it beats the documented 1000ms/24-block defaults. lint / test (104) / build green.

Note: `fetchPendingTxDetails` is a separate, bounded (10x/15s) poll against the **explorer API** (not RPC) for the pending-tx UI — left as-is.