### PR TITLE
Make token list per-account scoped like NFT list

### DIFF
--- a/src/components/NativeAppBridge.tsx
+++ b/src/components/NativeAppBridge.tsx
@@ -301,7 +301,11 @@ const NativeAppBridge: React.FC = () => {
             StorageUtil.clearAccountList(blockchain);
             StorageUtil.clearTransactionValues(blockchain);
           }
-          StorageUtil.clearTokenList();
+          // Full wipe: remove every account-scoped token + NFT list
+          // (and any legacy global keys). Unlike logout, CLEAR_WALLET is
+          // an explicit "erase everything" request from native settings.
+          StorageUtil.clearAllTokenData();
+          StorageUtil.clearAllNftData();
 
           // Confirm to native that web cleared its data
           confirmWalletCleared();

--- a/src/stores/tokenStore.ts
+++ b/src/stores/tokenStore.ts
@@ -127,12 +127,25 @@ class TokenStore {
     );
   }
 
+  // Token storage is now keyed by `${blockchain}_${account}` (see
+  // StorageUtil), mirroring the NFT list. Reads from the wrong scope are
+  // impossible, but we still need the scope to write. Pulls live values
+  // from qrlStore at the call site.
+  private get scope(): { blockchain: string; account: string } {
+    return {
+      blockchain: this.qrlStore.qrlConnection.blockchain,
+      account: this.qrlStore.activeAccount.accountAddress,
+    };
+  }
+
   // Called by Store after QrlStore.initializeBlockchain finishes (via the
   // qrlStore.onBlockchainReady hook). Restores the persisted token list and
   // hidden-token list, then seeds known tokens.
   async initialize() {
     await this.migrateLegacyAutoAddedTokens();
-    const persistedList = await StorageUtil.getTokenList();
+    await this.migrateGlobalTokenListToAccount();
+    const { blockchain, account } = this.scope;
+    const persistedList = await StorageUtil.getTokenList(blockchain, account);
     runInAction(() => {
       this.tokenList = persistedList;
     });
@@ -147,15 +160,50 @@ class TokenStore {
   // every token the explorer attributed to the active account into
   // tokenList, and persisted that to localStorage. After the gate, those
   // legacy entries can't be distinguished from user-curated picks — so we
-  // wipe TOKEN_LIST once on first load post-migration. The discovery
-  // picker (PR #143) repopulates legitimate holdings on the user's
-  // explicit say-so.
+  // wipe the legacy global TOKEN_LIST once on first load post-migration.
+  // The discovery picker (PR #143) repopulates legitimate holdings on the
+  // user's explicit say-so.
   private async migrateLegacyAutoAddedTokens() {
     const FLAG = "TOKEN_LIST_GATE_MIGRATED_V1";
     if (localStorage.getItem(FLAG)) return;
-    await StorageUtil.clearTokenList();
+    StorageUtil.clearLegacyGlobalTokenData();
     localStorage.setItem(FLAG, "1");
     log("Migration: wiped pre-gate tokenList; flag set");
+  }
+
+  // One-shot migration: the token list used to live under a single global
+  // key shared across every account/chain. It is now scoped per
+  // `${blockchain}_${account}` like the NFT list. Move whatever the user
+  // currently has under the global key into the active account's scope,
+  // then drop the global key. Deferred (flag not set) until an account is
+  // active so we never discard the legacy list before we can re-home it.
+  private async migrateGlobalTokenListToAccount() {
+    const FLAG = "TOKEN_LIST_PER_ACCOUNT_MIGRATED_V1";
+    if (localStorage.getItem(FLAG)) return;
+    const { blockchain, account } = this.scope;
+    if (!blockchain || !account) return;
+
+    const legacyTokens = StorageUtil.getLegacyGlobalTokenList();
+    if (legacyTokens.length > 0) {
+      const existing = await StorageUtil.getTokenList(blockchain, account);
+      const seen = new Set(existing.map((t) => t.address.toLowerCase()));
+      const merged = [
+        ...existing,
+        ...legacyTokens.filter((t) => !seen.has(t.address.toLowerCase())),
+      ];
+      await StorageUtil.updateTokenList(blockchain, account, merged);
+    }
+
+    const legacyHidden = StorageUtil.getLegacyGlobalHiddenTokens();
+    for (const addr of legacyHidden) {
+      await StorageUtil.hideToken(blockchain, account, addr);
+    }
+
+    StorageUtil.clearLegacyGlobalTokenData();
+    localStorage.setItem(FLAG, "1");
+    log(
+      `Migration: moved ${legacyTokens.length} global tokens to ${blockchain}_${account}; flag set`,
+    );
   }
 
   // Called by Store after QrlStore.setActiveAccount finishes (via the
@@ -175,11 +223,16 @@ class TokenStore {
     }
 
     log(`Switching token list to account: ${newActiveAccount}`);
-    // Token storage is global (not per-account like NFTs), so we wipe
-    // on switch to prevent account A's tokens leaking into account B.
-    await StorageUtil.clearTokenList();
+    // Token storage is per-account-scoped, so an account switch just
+    // means reloading from the new scope's key. No cross-account
+    // clearing needed — the old account's list stays under its own key
+    // for when the user switches back.
+    const blockchain = this.qrlStore.qrlConnection.blockchain;
+    const persisted = await StorageUtil.getTokenList(blockchain, newActiveAccount);
+    const hidden = await StorageUtil.getHiddenTokens(blockchain, newActiveAccount);
     runInAction(() => {
-      this.tokenList = [];
+      this.tokenList = persisted;
+      this.hiddenTokens = hidden;
       // Discovered list is per-address; drop it so a picker opened
       // after the switch can't leak the prior account's results.
       this.discoveredTokens = [];
@@ -189,8 +242,8 @@ class TokenStore {
       await this.addToken(token);
     }
 
-    // Refresh balances on whatever is in the list now (KNOWN_TOKEN_LIST
-    // entries, or nothing). No explorer call.
+    // Refresh balances on whatever is in the list now (persisted picks +
+    // KNOWN_TOKEN_LIST entries). No explorer call.
     void this.refreshTokenBalances();
   }
 
@@ -239,8 +292,7 @@ class TokenStore {
     );
 
     if (!existingToken) {
-      await StorageUtil.updateTokenList([...this.tokenList, token]);
-      this.tokenList = [...this.tokenList, token];
+      await this.setTokenList([...this.tokenList, token]);
       return token;
     }
 
@@ -256,33 +308,26 @@ class TokenStore {
   }
 
   async removeToken(token: TokenInterface) {
-    await StorageUtil.updateTokenList(
+    await this.setTokenList(
       this.tokenList.filter(
         (t) => t.address.toLowerCase() !== token.address.toLowerCase(),
       ),
     );
-    this.tokenList = this.tokenList.filter(
-      (t) => t.address !== token.address,
-    );
   }
 
   async updateToken(token: TokenInterface) {
-    await StorageUtil.updateTokenList(
+    await this.setTokenList(
       this.tokenList.map((t) =>
         t.address.toLocaleLowerCase() === token.address.toLocaleLowerCase()
           ? token
           : t,
       ),
     );
-    this.tokenList = this.tokenList.map((t) =>
-      t.address.toLocaleLowerCase() === token.address.toLocaleLowerCase()
-        ? token
-        : t,
-    );
   }
 
   async setTokenList(tokenList: TokenInterface[]) {
-    await StorageUtil.updateTokenList(tokenList);
+    const { blockchain, account } = this.scope;
+    await StorageUtil.updateTokenList(blockchain, account, tokenList);
     this.tokenList = tokenList;
   }
 
@@ -594,8 +639,9 @@ class TokenStore {
       }
 
       // Stale-write guard: if the active account changed under us,
-      // abandon the result. Writing it back would clobber the new
-      // account's list (token storage is global, not per-account).
+      // abandon the result. setTokenList writes to the current scope, so
+      // a stale write would land balances computed for the old account
+      // under the new account's key.
       if (this.qrlStore.activeAccount.accountAddress !== startAccount) {
         log(
           "refreshTokenBalances: active account changed mid-refresh, abandoning stale results",
@@ -711,14 +757,17 @@ class TokenStore {
       // else: already visible — skip
     }
     if (additions.length === 0 && unhides.length === 0) return;
-    // Stale-write guard: token storage is global, so a write here after
-    // an account switch would land in the new account's view.
+    // Stale-write guard: token storage is per-account-scoped, so a write
+    // lands in the right key even after a switch, but the in-memory
+    // append would still mix the prior account's picks into the new
+    // account's tokenList.
     if (this.qrlStore.activeAccount.accountAddress !== startAccount) {
       log(
         "addDiscoveredTokens: active account changed before write, abandoning picks",
       );
       return;
     }
+    const { blockchain, account } = this.scope;
     if (additions.length > 0) {
       await this.setTokenList([...this.tokenList, ...additions]);
     }
@@ -727,7 +776,7 @@ class TokenStore {
       // collapse the observable update into a single runInAction so the
       // UI re-renders once instead of N times.
       for (const addr of unhides) {
-        await StorageUtil.unhideToken(addr);
+        await StorageUtil.unhideToken(blockchain, account, addr);
       }
       const drop = new Set(unhides.map((a) => a.toLowerCase()));
       runInAction(() => {
@@ -748,14 +797,16 @@ class TokenStore {
   }
 
   async loadHiddenTokens() {
-    const hiddenTokens = await StorageUtil.getHiddenTokens();
+    const { blockchain, account } = this.scope;
+    const hiddenTokens = await StorageUtil.getHiddenTokens(blockchain, account);
     runInAction(() => {
       this.hiddenTokens = hiddenTokens;
     });
   }
 
   async hideToken(tokenAddress: string) {
-    await StorageUtil.hideToken(tokenAddress);
+    const { blockchain, account } = this.scope;
+    await StorageUtil.hideToken(blockchain, account, tokenAddress);
     runInAction(() => {
       const lowerCaseAddress = tokenAddress.toLowerCase();
       if (
@@ -770,7 +821,8 @@ class TokenStore {
   }
 
   async unhideToken(tokenAddress: string) {
-    await StorageUtil.unhideToken(tokenAddress);
+    const { blockchain, account } = this.scope;
+    await StorageUtil.unhideToken(blockchain, account, tokenAddress);
     runInAction(() => {
       this.hiddenTokens = this.hiddenTokens.filter(
         (addr) => addr.toLowerCase() !== tokenAddress.toLowerCase(),

--- a/src/stores/tokenStore.ts
+++ b/src/stores/tokenStore.ts
@@ -327,8 +327,16 @@ class TokenStore {
 
   async setTokenList(tokenList: TokenInterface[]) {
     const { blockchain, account } = this.scope;
+    if (!blockchain || !account) return;
     await StorageUtil.updateTokenList(blockchain, account, tokenList);
-    this.tokenList = tokenList;
+    // The active account/blockchain can change during the await; only apply the
+    // result if we're still on the same scope, and wrap the observable write in
+    // runInAction (MobX strict mode forbids mutating after an await otherwise).
+    if (this.scope.blockchain === blockchain && this.scope.account === account) {
+      runInAction(() => {
+        this.tokenList = tokenList;
+      });
+    }
   }
 
   async sendToken(

--- a/src/utils/logout.ts
+++ b/src/utils/logout.ts
@@ -39,8 +39,12 @@ export const handleLogout = async (navigate: (path: string) => void) => {
             clearAttemptTracker();
         }
 
-        // Clear token list
-        await StorageUtil.clearTokenList();
+        // NOTE: token and NFT lists are intentionally NOT cleared here.
+        // They are public contract addresses (not secrets) keyed per
+        // account, so preserving them means re-importing the same account
+        // restores its curated token/NFT lists instead of forcing the
+        // user to re-add every contract. A full wipe (CLEAR_WALLET) does
+        // clear them.
 
         // Navigate to homepage
         navigate(ROUTES.HOME);

--- a/src/utils/storage/storage.ts
+++ b/src/utils/storage/storage.ts
@@ -143,16 +143,88 @@ class StorageUtil {
     this.setItem(BLOCKCHAIN_CREATED_TOKEN, { name, symbol, decimals, address, tx, blockNumber, gasUsed, effectiveGasPrice, blockHash });
   }
 
-  static async updateTokenList(tokenList: TokenInterface[]) {
-    this.setItem(TOKEN_LIST_IDENTIFIER, tokenList);
+  /**
+   * Token list — keyed by `${blockchain}_${account}` (mirrors the NFT
+   * list) so manually-added tokens from one wallet/chain never bleed
+   * into another and survive logout/re-import of the same account.
+   * Returns `[]` when either scope component is empty (caller bootstrap
+   * typically races init). Replaces the older global key which leaked
+   * across accounts on switch and across networks on chain switch.
+   */
+  private static tokenListKey(blockchain: string, account: string) {
+    return `${blockchain}_${account.toLowerCase()}_${TOKEN_LIST_IDENTIFIER}`;
   }
 
-  static async getTokenList() {
+  private static hiddenTokensKey(blockchain: string, account: string) {
+    return `${blockchain}_${account.toLowerCase()}_${HIDDEN_TOKENS_IDENTIFIER}`;
+  }
+
+  static async updateTokenList(blockchain: string, account: string, tokenList: TokenInterface[]) {
+    if (!blockchain || !account) return;
+    this.setItem(this.tokenListKey(blockchain, account), tokenList);
+  }
+
+  static async getTokenList(blockchain: string, account: string) {
+    if (!blockchain || !account) return [];
+    return this.getItem<TokenInterface[]>(this.tokenListKey(blockchain, account)) ?? [];
+  }
+
+  static async clearTokenList(blockchain: string, account: string) {
+    if (!blockchain || !account) return;
+    localStorage.removeItem(this.tokenListKey(blockchain, account));
+  }
+
+  /**
+   * Reads the pre-per-account global token list (legacy key). Used once
+   * by the migration that moves it under the active account's scope.
+   */
+  static getLegacyGlobalTokenList(): TokenInterface[] {
     return this.getItem<TokenInterface[]>(TOKEN_LIST_IDENTIFIER) ?? [];
   }
 
-  static async clearTokenList() {
+  /**
+   * Reads the pre-per-account global hidden-tokens list (legacy key).
+   */
+  static getLegacyGlobalHiddenTokens(): string[] {
+    return this.getItem<string[]>(HIDDEN_TOKENS_IDENTIFIER) ?? [];
+  }
+
+  /**
+   * Removes the legacy global token + hidden-token keys after migration.
+   */
+  static clearLegacyGlobalTokenData(): void {
     localStorage.removeItem(TOKEN_LIST_IDENTIFIER);
+    localStorage.removeItem(HIDDEN_TOKENS_IDENTIFIER);
+  }
+
+  /**
+   * Full-wipe helper: removes every account-scoped token + hidden-token
+   * key (plus any legacy global keys). Used by the explicit "clear
+   * wallet" flow, NOT by logout (logout intentionally preserves these so
+   * re-importing the same account restores its curated token list).
+   */
+  static clearAllTokenData(): void {
+    this.removeKeysEndingWith(`_${TOKEN_LIST_IDENTIFIER}`);
+    this.removeKeysEndingWith(`_${HIDDEN_TOKENS_IDENTIFIER}`);
+    this.clearLegacyGlobalTokenData();
+  }
+
+  /**
+   * Full-wipe helper: removes every account-scoped NFT + hidden-NFT key.
+   * Used by the explicit "clear wallet" flow.
+   */
+  static clearAllNftData(): void {
+    this.removeKeysEndingWith(`_${NFT_LIST_IDENTIFIER}`);
+    this.removeKeysEndingWith(`_${HIDDEN_NFTS_IDENTIFIER}`);
+  }
+
+  private static removeKeysEndingWith(suffix: string): void {
+    const toRemove: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key && key.endsWith(suffix)) toRemove.push(key);
+    }
+    toRemove.forEach((k) => localStorage.removeItem(k));
   }
 
   static async getBlockChain() {
@@ -440,30 +512,33 @@ class StorageUtil {
   }
 
   /**
-   * Get list of hidden token addresses
+   * Get list of hidden token addresses for an account scope.
    */
-  static async getHiddenTokens(): Promise<string[]> {
-    return this.getItem<string[]>(HIDDEN_TOKENS_IDENTIFIER) ?? [];
+  static async getHiddenTokens(blockchain: string, account: string): Promise<string[]> {
+    if (!blockchain || !account) return [];
+    return this.getItem<string[]>(this.hiddenTokensKey(blockchain, account)) ?? [];
   }
 
   /**
    * Add a token address to the hidden list
    */
-  static async hideToken(tokenAddress: string) {
-    const hiddenTokens = await this.getHiddenTokens();
+  static async hideToken(blockchain: string, account: string, tokenAddress: string) {
+    if (!blockchain || !account) return;
+    const hiddenTokens = await this.getHiddenTokens(blockchain, account);
     if (!hiddenTokens.some(addr => addr.toLowerCase() === tokenAddress.toLowerCase())) {
       hiddenTokens.push(tokenAddress.toLowerCase());
-      this.setItem(HIDDEN_TOKENS_IDENTIFIER, hiddenTokens);
+      this.setItem(this.hiddenTokensKey(blockchain, account), hiddenTokens);
     }
   }
 
   /**
    * Remove a token address from the hidden list
    */
-  static async unhideToken(tokenAddress: string) {
-    let hiddenTokens = await this.getHiddenTokens();
+  static async unhideToken(blockchain: string, account: string, tokenAddress: string) {
+    if (!blockchain || !account) return;
+    let hiddenTokens = await this.getHiddenTokens(blockchain, account);
     hiddenTokens = hiddenTokens.filter(addr => addr.toLowerCase() !== tokenAddress.toLowerCase());
-    this.setItem(HIDDEN_TOKENS_IDENTIFIER, hiddenTokens);
+    this.setItem(this.hiddenTokensKey(blockchain, account), hiddenTokens);
   }
 
   static async setBalanceCache(blockchain: string, balances: Record<string, string>) {
@@ -477,10 +552,11 @@ class StorageUtil {
   }
 
   /**
-   * Clear all hidden tokens (used when refreshing to re-show all)
+   * Clear all hidden tokens for an account scope (re-show all).
    */
-  static async clearHiddenTokens() {
-    localStorage.removeItem(HIDDEN_TOKENS_IDENTIFIER);
+  static async clearHiddenTokens(blockchain: string, account: string) {
+    if (!blockchain || !account) return;
+    localStorage.removeItem(this.hiddenTokensKey(blockchain, account));
   }
 
   /**


### PR DESCRIPTION
## Summary

Migrates token list storage from a global key (shared across all accounts/chains) to a per-account-scoped key (`${blockchain}_${account}`), mirroring the existing NFT list implementation. This prevents token lists from leaking between accounts on switch and ensures manually-added tokens persist when re-importing the same account.

## Key Changes

- **TokenStore**: 
  - Added `scope` getter to pull live blockchain/account values from qrlStore
  - Added `migrateGlobalTokenListToAccount()` migration that moves legacy global tokens/hidden-tokens into the active account's scope on first load post-migration
  - Updated `initialize()` to call the new migration and load tokens from the scoped key
  - Updated `onActiveAccountChanged()` to load persisted tokens/hidden-tokens from the new account's scope instead of wiping the list
  - Updated all token/hidden-token operations (`addToken`, `removeToken`, `updateToken`, `hideToken`, `unhideToken`, etc.) to use scoped storage keys
  - Refactored `setTokenList()` to accept blockchain/account parameters and persist to the scoped key

- **StorageUtil**:
  - Added `tokenListKey()` and `hiddenTokensKey()` helpers to generate scoped storage keys
  - Updated `updateTokenList()`, `getTokenList()`, `clearTokenList()` to accept blockchain/account parameters
  - Added `getLegacyGlobalTokenList()` and `getLegacyGlobalHiddenTokens()` to read pre-migration global keys
  - Added `clearLegacyGlobalTokenData()` to remove legacy global keys after migration
  - Added `clearAllTokenData()` and `clearAllNftData()` helpers for full-wipe scenarios (CLEAR_WALLET)
  - Added `removeKeysEndingWith()` helper to batch-remove all scoped keys by suffix
  - Updated `getHiddenTokens()`, `hideToken()`, `unhideToken()`, `clearHiddenTokens()` to use scoped keys

- **Logout & NativeAppBridge**:
  - Removed token list clearing from `handleLogout()` (tokens now persist per-account like NFTs)
  - Updated `NativeAppBridge` CLEAR_WALLET handler to call `clearAllTokenData()` and `clearAllNftData()` for explicit full wipe

## Implementation Details

- Migration is deferred until an active account exists to avoid discarding the legacy list before re-homing it
- Account switch now reloads tokens from the new account's scope instead of wiping; the old account's list stays under its own key
- Stale-write guards updated to reflect that storage is now per-account-scoped (writes land in the right key even after a switch, but in-memory state still needs protection)
- Logout intentionally preserves token/NFT lists so re-importing the same account restores its curated lists; only explicit CLEAR_WALLET wipes them

https://claude.ai/code/session_012cRQCzLZGcFpCWEzmoYe2g