### PR TITLE
Release: @theqrl 1.0 + wallet.js 6, react-router 7.16, drop-ethers, tx-polling, token scoping

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 
     <!-- Security Headers - main CSP is set via nginx in production -->
     <!-- This meta CSP provides baseline protection for local development -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; media-src 'self' blob:; connect-src 'self' https://qrlwallet.com wss://qrlwallet.com https://zondscan.com http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:* http://192.168.*:* ws://192.168.*:*; base-uri 'self'; form-action 'self';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; media-src 'self' blob:; connect-src 'self' https://qrlwallet.com wss://qrlwallet.com https://zondscan.com http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*; base-uri 'self'; form-action 'self';">
     <meta name="referrer" content="strict-origin-when-cross-origin">
     
     <!-- Primary Meta Tags -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,8 +26,8 @@
         "@tailwindcss/postcss": "^4.1.18",
         "@tailwindcss/typography": "^0.5.19",
         "@tanstack/react-table": "^8.21.2",
-        "@theqrl/wallet.js": "^3.0.1",
-        "@theqrl/web3": "^0.4.0",
+        "@theqrl/wallet.js": "^6.1.0",
+        "@theqrl/web3": "^1.0.0",
         "@types/crypto-js": "^4.2.2",
         "axios": "^1.16.0",
         "bignumber.js": "^9.3.1",
@@ -107,9 +107,9 @@
       "license": "MIT"
     },
     "node_modules/@adraffy/ens-normalize": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
-      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.8.8.tgz",
+      "integrity": "sha512-QbJczL+zOCNUBkfjCww1DfhL+KNYgC/yCBApqT3d8b9BHg7CFw4O3bTY0BOogiMhw/vGnV2FD17bstxXWn61EA==",
       "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
@@ -2822,15 +2822,15 @@
       }
     },
     "node_modules/@ethereumjs/rlp": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-4.0.1.tgz",
-      "integrity": "sha512-tqsQiBQDQdmPWE1xkkBq4rlSW5QZpLOUJ5RJh2/9fug+q9tnUhuZoVLk7s0scUIKTOzEtR72DFBXI4WiZcMpvw==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-10.1.1.tgz",
+      "integrity": "sha512-jbnWTEwcpoY+gE0r+wxfDG9zgiu54DcTcwnc9sX3DsqKR4l5K7x2V8mQL3Et6hURa4DuT9g7z6ukwpBLFchszg==",
       "license": "MPL-2.0",
       "bin": {
-        "rlp": "bin/rlp"
+        "rlp": "bin/rlp.cjs"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=20"
       }
     },
     "node_modules/@ethersproject/abstract-provider": {
@@ -6045,36 +6045,48 @@
       }
     },
     "node_modules/@theqrl/abi": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@theqrl/abi/-/abi-0.4.4.tgz",
-      "integrity": "sha512-3rG8SNF92KUGC1DR95YkFPI+dv7FC0FVEnMKI4oA0VV+wJnEptHySNIOmYFQNEMu+M+wPrPkT9h8jl5uv2/Iag==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/abi/-/abi-1.0.0.tgz",
+      "integrity": "sha512-cZr1gGCRTDCkb6ND7wCKDclj149+nO1YMovVI9z9TBXdlNLLFfG+s90m5g5DyPIpCV4d2SfTxottAdYyJ3TRKA==",
       "license": "MIT",
       "dependencies": {
-        "@ethersproject/address": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/constants": "^5.7.0",
-        "@ethersproject/hash": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0",
-        "@theqrl/web3-utils": "0.4.4"
+        "@ethersproject/address": "5.8.0",
+        "@ethersproject/bignumber": "5.8.0",
+        "@ethersproject/bytes": "5.8.0",
+        "@ethersproject/constants": "5.8.0",
+        "@ethersproject/hash": "5.8.0",
+        "@ethersproject/keccak256": "5.8.0",
+        "@ethersproject/logger": "5.8.0",
+        "@ethersproject/properties": "5.8.0",
+        "@ethersproject/strings": "5.8.0",
+        "@theqrl/web3-utils": "1.0.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theqrl/mldsa87": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@theqrl/mldsa87/-/mldsa87-2.0.1.tgz",
-      "integrity": "sha512-BPEvwrrphkMjyPnDorMzQdfrtICTZsiUxiBnwFkv2SfIcQwTTPQV3kTVfidZXXE7033ZCvhu1u5Aiw6TrjxPPQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/mldsa87/-/mldsa87-2.1.1.tgz",
+      "integrity": "sha512-CwjPRzXjVr19ACuyJLEMITuQrXOsQAIHbkeFrlxIyNqGX67oCipVo6ASvPQOzE5DvJ36hX5amWZtkFJ/RVI18g==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "2.0.1"
+        "@noble/hashes": "2.2.0"
       },
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@theqrl/mldsa87/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@theqrl/qrl-cryptography": {
@@ -6127,180 +6139,204 @@
       }
     },
     "node_modules/@theqrl/wallet.js": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@theqrl/wallet.js/-/wallet.js-3.0.1.tgz",
-      "integrity": "sha512-2kDlvUQAoks6W/pYNcjXEBLXd3v+h0yN1kqx3oz21kBRXIwtDm2EhrMmIAOE44fvapDRmLfypfZipX1W2WIjKg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/wallet.js/-/wallet.js-6.1.0.tgz",
+      "integrity": "sha512-Onsj3rNZHDhzl0rj5RLwr3dWXC4yz/mZV9G8OpZsnmGwQe11mX6+b0uRuXZDA49sGDC1jQ8LDpm7oF048P/v0Q==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "2.0.1",
-        "@theqrl/mldsa87": "2.0.1"
+        "@noble/hashes": "2.2.0",
+        "@theqrl/mldsa87": "2.1.1"
       },
       "engines": {
         "node": ">=20.19"
       }
     },
+    "node_modules/@theqrl/wallet.js/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@theqrl/web3": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3/-/web3-0.4.4.tgz",
-      "integrity": "sha512-5XHHQP2RXB4BzUuvu1iTRxsRhtYqiXKx1TcyfMuKGFCifykP2jxEt0B2AG9cD8DnbRh6JWmavrDeK/aeu10d+A==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3/-/web3-1.0.0.tgz",
+      "integrity": "sha512-KV5H94nmXoZrZqukY9sOg7a8n6sKiPZAxJvMWa7UZqdkJQJmVU1aCp9owHufPE8ZrBCmcZb4+3bo05IRTgbpXQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-core": "0.4.4",
-        "@theqrl/web3-errors": "0.4.3",
-        "@theqrl/web3-net": "0.4.4",
-        "@theqrl/web3-providers-http": "0.4.4",
-        "@theqrl/web3-providers-ws": "0.4.4",
-        "@theqrl/web3-qrl": "0.4.4",
-        "@theqrl/web3-qrl-abi": "0.4.4",
-        "@theqrl/web3-qrl-accounts": "0.4.4",
-        "@theqrl/web3-qrl-contract": "0.4.4",
-        "@theqrl/web3-qrl-iban": "0.4.4",
-        "@theqrl/web3-qrl-qrns": "0.4.4",
-        "@theqrl/web3-rpc-methods": "0.4.4",
-        "@theqrl/web3-types": "0.4.3",
-        "@theqrl/web3-utils": "0.4.4",
-        "@theqrl/web3-validator": "0.4.4"
+        "@theqrl/web3-core": "1.0.0",
+        "@theqrl/web3-errors": "1.0.0",
+        "@theqrl/web3-net": "1.0.0",
+        "@theqrl/web3-providers-http": "1.0.0",
+        "@theqrl/web3-providers-ws": "1.0.0",
+        "@theqrl/web3-qrl": "1.0.0",
+        "@theqrl/web3-qrl-abi": "1.0.0",
+        "@theqrl/web3-qrl-accounts": "1.0.0",
+        "@theqrl/web3-qrl-contract": "1.0.0",
+        "@theqrl/web3-qrl-iban": "1.0.0",
+        "@theqrl/web3-qrl-qrns": "1.0.0",
+        "@theqrl/web3-rpc-methods": "1.0.0",
+        "@theqrl/web3-types": "1.0.0",
+        "@theqrl/web3-utils": "1.0.0",
+        "@theqrl/web3-validator": "1.0.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-core": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-core/-/web3-core-0.4.4.tgz",
-      "integrity": "sha512-GgIe3U/6NhONG7YKlYp1HzjFt8gkGwfbPac6HKDqJVpQo1dd2pNjcWUfP4EFa3YP5748xnatStQrSCBx76gg5w==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-core/-/web3-core-1.0.0.tgz",
+      "integrity": "sha512-oxs4mR4hC3tXWnan+fcWIIQP+/O9Ysb7M47jGj/NWRaix0SF70v2RKELPy57Rn/f5fsdJb8GyUCsJmOaSbDqrw==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-errors": "0.4.3",
-        "@theqrl/web3-providers-http": "0.4.4",
-        "@theqrl/web3-providers-ws": "0.4.4",
-        "@theqrl/web3-qrl-iban": "0.4.4",
-        "@theqrl/web3-types": "0.4.3",
-        "@theqrl/web3-utils": "0.4.4",
-        "@theqrl/web3-validator": "0.4.4"
+        "@theqrl/web3-errors": "1.0.0",
+        "@theqrl/web3-providers-http": "1.0.0",
+        "@theqrl/web3-providers-ws": "1.0.0",
+        "@theqrl/web3-qrl-iban": "1.0.0",
+        "@theqrl/web3-types": "1.0.0",
+        "@theqrl/web3-utils": "1.0.0",
+        "@theqrl/web3-validator": "1.0.0"
       },
       "engines": {
         "node": ">=20"
       },
       "optionalDependencies": {
-        "@theqrl/web3-providers-ipc": "0.4.4"
+        "@theqrl/web3-providers-ipc": "1.0.0"
       }
     },
     "node_modules/@theqrl/web3-errors": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-0.4.3.tgz",
-      "integrity": "sha512-tazXfP8xZdzr3MwaH6o6kLn+64CYhUS+2ybufTanVqL+YoErIwMyPQQaL/t4GBMTHypFDSy4AVRfEQLvCw+Z9w==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-1.0.0.tgz",
+      "integrity": "sha512-WTfkfQ0gnHy7yCXwEBaqgxjiQI6IlnAOeCS3YX76vkz69IJgtooYHM4jx95QMN0NCuKh3bOIyMaTPyzebYfoEg==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-types": "0.4.3"
+        "@theqrl/web3-types": "1.0.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-net": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-net/-/web3-net-0.4.4.tgz",
-      "integrity": "sha512-AeEFBYzYbJI16Iap3Td9GybFj9rAvkqCFbJYKQp4IJSWWgsEJYHcevig57cahTmeiYpNscbrmrL0jPQAI+m3Cg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-net/-/web3-net-1.0.0.tgz",
+      "integrity": "sha512-kMdyX3P3Qb9toGAw8w+tVLvYIWm+ccXHVo4ZjBDJkEyErKd+WtuOdkDLeB0W7rY3wWdIrYP5bq/sp33KfvAjzw==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-core": "0.4.4",
-        "@theqrl/web3-rpc-methods": "0.4.4",
-        "@theqrl/web3-types": "0.4.3",
-        "@theqrl/web3-utils": "0.4.4"
+        "@theqrl/web3-core": "1.0.0",
+        "@theqrl/web3-rpc-methods": "1.0.0",
+        "@theqrl/web3-types": "1.0.0",
+        "@theqrl/web3-utils": "1.0.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-providers-http": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-http/-/web3-providers-http-0.4.4.tgz",
-      "integrity": "sha512-Ol6usX4HWWPStTkfUIhdSmnGX9XZ6RciwG8mOBWkw/A0KL50LE137C+uAOb36NMK7tO/vF2E5xHdFCGM2d705g==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-http/-/web3-providers-http-1.0.0.tgz",
+      "integrity": "sha512-4f6C+zaLidNe8tx4jTS89opf0B1LTHKzNqqkO6tOaBkKAWwhQG4P+YUHxF3bR7FdD1x9cV2MO0ReDo5Mt5sG4Q==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-errors": "0.4.3",
-        "@theqrl/web3-types": "0.4.3",
-        "@theqrl/web3-utils": "0.4.4",
-        "cross-fetch": "^3.1.5"
+        "@theqrl/web3-errors": "1.0.0",
+        "@theqrl/web3-types": "1.0.0",
+        "@theqrl/web3-utils": "1.0.0",
+        "cross-fetch": "4.1.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-providers-ipc": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-ipc/-/web3-providers-ipc-0.4.4.tgz",
-      "integrity": "sha512-Dd4vOKZ3YnoiR5HJHBQse+xbeQ4zc+r9MFHs4mKalh+3oeqB3TCQOfN7NImoB2dUBMmThUlyz0C0uw0mVL7IVw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-ipc/-/web3-providers-ipc-1.0.0.tgz",
+      "integrity": "sha512-8SNNkZkoIyrwk2as45idvOKOPyIMeRxIIIaizz5pZTF4jIVdL7Fay2Xq2AtugzTns9mT/aXEoAlucLM87+Ftdg==",
       "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
-        "@theqrl/web3-errors": "0.4.3",
-        "@theqrl/web3-types": "0.4.3",
-        "@theqrl/web3-utils": "0.4.4"
+        "@theqrl/web3-errors": "1.0.0",
+        "@theqrl/web3-types": "1.0.0",
+        "@theqrl/web3-utils": "1.0.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-providers-ws": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-ws/-/web3-providers-ws-0.4.4.tgz",
-      "integrity": "sha512-AAlNywppRAZcygAro7Q0Vu7b7loCjtKdtH61EIVwKjfcAqpJFDnCCrIZ+qiLlAZO09fFuYHwzx6O4KUgzTqgfA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-ws/-/web3-providers-ws-1.0.0.tgz",
+      "integrity": "sha512-Ja0WD2ettZD1KbkgBmX5of9Xm+m0D0SBfTMKo7md++EIYKE52QLfOX9Qv8FPG90H4rlnNg5OMJDsLK3tzOlwFg==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-errors": "0.4.3",
-        "@theqrl/web3-types": "0.4.3",
-        "@theqrl/web3-utils": "0.4.4",
-        "@types/ws": "8.5.3",
-        "isomorphic-ws": "^5.0.0",
-        "ws": "^8.17.1"
+        "@theqrl/web3-errors": "1.0.0",
+        "@theqrl/web3-types": "1.0.0",
+        "@theqrl/web3-utils": "1.0.0",
+        "@types/ws": "8.18.1",
+        "isomorphic-ws": "5.0.0",
+        "ws": "8.20.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl/-/web3-qrl-0.4.4.tgz",
-      "integrity": "sha512-kBJhW3AJf5wabjuNz3kpo0CJFaO6m2Rayf7YKyYKhbIfX6fzUBOWRaL6gpFj7onR9KlO0vvHO3Lb4pXZFw6Ekw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl/-/web3-qrl-1.0.0.tgz",
+      "integrity": "sha512-sda6prwQMjkzPrommwncCfmkpXWuKg0VZ8JQKHFbbqZiqOmJwZ9sRKqHsag3eEUykDhMYQCu4ztkfom/bc7rTw==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/wallet.js": "^2.0.2",
-        "@theqrl/web3-core": "0.4.4",
-        "@theqrl/web3-errors": "0.4.3",
-        "@theqrl/web3-net": "0.4.4",
-        "@theqrl/web3-providers-ws": "0.4.4",
-        "@theqrl/web3-qrl-abi": "0.4.4",
-        "@theqrl/web3-qrl-accounts": "0.4.4",
-        "@theqrl/web3-rpc-methods": "0.4.4",
-        "@theqrl/web3-types": "0.4.3",
-        "@theqrl/web3-utils": "0.4.4",
-        "@theqrl/web3-validator": "0.4.4",
-        "setimmediate": "^1.0.5"
+        "@theqrl/wallet.js": "2.0.2",
+        "@theqrl/web3-core": "1.0.0",
+        "@theqrl/web3-errors": "1.0.0",
+        "@theqrl/web3-net": "1.0.0",
+        "@theqrl/web3-providers-ws": "1.0.0",
+        "@theqrl/web3-qrl-abi": "1.0.0",
+        "@theqrl/web3-qrl-accounts": "1.0.0",
+        "@theqrl/web3-rpc-methods": "1.0.0",
+        "@theqrl/web3-types": "1.0.0",
+        "@theqrl/web3-utils": "1.0.0",
+        "@theqrl/web3-validator": "1.0.0",
+        "setimmediate": "1.0.5"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl-abi": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-abi/-/web3-qrl-abi-0.4.4.tgz",
-      "integrity": "sha512-aI1vFF+SwDq+dOnq9AHDtAw+zHaJUqAY2PVfCvgAlbseZh26Hl/qSL27YxNN2hCZOJoHVSa3du44TZxO1qrtYA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-abi/-/web3-qrl-abi-1.0.0.tgz",
+      "integrity": "sha512-fd2/u3NBGk3VwKsnsOxT+tGkN3qC7QvZAZaz7LcjHq5N/mwqryUZaTO/kYB0i+SnhuQCiT2pLP/k8zAb8qvWYQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@ethersproject/bignumber": "^5.7.0",
-        "@theqrl/abi": "0.4.4",
-        "@theqrl/wallet.js": "^2.0.2",
-        "@theqrl/web3-errors": "0.4.3",
-        "@theqrl/web3-types": "0.4.3",
-        "@theqrl/web3-utils": "0.4.4",
-        "@theqrl/web3-validator": "0.4.4",
-        "crc-32": "^1.2.2",
-        "sha3": "^2.1.4"
+        "@ethersproject/bignumber": "5.8.0",
+        "@theqrl/abi": "1.0.0",
+        "@theqrl/wallet.js": "2.0.2",
+        "@theqrl/web3-errors": "1.0.0",
+        "@theqrl/web3-types": "1.0.0",
+        "@theqrl/web3-utils": "1.0.0",
+        "@theqrl/web3-validator": "1.0.0",
+        "crc-32": "1.2.2",
+        "sha3": "2.1.4"
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@theqrl/web3-qrl-abi/node_modules/@theqrl/mldsa87": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/mldsa87/-/mldsa87-2.0.1.tgz",
+      "integrity": "sha512-BPEvwrrphkMjyPnDorMzQdfrtICTZsiUxiBnwFkv2SfIcQwTTPQV3kTVfidZXXE7033ZCvhu1u5Aiw6TrjxPPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@theqrl/web3-qrl-abi/node_modules/@theqrl/wallet.js": {
@@ -6314,24 +6350,36 @@
       }
     },
     "node_modules/@theqrl/web3-qrl-accounts": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-accounts/-/web3-qrl-accounts-0.4.4.tgz",
-      "integrity": "sha512-0FpoMl56A+xbjuaNUCWFtpEa59T2bhuUuX+j/2zD6bYvGFO1z/DFVdhWVAFihUxZCjSwuM6p01d+azjqvMkTNg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-accounts/-/web3-qrl-accounts-1.0.0.tgz",
+      "integrity": "sha512-53Rwd3oJT45eE1N1NbTFxMZWE0VelIJ+XWgSIx3HRrcd22TsSTNF7ixSqO++ktkcG4BmZ/edHV0m+OHvkBLMRQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@ethereumjs/rlp": "^4.0.1",
-        "@theqrl/mldsa87": "^2.0.1",
-        "@theqrl/qrl-cryptography": "^0.1.0",
-        "@theqrl/wallet.js": "^2.0.2",
-        "@theqrl/web3-errors": "0.4.3",
-        "@theqrl/web3-types": "0.4.3",
-        "@theqrl/web3-utils": "0.4.4",
-        "@theqrl/web3-validator": "0.4.4",
-        "crc-32": "^1.2.2",
-        "sha3": "^2.1.4"
+        "@ethereumjs/rlp": "10.1.1",
+        "@theqrl/mldsa87": "2.0.4",
+        "@theqrl/qrl-cryptography": "0.1.3",
+        "@theqrl/wallet.js": "2.0.2",
+        "@theqrl/web3-errors": "1.0.0",
+        "@theqrl/web3-types": "1.0.0",
+        "@theqrl/web3-utils": "1.0.0",
+        "@theqrl/web3-validator": "1.0.0",
+        "crc-32": "1.2.2",
+        "sha3": "2.1.4"
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@theqrl/web3-qrl-accounts/node_modules/@theqrl/mldsa87": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/mldsa87/-/mldsa87-2.0.4.tgz",
+      "integrity": "sha512-xUcrFSZ1OeRSyzU5xCd/TuB+dE/z7U9MafNtKZYmPhRwcucNbhobsXHab8GO5w02dy732sdPidOT2Tkn+vjZuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@theqrl/web3-qrl-accounts/node_modules/@theqrl/wallet.js": {
@@ -6344,57 +6392,81 @@
         "@theqrl/mldsa87": "2.0.1"
       }
     },
+    "node_modules/@theqrl/web3-qrl-accounts/node_modules/@theqrl/wallet.js/node_modules/@theqrl/mldsa87": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/mldsa87/-/mldsa87-2.0.1.tgz",
+      "integrity": "sha512-BPEvwrrphkMjyPnDorMzQdfrtICTZsiUxiBnwFkv2SfIcQwTTPQV3kTVfidZXXE7033ZCvhu1u5Aiw6TrjxPPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@theqrl/web3-qrl-contract": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-contract/-/web3-qrl-contract-0.4.4.tgz",
-      "integrity": "sha512-dcsgwPZvV7bZGaUp9o/FDOMPmBd1unWccau/6fa8jYV8fiWcX+dgQrg8kjC0B+Qdr2ePAx9tMYzKCl1AxHVCtw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-contract/-/web3-qrl-contract-1.0.0.tgz",
+      "integrity": "sha512-Fl5tPcmBYnskT5KikmE7QNvterct4vszVWTa5hAgXi+GdBB/CbbhKLg4MBEowuXdD9WYW3llJsdlY/d9HdXpTQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-core": "0.4.4",
-        "@theqrl/web3-errors": "0.4.3",
-        "@theqrl/web3-qrl": "0.4.4",
-        "@theqrl/web3-qrl-abi": "0.4.4",
-        "@theqrl/web3-types": "0.4.3",
-        "@theqrl/web3-utils": "0.4.4",
-        "@theqrl/web3-validator": "0.4.4"
+        "@theqrl/web3-core": "1.0.0",
+        "@theqrl/web3-errors": "1.0.0",
+        "@theqrl/web3-qrl": "1.0.0",
+        "@theqrl/web3-qrl-abi": "1.0.0",
+        "@theqrl/web3-types": "1.0.0",
+        "@theqrl/web3-utils": "1.0.0",
+        "@theqrl/web3-validator": "1.0.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl-iban": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-iban/-/web3-qrl-iban-0.4.4.tgz",
-      "integrity": "sha512-9vg2VELTkA54CeMEEhE79VTVTXULTxFSOKmyl0d9+HL77EDx8hl8FL7FWbwgKYvI5RXJ3osRifNTdugPE2qGNQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-iban/-/web3-qrl-iban-1.0.0.tgz",
+      "integrity": "sha512-ggFrr7A8RVFKhMqhDAnl1c77shAea4vfSuRWvHbOqLkhAxiEakjVhjVhMJxu24epXru4JT4wQiDDNYw9dGTKBQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-errors": "0.4.3",
-        "@theqrl/web3-types": "0.4.3",
-        "@theqrl/web3-utils": "0.4.4",
-        "@theqrl/web3-validator": "0.4.4"
+        "@theqrl/web3-errors": "1.0.0",
+        "@theqrl/web3-types": "1.0.0",
+        "@theqrl/web3-utils": "1.0.0",
+        "@theqrl/web3-validator": "1.0.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl-qrns": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-qrns/-/web3-qrl-qrns-0.4.4.tgz",
-      "integrity": "sha512-lfOkrSWQidwGU2IvSWBTzo6mVFjOieUlyR7/1M0z3HyN0NOgPx8SDy6LNv2EJjBZkWzCS5e6NsLptiXq5it/Dw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-qrns/-/web3-qrl-qrns-1.0.0.tgz",
+      "integrity": "sha512-WV1O9e7VUw/BD5604C9xLU8qG3e04s7aMgpNy/Sz23N9bksZoskRJ/fTyZSWSsITSlzh4W3k4IoAi8pMg6yB5w==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@adraffy/ens-normalize": "^1.8.8",
-        "@theqrl/web3-core": "0.4.4",
-        "@theqrl/web3-errors": "0.4.3",
-        "@theqrl/web3-net": "0.4.4",
-        "@theqrl/web3-qrl": "0.4.4",
-        "@theqrl/web3-qrl-contract": "0.4.4",
-        "@theqrl/web3-types": "0.4.3",
-        "@theqrl/web3-utils": "0.4.4",
-        "@theqrl/web3-validator": "0.4.4"
+        "@adraffy/ens-normalize": "1.8.8",
+        "@theqrl/web3-core": "1.0.0",
+        "@theqrl/web3-errors": "1.0.0",
+        "@theqrl/web3-net": "1.0.0",
+        "@theqrl/web3-qrl": "1.0.0",
+        "@theqrl/web3-qrl-contract": "1.0.0",
+        "@theqrl/web3-types": "1.0.0",
+        "@theqrl/web3-utils": "1.0.0",
+        "@theqrl/web3-validator": "1.0.0"
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@theqrl/web3-qrl/node_modules/@theqrl/mldsa87": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/mldsa87/-/mldsa87-2.0.1.tgz",
+      "integrity": "sha512-BPEvwrrphkMjyPnDorMzQdfrtICTZsiUxiBnwFkv2SfIcQwTTPQV3kTVfidZXXE7033ZCvhu1u5Aiw6TrjxPPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@theqrl/web3-qrl/node_modules/@theqrl/wallet.js": {
@@ -6408,53 +6480,53 @@
       }
     },
     "node_modules/@theqrl/web3-rpc-methods": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-rpc-methods/-/web3-rpc-methods-0.4.4.tgz",
-      "integrity": "sha512-Ris/b0I1LkQhIh/8PBKwR9tONGhlhjV+559vmCZYmsRdyg1RwKI943H6Jk9EBdB6/yPBshGGPhPi2sV3V7i65g==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-rpc-methods/-/web3-rpc-methods-1.0.0.tgz",
+      "integrity": "sha512-iLgor2K+YEQrfzaIE88a63CBZkR8YqecRWUk//g1IVpTwEofhyXhRYsMAk7JjoYClcQD/IEe0VdY5H8xVpdcOQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-core": "0.4.4",
-        "@theqrl/web3-types": "0.4.3",
-        "@theqrl/web3-validator": "0.4.4"
+        "@theqrl/web3-core": "1.0.0",
+        "@theqrl/web3-types": "1.0.0",
+        "@theqrl/web3-validator": "1.0.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-types": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-0.4.3.tgz",
-      "integrity": "sha512-8RV7QN4Qx+4sjrfkNWguJsZ/P8W19zvQWkr35YmzonG+WDdEYBINIfnSt1Lxy0pcNNSpRUQ+EwdomVmMH11vmA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-1.0.0.tgz",
+      "integrity": "sha512-e3RL2TN3UNsvoPe4BVM1DY98YUiuReq5qrqUkSNp7spdFo5snxqUt2FQtRM1QDdv9qJl5tZ3ccbBt0hLHD6TCg==",
       "license": "LGPL-3.0",
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-utils": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-0.4.4.tgz",
-      "integrity": "sha512-3efGY0HhE0selNoawGbnHW/7tm3cHSK0gIedxjvIMDCQeRnhmd6nNfMAWk3GUA0H3CwGc96SHo+XP3yMDw51+Q==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-1.0.0.tgz",
+      "integrity": "sha512-TzTQBaVgCY7ZtgAPohSox5Od9ldqAOPg0JDY3oqnskguODDy7ptiWuzSZ5FYpeJOk+AhMKSJ+B8ejqGmdaZB1Q==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/qrl-cryptography": "^0.1.0",
-        "@theqrl/web3-errors": "0.4.3",
-        "@theqrl/web3-types": "0.4.3",
-        "@theqrl/web3-validator": "0.4.4"
+        "@theqrl/qrl-cryptography": "0.1.3",
+        "@theqrl/web3-errors": "1.0.0",
+        "@theqrl/web3-types": "1.0.0",
+        "@theqrl/web3-validator": "1.0.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-validator": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-0.4.4.tgz",
-      "integrity": "sha512-XhG5bnXDEdhzODDFen1ZBWTkqkeUaotdJWfzWbOHXeWKXHRuqSIPluLYgLt/Ph+s8VyPd0W+frafJi7oBsUXcw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-1.0.0.tgz",
+      "integrity": "sha512-77Jd6nipdVlZw4eBuCBN1zqUwbhp3rWKsakOtqsgsAk7PlnFYYQ+MOVe7HF2G1eH3N6H5XMobo5jZudB3pBlvw==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/qrl-cryptography": "^0.1.0",
-        "@theqrl/web3-errors": "0.4.3",
-        "@theqrl/web3-types": "0.4.3",
-        "util": "^0.12.5",
+        "@theqrl/qrl-cryptography": "0.1.3",
+        "@theqrl/web3-errors": "1.0.0",
+        "@theqrl/web3-types": "1.0.0",
+        "util": "0.12.5",
         "zod": "3.22.3"
       },
       "engines": {
@@ -6734,9 +6806,9 @@
       "license": "MIT"
     },
     "node_modules/@types/ws": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
-      "integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -8301,9 +8373,9 @@
       "license": "MIT"
     },
     "node_modules/cross-fetch": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
-      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^2.7.0"
@@ -15362,9 +15434,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "crypto-js": "^4.2.0",
-        "ethers": "^6.13.5",
         "lucide-react": "^0.562.0",
         "mobx": "^6.13.0",
         "mobx-react-lite": "^4.0.7",
@@ -7447,12 +7446,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/aes-js": {
-      "version": "4.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
-      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
-      "license": "MIT"
-    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -8811,15 +8804,15 @@
       "license": "MIT"
     },
     "node_modules/engine.io-client": {
-      "version": "6.6.4",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.4.tgz",
-      "integrity": "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==",
+      "version": "6.6.5",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.5.tgz",
+      "integrity": "sha512-QCwxUDULPlXv8F6tqMMKx5dNkTe6OaBYRMPYeXKBlyOoKvAmE0ac6pW7fFhSscJ/5SI7666/U/B+MElbsrJlIg==",
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.4.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.18.3",
+        "ws": "~8.20.1",
         "xmlhttprequest-ssl": "~2.1.1"
       }
     },
@@ -9463,106 +9456,6 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/ethers": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.16.0.tgz",
-      "integrity": "sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/ethers-io/"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@adraffy/ens-normalize": "1.10.1",
-        "@noble/curves": "1.2.0",
-        "@noble/hashes": "1.3.2",
-        "@types/node": "22.7.5",
-        "aes-js": "4.0.0-beta.5",
-        "tslib": "2.7.0",
-        "ws": "8.17.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/ethers/node_modules/@adraffy/ens-normalize": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
-      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
-      "license": "MIT"
-    },
-    "node_modules/ethers/node_modules/@noble/curves": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
-      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.3.2"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/ethers/node_modules/@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/ethers/node_modules/@types/node": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
-      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.19.2"
-      }
-    },
-    "node_modules/ethers/node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-      "license": "0BSD"
-    },
-    "node_modules/ethers/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "license": "MIT"
-    },
-    "node_modules/ethers/node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/exit-x": {
@@ -15594,9 +15487,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "react-dom": "^19.2.3",
         "react-helmet-async": "^2.0.5",
         "react-hook-form": "^7.52.1",
-        "react-router-dom": "^7.12.0",
+        "react-router-dom": "^7.16.0",
         "socket.io-client": "^4.8.3",
         "tailwind-merge": "^2.6.0",
         "zod": "^4.3.4"
@@ -13559,9 +13559,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.12.0.tgz",
-      "integrity": "sha512-kTPDYPFzDVGIIGNLS5VJykK0HfHLY5MF3b+xj0/tTyNYL1gF1qs7u67Z9jEhQk2sQ98SUaHxlG31g1JtF7IfVw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
+      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -13581,12 +13581,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.12.0.tgz",
-      "integrity": "sha512-pfO9fiBcpEfX4Tx+iTYKDtPbrSLLCbwJ5EqP+SPYQu1VYCXdy79GSj0wttR0U4cikVdlImZuEZ/9ZNCgoaxwBA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.16.0.tgz",
+      "integrity": "sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.12.0"
+        "react-router": "7.16.0"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "react-dom": "^19.2.3",
         "react-helmet-async": "^2.0.5",
         "react-hook-form": "^7.52.1",
-        "react-router-dom": "^7.12.0",
+        "react-router-dom": "^7.16.0",
         "socket.io-client": "^4.8.3",
         "tailwind-merge": "^2.6.0",
         "zod": "^4.3.4"
@@ -3808,33 +3808,6 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
-    "node_modules/@noble/curves": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.0.0.tgz",
-      "integrity": "sha512-2upgEu0iLiDVDZkNLeFV2+ht0BAVgQnEmCk6JsOch9Rp8xfkMCbvbAZlA2pBHQc73dbl+vFOXfqkf4uemdn0bw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.3.0"
-      }
-    },
-    "node_modules/@noble/curves/node_modules/@noble/hashes": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
-      "integrity": "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/@noble/hashes": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
@@ -5362,78 +5335,6 @@
         "win32"
       ]
     },
-    "node_modules/@scure/base": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
-      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@scure/bip32": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.4.0.tgz",
-      "integrity": "sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/curves": "~1.4.0",
-        "@noble/hashes": "~1.4.0",
-        "@scure/base": "~1.1.6"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@scure/bip32/node_modules/@noble/curves": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
-      "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.4.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@scure/bip32/node_modules/@noble/hashes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@scure/bip39": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.3.0.tgz",
-      "integrity": "sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "~1.4.0",
-        "@scure/base": "~1.1.6"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@scure/bip39/node_modules/@noble/hashes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.46",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.46.tgz",
@@ -6144,9 +6045,9 @@
       }
     },
     "node_modules/@theqrl/abi": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/abi/-/abi-0.4.0.tgz",
-      "integrity": "sha512-Or7z/3cshVyfZNgqXvkZ0YkOi7TBlkfQhUlcviSW7U9+MI1S8S0MhKj2TbS8JkZxjlr5aW7+4uNDGkaM0o91gA==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/abi/-/abi-0.4.4.tgz",
+      "integrity": "sha512-3rG8SNF92KUGC1DR95YkFPI+dv7FC0FVEnMKI4oA0VV+wJnEptHySNIOmYFQNEMu+M+wPrPkT9h8jl5uv2/Iag==",
       "license": "MIT",
       "dependencies": {
         "@ethersproject/address": "^5.7.0",
@@ -6158,7 +6059,10 @@
         "@ethersproject/logger": "^5.7.0",
         "@ethersproject/properties": "^5.7.0",
         "@ethersproject/strings": "^5.7.0",
-        "@theqrl/web3-utils": "^0.4.0"
+        "@theqrl/web3-utils": "0.4.4"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/mldsa87": {
@@ -6174,23 +6078,49 @@
       }
     },
     "node_modules/@theqrl/qrl-cryptography": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/qrl-cryptography/-/qrl-cryptography-0.1.0.tgz",
-      "integrity": "sha512-fSy4qRdZGrPjTzfiRzgNctgm34c1PEDiXgiOs1GnXkLNW4unZpgLQRbwhlY4awNZy65e9IpxykrvYOx4um5dIg==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@theqrl/qrl-cryptography/-/qrl-cryptography-0.1.3.tgz",
+      "integrity": "sha512-rtgii8JB6W0Gk7jen2WZU6Iubl+mHKFUobGG6zzipippVxhbeA0Vb6SJ/Hi5IEbGr44KlY4sBZMjWEBLaSEQpw==",
       "license": "MIT",
       "dependencies": {
-        "@noble/curves": "1.0.0",
-        "@noble/hashes": "1.6.1",
-        "@theqrl/mldsa87": "2.0.1"
+        "@noble/hashes": "^2.2.0",
+        "@theqrl/mldsa87": "2.0.4"
+      },
+      "engines": {
+        "node": ">=20.19"
       }
     },
     "node_modules/@theqrl/qrl-cryptography/node_modules/@noble/hashes": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.1.tgz",
-      "integrity": "sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
       "license": "MIT",
       "engines": {
-        "node": "^14.21.3 || >=16"
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@theqrl/qrl-cryptography/node_modules/@theqrl/mldsa87": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/mldsa87/-/mldsa87-2.0.4.tgz",
+      "integrity": "sha512-xUcrFSZ1OeRSyzU5xCd/TuB+dE/z7U9MafNtKZYmPhRwcucNbhobsXHab8GO5w02dy732sdPidOT2Tkn+vjZuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@theqrl/qrl-cryptography/node_modules/@theqrl/mldsa87/node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -6210,178 +6140,167 @@
       }
     },
     "node_modules/@theqrl/web3": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3/-/web3-0.4.0.tgz",
-      "integrity": "sha512-ikpRzvJmctrkEr46V5E0etlUZBo4lhXoNFu3tS+3hjaNiExk+2IwKzSFtgL8/7k6JOZKcqjbFUUWiEBSfrtviw==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3/-/web3-0.4.4.tgz",
+      "integrity": "sha512-5XHHQP2RXB4BzUuvu1iTRxsRhtYqiXKx1TcyfMuKGFCifykP2jxEt0B2AG9cD8DnbRh6JWmavrDeK/aeu10d+A==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-core": "^0.4.0",
-        "@theqrl/web3-errors": "^0.4.0",
-        "@theqrl/web3-net": "^0.4.0",
-        "@theqrl/web3-providers-http": "^0.4.0",
-        "@theqrl/web3-providers-ws": "^0.4.0",
-        "@theqrl/web3-qrl": "^0.4.0",
-        "@theqrl/web3-qrl-abi": "^0.4.0",
-        "@theqrl/web3-qrl-accounts": "^0.4.0",
-        "@theqrl/web3-qrl-contract": "^0.4.0",
-        "@theqrl/web3-qrl-iban": "^0.4.0",
-        "@theqrl/web3-qrl-qrns": "^0.4.0",
-        "@theqrl/web3-rpc-methods": "^0.4.0",
-        "@theqrl/web3-types": "^0.4.0",
-        "@theqrl/web3-utils": "^0.4.0",
-        "@theqrl/web3-validator": "^0.4.0"
+        "@theqrl/web3-core": "0.4.4",
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-net": "0.4.4",
+        "@theqrl/web3-providers-http": "0.4.4",
+        "@theqrl/web3-providers-ws": "0.4.4",
+        "@theqrl/web3-qrl": "0.4.4",
+        "@theqrl/web3-qrl-abi": "0.4.4",
+        "@theqrl/web3-qrl-accounts": "0.4.4",
+        "@theqrl/web3-qrl-contract": "0.4.4",
+        "@theqrl/web3-qrl-iban": "0.4.4",
+        "@theqrl/web3-qrl-qrns": "0.4.4",
+        "@theqrl/web3-rpc-methods": "0.4.4",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-utils": "0.4.4",
+        "@theqrl/web3-validator": "0.4.4"
       },
       "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=6.12.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-core": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-core/-/web3-core-0.4.0.tgz",
-      "integrity": "sha512-djRYNVIfgCFF8B9hUZN3UaXQX1n+ZkyDLr2ysobtqHS6PdI83UuX1rWx+eFm+J5L/DkuXIsRXcUNF0WLUKbvpw==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-core/-/web3-core-0.4.4.tgz",
+      "integrity": "sha512-GgIe3U/6NhONG7YKlYp1HzjFt8gkGwfbPac6HKDqJVpQo1dd2pNjcWUfP4EFa3YP5748xnatStQrSCBx76gg5w==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-errors": "^0.4.0",
-        "@theqrl/web3-providers-http": "^0.4.0",
-        "@theqrl/web3-providers-ws": "^0.4.0",
-        "@theqrl/web3-qrl-iban": "^0.4.0",
-        "@theqrl/web3-types": "^0.4.0",
-        "@theqrl/web3-utils": "^0.4.0",
-        "@theqrl/web3-validator": "^0.4.0"
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-providers-http": "0.4.4",
+        "@theqrl/web3-providers-ws": "0.4.4",
+        "@theqrl/web3-qrl-iban": "0.4.4",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-utils": "0.4.4",
+        "@theqrl/web3-validator": "0.4.4"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
+        "node": ">=20"
       },
       "optionalDependencies": {
-        "@theqrl/web3-providers-ipc": "^0.4.0"
+        "@theqrl/web3-providers-ipc": "0.4.4"
       }
     },
     "node_modules/@theqrl/web3-errors": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-0.4.0.tgz",
-      "integrity": "sha512-Fv198hEWtiDx+Cct7zWpkc6tyGOCTC0v2jxeqLvRq7TQgbJoCAJKrt9rNYfPyiLhBwRhK5hQqeKexKtwJBxKSw==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-0.4.3.tgz",
+      "integrity": "sha512-tazXfP8xZdzr3MwaH6o6kLn+64CYhUS+2ybufTanVqL+YoErIwMyPQQaL/t4GBMTHypFDSy4AVRfEQLvCw+Z9w==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-types": "^0.4.0"
+        "@theqrl/web3-types": "0.4.3"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-net": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-net/-/web3-net-0.4.0.tgz",
-      "integrity": "sha512-fmcpPS1DgEHpTXoa0tr4xHQg1CFsT1x7o2nHP8TQE0ovPCRd0MAysSQGK+WJz7TrQidH4Kr8iGWQd0lVMlVgvg==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-net/-/web3-net-0.4.4.tgz",
+      "integrity": "sha512-AeEFBYzYbJI16Iap3Td9GybFj9rAvkqCFbJYKQp4IJSWWgsEJYHcevig57cahTmeiYpNscbrmrL0jPQAI+m3Cg==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-core": "^0.4.0",
-        "@theqrl/web3-rpc-methods": "^0.4.0",
-        "@theqrl/web3-types": "^0.4.0",
-        "@theqrl/web3-utils": "^0.4.0"
+        "@theqrl/web3-core": "0.4.4",
+        "@theqrl/web3-rpc-methods": "0.4.4",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-utils": "0.4.4"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-providers-http": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-http/-/web3-providers-http-0.4.0.tgz",
-      "integrity": "sha512-RhWbjhYgASQktEuKDNuavxP3iI8mH7WBRNpJiSABXl9d7LjFOJnKKu5rxMZw5doVUcFQiS7NTIzWe7Y/jgFpeg==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-http/-/web3-providers-http-0.4.4.tgz",
+      "integrity": "sha512-Ol6usX4HWWPStTkfUIhdSmnGX9XZ6RciwG8mOBWkw/A0KL50LE137C+uAOb36NMK7tO/vF2E5xHdFCGM2d705g==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-errors": "^0.4.0",
-        "@theqrl/web3-types": "^0.4.0",
-        "@theqrl/web3-utils": "^0.4.0",
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-utils": "0.4.4",
         "cross-fetch": "^3.1.5"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-providers-ipc": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-ipc/-/web3-providers-ipc-0.4.0.tgz",
-      "integrity": "sha512-oVDyVQMFKMx6xX6nPFearqRQNb+72YCGQCNbtNZpGXxqlzpXG3m+ddOzPP7ECCEP2TKG3aVB88bbTr+dc4ejwA==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-ipc/-/web3-providers-ipc-0.4.4.tgz",
+      "integrity": "sha512-Dd4vOKZ3YnoiR5HJHBQse+xbeQ4zc+r9MFHs4mKalh+3oeqB3TCQOfN7NImoB2dUBMmThUlyz0C0uw0mVL7IVw==",
       "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
-        "@theqrl/web3-errors": "^0.4.0",
-        "@theqrl/web3-types": "^0.4.0",
-        "@theqrl/web3-utils": "^0.4.0"
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-utils": "0.4.4"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-providers-ws": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-ws/-/web3-providers-ws-0.4.0.tgz",
-      "integrity": "sha512-m7F9YXVvO9ym35J47Rg/KXykbVdF7sH4tMSaNC5JvnXGUlA2kNzkg54AOhd2VY6p+SxJVy6aDu7zTf8lEbNpbw==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-ws/-/web3-providers-ws-0.4.4.tgz",
+      "integrity": "sha512-AAlNywppRAZcygAro7Q0Vu7b7loCjtKdtH61EIVwKjfcAqpJFDnCCrIZ+qiLlAZO09fFuYHwzx6O4KUgzTqgfA==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-errors": "^0.4.0",
-        "@theqrl/web3-types": "^0.4.0",
-        "@theqrl/web3-utils": "^0.4.0",
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-utils": "0.4.4",
         "@types/ws": "8.5.3",
         "isomorphic-ws": "^5.0.0",
-        "ws": "^8.8.1"
+        "ws": "^8.17.1"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl/-/web3-qrl-0.4.0.tgz",
-      "integrity": "sha512-Wt6NPm8MRfmUbhCF7Zyl3GCc33zBrxMCaNDBv33jYLPXgBLgsNrN3vtd983ObYLoqBXr29qKxunG9Hw9DOmmRQ==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl/-/web3-qrl-0.4.4.tgz",
+      "integrity": "sha512-kBJhW3AJf5wabjuNz3kpo0CJFaO6m2Rayf7YKyYKhbIfX6fzUBOWRaL6gpFj7onR9KlO0vvHO3Lb4pXZFw6Ekw==",
       "license": "LGPL-3.0",
       "dependencies": {
         "@theqrl/wallet.js": "^2.0.2",
-        "@theqrl/web3-core": "^0.4.0",
-        "@theqrl/web3-errors": "^0.4.0",
-        "@theqrl/web3-net": "^0.4.0",
-        "@theqrl/web3-providers-ws": "^0.4.0",
-        "@theqrl/web3-qrl-abi": "^0.4.0",
-        "@theqrl/web3-qrl-accounts": "^0.4.0",
-        "@theqrl/web3-rpc-methods": "^0.4.0",
-        "@theqrl/web3-types": "^0.4.0",
-        "@theqrl/web3-utils": "^0.4.0",
-        "@theqrl/web3-validator": "^0.4.0",
+        "@theqrl/web3-core": "0.4.4",
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-net": "0.4.4",
+        "@theqrl/web3-providers-ws": "0.4.4",
+        "@theqrl/web3-qrl-abi": "0.4.4",
+        "@theqrl/web3-qrl-accounts": "0.4.4",
+        "@theqrl/web3-rpc-methods": "0.4.4",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-utils": "0.4.4",
+        "@theqrl/web3-validator": "0.4.4",
         "setimmediate": "^1.0.5"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl-abi": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-abi/-/web3-qrl-abi-0.4.0.tgz",
-      "integrity": "sha512-wLrYYkmZmI/so7AH3IT6m37RXN6ZizYAoEFs/RHvjdTfgRTjyelnnVKuQ4a7c8h07EsYQ0F7apN0z9KMkTnzdA==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-abi/-/web3-qrl-abi-0.4.4.tgz",
+      "integrity": "sha512-aI1vFF+SwDq+dOnq9AHDtAw+zHaJUqAY2PVfCvgAlbseZh26Hl/qSL27YxNN2hCZOJoHVSa3du44TZxO1qrtYA==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@ethereumjs/rlp": "^4.0.1",
         "@ethersproject/bignumber": "^5.7.0",
-        "@theqrl/abi": "^0.4.0",
+        "@theqrl/abi": "0.4.4",
         "@theqrl/wallet.js": "^2.0.2",
-        "@theqrl/web3-errors": "^0.4.0",
-        "@theqrl/web3-types": "^0.4.0",
-        "@theqrl/web3-utils": "^0.4.0",
-        "@theqrl/web3-validator": "^0.4.0",
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-utils": "0.4.4",
+        "@theqrl/web3-validator": "0.4.4",
         "crc-32": "^1.2.2",
-        "ethereum-cryptography": "^2.0.0",
         "sha3": "^2.1.4"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl-abi/node_modules/@theqrl/wallet.js": {
@@ -6395,25 +6314,24 @@
       }
     },
     "node_modules/@theqrl/web3-qrl-accounts": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-accounts/-/web3-qrl-accounts-0.4.0.tgz",
-      "integrity": "sha512-LwH4TWpE33lA7+iwQP45opKK1YWd/qpSfOX3GeCp3lOk/iRsy0AVgCeX2Q/Qtm+S6dt5xTIz1zVc4wA75gzLOQ==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-accounts/-/web3-qrl-accounts-0.4.4.tgz",
+      "integrity": "sha512-0FpoMl56A+xbjuaNUCWFtpEa59T2bhuUuX+j/2zD6bYvGFO1z/DFVdhWVAFihUxZCjSwuM6p01d+azjqvMkTNg==",
       "license": "LGPL-3.0",
       "dependencies": {
         "@ethereumjs/rlp": "^4.0.1",
         "@theqrl/mldsa87": "^2.0.1",
         "@theqrl/qrl-cryptography": "^0.1.0",
         "@theqrl/wallet.js": "^2.0.2",
-        "@theqrl/web3-errors": "^0.4.0",
-        "@theqrl/web3-types": "^0.4.0",
-        "@theqrl/web3-utils": "^0.4.0",
-        "@theqrl/web3-validator": "^0.4.0",
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-utils": "0.4.4",
+        "@theqrl/web3-validator": "0.4.4",
         "crc-32": "^1.2.2",
         "sha3": "^2.1.4"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl-accounts/node_modules/@theqrl/wallet.js": {
@@ -6427,59 +6345,56 @@
       }
     },
     "node_modules/@theqrl/web3-qrl-contract": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-contract/-/web3-qrl-contract-0.4.0.tgz",
-      "integrity": "sha512-EGh2s9vxBDTZEt/rvdFszXp2OQOn9cCg7Yx2uI6kBP7xPf4OO4sJiN8JLHtpBBKvQmIqJDJVhnOTwUrikPW6qw==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-contract/-/web3-qrl-contract-0.4.4.tgz",
+      "integrity": "sha512-dcsgwPZvV7bZGaUp9o/FDOMPmBd1unWccau/6fa8jYV8fiWcX+dgQrg8kjC0B+Qdr2ePAx9tMYzKCl1AxHVCtw==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-core": "^0.4.0",
-        "@theqrl/web3-errors": "^0.4.0",
-        "@theqrl/web3-qrl": "^0.4.0",
-        "@theqrl/web3-qrl-abi": "^0.4.0",
-        "@theqrl/web3-types": "^0.4.0",
-        "@theqrl/web3-utils": "^0.4.0",
-        "@theqrl/web3-validator": "^0.4.0"
+        "@theqrl/web3-core": "0.4.4",
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-qrl": "0.4.4",
+        "@theqrl/web3-qrl-abi": "0.4.4",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-utils": "0.4.4",
+        "@theqrl/web3-validator": "0.4.4"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl-iban": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-iban/-/web3-qrl-iban-0.4.0.tgz",
-      "integrity": "sha512-Waths6HKq3UzRGgSsbuz7mCfh0YfTeGAoqeulUh9qbLnBpF5CsWZ/v5WXMgy9l/R4S66Ro0IjxjfkWqLduIxRw==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-iban/-/web3-qrl-iban-0.4.4.tgz",
+      "integrity": "sha512-9vg2VELTkA54CeMEEhE79VTVTXULTxFSOKmyl0d9+HL77EDx8hl8FL7FWbwgKYvI5RXJ3osRifNTdugPE2qGNQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-errors": "^0.4.0",
-        "@theqrl/web3-types": "^0.4.0",
-        "@theqrl/web3-utils": "^0.4.0",
-        "@theqrl/web3-validator": "^0.4.0"
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-utils": "0.4.4",
+        "@theqrl/web3-validator": "0.4.4"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl-qrns": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-qrns/-/web3-qrl-qrns-0.4.0.tgz",
-      "integrity": "sha512-zH6ktA+VxZok44xqe8uAdlts0MjgQw5J0fxFlCLvSU5lmlXq4JBQ5hOgGZILJCqyhyptmDx3fgfVlj943AUIkQ==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-qrns/-/web3-qrl-qrns-0.4.4.tgz",
+      "integrity": "sha512-lfOkrSWQidwGU2IvSWBTzo6mVFjOieUlyR7/1M0z3HyN0NOgPx8SDy6LNv2EJjBZkWzCS5e6NsLptiXq5it/Dw==",
       "license": "LGPL-3.0",
       "dependencies": {
         "@adraffy/ens-normalize": "^1.8.8",
-        "@theqrl/web3-core": "^0.4.0",
-        "@theqrl/web3-errors": "^0.4.0",
-        "@theqrl/web3-net": "^0.4.0",
-        "@theqrl/web3-qrl": "^0.4.0",
-        "@theqrl/web3-qrl-contract": "^0.4.0",
-        "@theqrl/web3-types": "^0.4.0",
-        "@theqrl/web3-utils": "^0.4.0",
-        "@theqrl/web3-validator": "^0.4.0"
+        "@theqrl/web3-core": "0.4.4",
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-net": "0.4.4",
+        "@theqrl/web3-qrl": "0.4.4",
+        "@theqrl/web3-qrl-contract": "0.4.4",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-utils": "0.4.4",
+        "@theqrl/web3-validator": "0.4.4"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl/node_modules/@theqrl/wallet.js": {
@@ -6493,67 +6408,63 @@
       }
     },
     "node_modules/@theqrl/web3-rpc-methods": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-rpc-methods/-/web3-rpc-methods-0.4.0.tgz",
-      "integrity": "sha512-wIlbv8bp67MmVY9RGu5TNsGPIgeWCQtlXCiPul7ht0uvx2i1Ivhxbs371N6tnQWNmMzJm90NWW5/IYsDUuh7RA==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-rpc-methods/-/web3-rpc-methods-0.4.4.tgz",
+      "integrity": "sha512-Ris/b0I1LkQhIh/8PBKwR9tONGhlhjV+559vmCZYmsRdyg1RwKI943H6Jk9EBdB6/yPBshGGPhPi2sV3V7i65g==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-core": "^0.4.0",
-        "@theqrl/web3-types": "^0.4.0",
-        "@theqrl/web3-validator": "^0.4.0"
+        "@theqrl/web3-core": "0.4.4",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-validator": "0.4.4"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-types": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-0.4.0.tgz",
-      "integrity": "sha512-cqf82rY1DUWefIfBRQOnOiLfKld8CRdBW2A0lUXy+GpRMWZq/ubZyZ81F51g1sKNFLvPhgFYNVQ9bGAiuTzhxg==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-0.4.3.tgz",
+      "integrity": "sha512-8RV7QN4Qx+4sjrfkNWguJsZ/P8W19zvQWkr35YmzonG+WDdEYBINIfnSt1Lxy0pcNNSpRUQ+EwdomVmMH11vmA==",
       "license": "LGPL-3.0",
       "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-utils": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-0.4.0.tgz",
-      "integrity": "sha512-E5j+xYUSiv2AexBIq4tp6VbqwfKlTY8i/a8QOwajvKWz+NWRggQgE2FSrQoVo05JWz8I0YzWc5+lFcAYBF3COg==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-0.4.4.tgz",
+      "integrity": "sha512-3efGY0HhE0selNoawGbnHW/7tm3cHSK0gIedxjvIMDCQeRnhmd6nNfMAWk3GUA0H3CwGc96SHo+XP3yMDw51+Q==",
       "license": "LGPL-3.0",
       "dependencies": {
         "@theqrl/qrl-cryptography": "^0.1.0",
-        "@theqrl/web3-errors": "^0.4.0",
-        "@theqrl/web3-types": "^0.4.0",
-        "@theqrl/web3-validator": "^0.4.0"
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-validator": "0.4.4"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-validator": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-0.4.0.tgz",
-      "integrity": "sha512-bAJLORT1gQz8hOoC9TS0K2MDvZ5lyYe0KaLIJHeZ2hbKEkYjHlXo8T/hUYPwZnlENhHYmjPMt46uaLaU8lyc0g==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-0.4.4.tgz",
+      "integrity": "sha512-XhG5bnXDEdhzODDFen1ZBWTkqkeUaotdJWfzWbOHXeWKXHRuqSIPluLYgLt/Ph+s8VyPd0W+frafJi7oBsUXcw==",
       "license": "LGPL-3.0",
       "dependencies": {
         "@theqrl/qrl-cryptography": "^0.1.0",
-        "@theqrl/web3-errors": "^0.4.0",
-        "@theqrl/web3-types": "^0.4.0",
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-types": "0.4.3",
         "util": "^0.12.5",
-        "zod": "^3.21.4"
+        "zod": "3.22.3"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-validator/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
+      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -7037,9 +6948,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7948,9 +7859,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8396,48 +8307,6 @@
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^2.7.0"
-      }
-    },
-    "node_modules/cross-fetch/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/cross-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
-    "node_modules/cross-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/cross-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -9422,42 +9291,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/ethereum-cryptography": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.2.1.tgz",
-      "integrity": "sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/curves": "1.4.2",
-        "@noble/hashes": "1.4.0",
-        "@scure/bip32": "1.4.0",
-        "@scure/bip39": "1.3.0"
-      }
-    },
-    "node_modules/ethereum-cryptography/node_modules/@noble/curves": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
-      "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.4.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/ethereum-cryptography/node_modules/@noble/hashes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/exit-x": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz",
@@ -9890,9 +9723,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12648,6 +12481,48 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -13452,9 +13327,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.12.0.tgz",
-      "integrity": "sha512-kTPDYPFzDVGIIGNLS5VJykK0HfHLY5MF3b+xj0/tTyNYL1gF1qs7u67Z9jEhQk2sQ98SUaHxlG31g1JtF7IfVw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
+      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -13474,12 +13349,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.12.0.tgz",
-      "integrity": "sha512-pfO9fiBcpEfX4Tx+iTYKDtPbrSLLCbwJ5EqP+SPYQu1VYCXdy79GSj0wttR0U4cikVdlImZuEZ/9ZNCgoaxwBA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.16.0.tgz",
+      "integrity": "sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.12.0"
+        "react-router": "7.16.0"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "react-dom": "^19.2.3",
     "react-helmet-async": "^2.0.5",
     "react-hook-form": "^7.52.1",
-    "react-router-dom": "^7.12.0",
+    "react-router-dom": "^7.16.0",
     "socket.io-client": "^4.8.3",
     "tailwind-merge": "^2.6.0",
     "zod": "^4.3.4"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "react-dom": "^19.2.3",
     "react-helmet-async": "^2.0.5",
     "react-hook-form": "^7.52.1",
-    "react-router-dom": "^7.12.0",
+    "react-router-dom": "^7.16.0",
     "socket.io-client": "^4.8.3",
     "tailwind-merge": "^2.6.0",
     "zod": "^4.3.4"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "crypto-js": "^4.2.0",
-    "ethers": "^6.13.5",
     "lucide-react": "^0.562.0",
     "mobx": "^6.13.0",
     "mobx-react-lite": "^4.0.7",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "@tailwindcss/postcss": "^4.1.18",
     "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-table": "^8.21.2",
-    "@theqrl/wallet.js": "^3.0.1",
-    "@theqrl/web3": "^0.4.0",
+    "@theqrl/wallet.js": "^6.1.0",
+    "@theqrl/web3": "^1.0.0",
     "@types/crypto-js": "^4.2.2",
     "axios": "^1.16.0",
     "bignumber.js": "^9.3.1",
@@ -103,5 +103,8 @@
     "typescript": "^5.2.2",
     "typescript-eslint": "^8.48.0",
     "vite": "^7.3.2"
+  },
+  "overrides": {
+    "ws": "^8.21.0"
   }
 }

--- a/src/components/Core/Body/CreateToken/TokenCreationForm/TokenCreationForm.tsx
+++ b/src/components/Core/Body/CreateToken/TokenCreationForm/TokenCreationForm.tsx
@@ -24,7 +24,7 @@ import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { useEffect, useState } from "react";
 import { useStore } from "@/stores/store";
-import { ethers } from "ethers";
+import { formatUnits, parseUnits } from "@/utils/web3/units";
 import { useNavigate } from "react-router-dom";
 import { ROUTES } from "@/router/router";
 import { PinInput } from "@/components/UI/PinInput/PinInput";
@@ -105,7 +105,7 @@ export const TokenCreationForm = observer(
 
         const formatRealValue = (supply: string, decimals: number) => {
             try {
-                return ethers.formatUnits(supply, decimals);
+                return formatUnits(supply, decimals);
             } catch {
                 return "Invalid value";
             }
@@ -170,12 +170,12 @@ export const TokenCreationForm = observer(
 
                 const tokenName = formData.tokenName;
                 const tokenSymbol = formData.tokenSymbol;
-                const initialSupply = ethers.parseUnits(formData.initialSupply, formData.decimals).toString();
+                const initialSupply = parseUnits(formData.initialSupply, formData.decimals).toString();
                 const decimals = formData.decimals;
-                const maxSupply = formData.maxSupply ? ethers.parseUnits(formData.maxSupply, decimals).toString() : undefined;
+                const maxSupply = formData.maxSupply ? parseUnits(formData.maxSupply, decimals).toString() : undefined;
                 const recipientAddress = formData.recipientAddress;
-                const maxWalletAmount = formData.maxWalletAmount ? ethers.parseUnits(formData.maxWalletAmount, decimals).toString() : undefined;
-                const maxTransactionLimit = formData.maxTransactionLimit ? ethers.parseUnits(formData.maxTransactionLimit, decimals).toString() : undefined;
+                const maxWalletAmount = formData.maxWalletAmount ? parseUnits(formData.maxWalletAmount, decimals).toString() : undefined;
+                const maxTransactionLimit = formData.maxTransactionLimit ? parseUnits(formData.maxTransactionLimit, decimals).toString() : undefined;
 
                 // Navigate immediately to show loading state, then start creation
                 tokenStore.setCreatingToken(tokenName, true);

--- a/src/components/Core/Body/Tokens/TokenForm/TokenForm.tsx
+++ b/src/components/Core/Body/Tokens/TokenForm/TokenForm.tsx
@@ -14,7 +14,7 @@ import { useStore } from "@/stores/store";
 import { Button } from "@/components/UI/Button";
 import { Check, Plus, RefreshCw, Import, Coins, Sparkles } from "lucide-react";
 import { AddTokenModal } from "../AddTokenModal/AddTokenModal";
-import { formatUnits } from "ethers";
+import { formatUnits } from "@/utils/web3/units";
 import { QRL_PROVIDER } from "@/config";
 import { StorageUtil } from "@/utils/storage";
 

--- a/src/components/Core/Body/Tokens/TokenForm/TokenForm.tsx
+++ b/src/components/Core/Body/Tokens/TokenForm/TokenForm.tsx
@@ -166,27 +166,11 @@ const TokenForm = observer(() => {
                     data={tokenList}
                     isLoading={isLoading}
                     emptyMessage={
-                        pendingDiscoveredTokens.length > 0 ? (
-                            <div className="flex flex-col items-center gap-2 py-2">
-                                <div className="flex items-center gap-2 text-sm">
-                                    <Sparkles className="h-4 w-4 text-muted-foreground/70" />
-                                    Explorer found this address to own{" "}
-                                    <span className="font-medium">
-                                        {pendingDiscoveredTokens.length}
-                                    </span>{" "}
-                                    token
-                                    {pendingDiscoveredTokens.length === 1 ? "" : "s"}.
-                                </div>
-                                <Button
-                                    variant="outline"
-                                    size="sm"
-                                    onClick={() => setIsAddTokenModalOpen(true)}
-                                >
-                                    <Plus className="mr-2 h-4 w-4" />
-                                    Review and add
-                                </Button>
-                            </div>
-                        ) : undefined
+                        <TokensEmptyState
+                            discoveredCount={pendingDiscoveredTokens.length}
+                            onAddExisting={() => setIsAddTokenModalOpen(true)}
+                            onCreateNew={() => navigate(ROUTES.CREATE_TOKEN)}
+                        />
                     }
                 />
             </CardContent>
@@ -194,5 +178,66 @@ const TokenForm = observer(() => {
         </Card>
     );
 });
+
+// Mirrors the NFT gallery's empty-state (NftGallery.tsx) so the two
+// dashboard cards stay visually consistent: a heading, a one-line hint,
+// and a clear call-to-action button instead of a bare sentence. Tokens
+// have two add paths (import existing / create new), so the CTA is a
+// dropdown matching the card header's "+" menu.
+function TokensEmptyState({
+    discoveredCount,
+    onAddExisting,
+    onCreateNew,
+}: {
+    discoveredCount: number;
+    onAddExisting: () => void;
+    onCreateNew: () => void;
+}) {
+    return (
+        <div className="flex flex-col items-center gap-2 py-4 text-center">
+            {discoveredCount > 0 ? (
+                <>
+                    <div className="flex items-center gap-2 text-sm">
+                        <Sparkles className="h-4 w-4 text-muted-foreground/70" />
+                        Explorer found this address to own{" "}
+                        <span className="font-medium">{discoveredCount}</span> token
+                        {discoveredCount === 1 ? "" : "s"}.
+                    </div>
+                    <Button variant="outline" size="sm" onClick={onAddExisting}>
+                        <Plus className="mr-2 h-4 w-4" />
+                        Review and add
+                    </Button>
+                </>
+            ) : (
+                <>
+                    <div>
+                        <p className="text-sm font-medium">No tokens yet</p>
+                        <p className="text-xs text-muted-foreground">
+                            Add an existing token or create a new one.
+                        </p>
+                    </div>
+                    <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                            <Button variant="outline" size="sm">
+                                <Plus className="mr-2 h-4 w-4" />
+                                Add Token
+                            </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="center">
+                            <DropdownMenuItem onClick={onAddExisting}>
+                                <Import className="mr-2 h-4 w-4" />
+                                Add Existing Token
+                            </DropdownMenuItem>
+                            <DropdownMenuItem onClick={onCreateNew}>
+                                <Coins className="mr-2 h-4 w-4" />
+                                Create New Token
+                            </DropdownMenuItem>
+                        </DropdownMenuContent>
+                    </DropdownMenu>
+                </>
+            )}
+        </div>
+    );
+}
 
 export default TokenForm;

--- a/src/components/Core/Body/Transfer/Transfer.tsx
+++ b/src/components/Core/Body/Transfer/Transfer.tsx
@@ -48,7 +48,7 @@ import { FeeLevel } from "@/stores/qrlStore";
 import { SEO } from "@/components/SEO/SEO";
 import { getOptimalTokenBalance, formatAddressShort } from "@/utils/formatting";
 import { fetchBalance } from "@/utils/web3";
-import { formatUnits, parseUnits } from "ethers";
+import { formatUnits, parseUnits } from "@/utils/web3/units";
 import { BigNumber } from "bignumber.js";
 
 const Transfer = observer(() => {

--- a/src/components/NativeAppBridge.tsx
+++ b/src/components/NativeAppBridge.tsx
@@ -301,7 +301,11 @@ const NativeAppBridge: React.FC = () => {
             StorageUtil.clearAccountList(blockchain);
             StorageUtil.clearTransactionValues(blockchain);
           }
-          StorageUtil.clearTokenList();
+          // Full wipe: remove every account-scoped token + NFT list
+          // (and any legacy global keys). Unlike logout, CLEAR_WALLET is
+          // an explicit "erase everything" request from native settings.
+          StorageUtil.clearAllTokenData();
+          StorageUtil.clearAllNftData();
 
           // Confirm to native that web cleared its data
           confirmWalletCleared();

--- a/src/stores/qrlStore.ts
+++ b/src/stores/qrlStore.ts
@@ -3,6 +3,7 @@ import { deriveHexSeedAsync } from "@/utils/crypto";
 import { StorageUtil, AccountListItem, AccountSource } from "@/utils/storage";
 import { log } from "@/utils";
 import { getQrlWeb3 } from "@/utils/web3";
+import { QRL_TX_POLLING_CONFIG } from "@/utils/web3/txPolling";
 import type { TransactionReceipt, Web3QRLInterface } from "@theqrl/web3";
 import { action, computed, makeAutoObservable, observable, runInAction } from "mobx";
 
@@ -241,7 +242,9 @@ class QrlStore {
       }
       const Web3 = this._Web3;
       const httpProvider = new Web3.providers.HttpProvider(url);
-      const { qrl } = new Web3({ provider: httpProvider });
+      // QRL blocks are ~60s; web3's default 1s receipt polling + 24-confirmation
+      // watch fires ~100 RPC calls per tx. QRL_TX_POLLING_CONFIG slows it to ~10.
+      const { qrl } = new Web3({ provider: httpProvider, config: QRL_TX_POLLING_CONFIG });
 
 
       runInAction(() => {

--- a/src/stores/tokenStore.ts
+++ b/src/stores/tokenStore.ts
@@ -127,12 +127,25 @@ class TokenStore {
     );
   }
 
+  // Token storage is now keyed by `${blockchain}_${account}` (see
+  // StorageUtil), mirroring the NFT list. Reads from the wrong scope are
+  // impossible, but we still need the scope to write. Pulls live values
+  // from qrlStore at the call site.
+  private get scope(): { blockchain: string; account: string } {
+    return {
+      blockchain: this.qrlStore.qrlConnection.blockchain,
+      account: this.qrlStore.activeAccount.accountAddress,
+    };
+  }
+
   // Called by Store after QrlStore.initializeBlockchain finishes (via the
   // qrlStore.onBlockchainReady hook). Restores the persisted token list and
   // hidden-token list, then seeds known tokens.
   async initialize() {
     await this.migrateLegacyAutoAddedTokens();
-    const persistedList = await StorageUtil.getTokenList();
+    await this.migrateGlobalTokenListToAccount();
+    const { blockchain, account } = this.scope;
+    const persistedList = await StorageUtil.getTokenList(blockchain, account);
     runInAction(() => {
       this.tokenList = persistedList;
     });
@@ -147,15 +160,50 @@ class TokenStore {
   // every token the explorer attributed to the active account into
   // tokenList, and persisted that to localStorage. After the gate, those
   // legacy entries can't be distinguished from user-curated picks — so we
-  // wipe TOKEN_LIST once on first load post-migration. The discovery
-  // picker (PR #143) repopulates legitimate holdings on the user's
-  // explicit say-so.
+  // wipe the legacy global TOKEN_LIST once on first load post-migration.
+  // The discovery picker (PR #143) repopulates legitimate holdings on the
+  // user's explicit say-so.
   private async migrateLegacyAutoAddedTokens() {
     const FLAG = "TOKEN_LIST_GATE_MIGRATED_V1";
     if (localStorage.getItem(FLAG)) return;
-    await StorageUtil.clearTokenList();
+    StorageUtil.clearLegacyGlobalTokenData();
     localStorage.setItem(FLAG, "1");
     log("Migration: wiped pre-gate tokenList; flag set");
+  }
+
+  // One-shot migration: the token list used to live under a single global
+  // key shared across every account/chain. It is now scoped per
+  // `${blockchain}_${account}` like the NFT list. Move whatever the user
+  // currently has under the global key into the active account's scope,
+  // then drop the global key. Deferred (flag not set) until an account is
+  // active so we never discard the legacy list before we can re-home it.
+  private async migrateGlobalTokenListToAccount() {
+    const FLAG = "TOKEN_LIST_PER_ACCOUNT_MIGRATED_V1";
+    if (localStorage.getItem(FLAG)) return;
+    const { blockchain, account } = this.scope;
+    if (!blockchain || !account) return;
+
+    const legacyTokens = StorageUtil.getLegacyGlobalTokenList();
+    if (legacyTokens.length > 0) {
+      const existing = await StorageUtil.getTokenList(blockchain, account);
+      const seen = new Set(existing.map((t) => t.address.toLowerCase()));
+      const merged = [
+        ...existing,
+        ...legacyTokens.filter((t) => !seen.has(t.address.toLowerCase())),
+      ];
+      await StorageUtil.updateTokenList(blockchain, account, merged);
+    }
+
+    const legacyHidden = StorageUtil.getLegacyGlobalHiddenTokens();
+    for (const addr of legacyHidden) {
+      await StorageUtil.hideToken(blockchain, account, addr);
+    }
+
+    StorageUtil.clearLegacyGlobalTokenData();
+    localStorage.setItem(FLAG, "1");
+    log(
+      `Migration: moved ${legacyTokens.length} global tokens to ${blockchain}_${account}; flag set`,
+    );
   }
 
   // Called by Store after QrlStore.setActiveAccount finishes (via the
@@ -175,11 +223,16 @@ class TokenStore {
     }
 
     log(`Switching token list to account: ${newActiveAccount}`);
-    // Token storage is global (not per-account like NFTs), so we wipe
-    // on switch to prevent account A's tokens leaking into account B.
-    await StorageUtil.clearTokenList();
+    // Token storage is per-account-scoped, so an account switch just
+    // means reloading from the new scope's key. No cross-account
+    // clearing needed — the old account's list stays under its own key
+    // for when the user switches back.
+    const blockchain = this.qrlStore.qrlConnection.blockchain;
+    const persisted = await StorageUtil.getTokenList(blockchain, newActiveAccount);
+    const hidden = await StorageUtil.getHiddenTokens(blockchain, newActiveAccount);
     runInAction(() => {
-      this.tokenList = [];
+      this.tokenList = persisted;
+      this.hiddenTokens = hidden;
       // Discovered list is per-address; drop it so a picker opened
       // after the switch can't leak the prior account's results.
       this.discoveredTokens = [];
@@ -189,8 +242,8 @@ class TokenStore {
       await this.addToken(token);
     }
 
-    // Refresh balances on whatever is in the list now (KNOWN_TOKEN_LIST
-    // entries, or nothing). No explorer call.
+    // Refresh balances on whatever is in the list now (persisted picks +
+    // KNOWN_TOKEN_LIST entries). No explorer call.
     void this.refreshTokenBalances();
   }
 
@@ -239,8 +292,7 @@ class TokenStore {
     );
 
     if (!existingToken) {
-      await StorageUtil.updateTokenList([...this.tokenList, token]);
-      this.tokenList = [...this.tokenList, token];
+      await this.setTokenList([...this.tokenList, token]);
       return token;
     }
 
@@ -256,33 +308,26 @@ class TokenStore {
   }
 
   async removeToken(token: TokenInterface) {
-    await StorageUtil.updateTokenList(
+    await this.setTokenList(
       this.tokenList.filter(
         (t) => t.address.toLowerCase() !== token.address.toLowerCase(),
       ),
     );
-    this.tokenList = this.tokenList.filter(
-      (t) => t.address !== token.address,
-    );
   }
 
   async updateToken(token: TokenInterface) {
-    await StorageUtil.updateTokenList(
+    await this.setTokenList(
       this.tokenList.map((t) =>
         t.address.toLocaleLowerCase() === token.address.toLocaleLowerCase()
           ? token
           : t,
       ),
     );
-    this.tokenList = this.tokenList.map((t) =>
-      t.address.toLocaleLowerCase() === token.address.toLocaleLowerCase()
-        ? token
-        : t,
-    );
   }
 
   async setTokenList(tokenList: TokenInterface[]) {
-    await StorageUtil.updateTokenList(tokenList);
+    const { blockchain, account } = this.scope;
+    await StorageUtil.updateTokenList(blockchain, account, tokenList);
     this.tokenList = tokenList;
   }
 
@@ -594,8 +639,9 @@ class TokenStore {
       }
 
       // Stale-write guard: if the active account changed under us,
-      // abandon the result. Writing it back would clobber the new
-      // account's list (token storage is global, not per-account).
+      // abandon the result. setTokenList writes to the current scope, so
+      // a stale write would land balances computed for the old account
+      // under the new account's key.
       if (this.qrlStore.activeAccount.accountAddress !== startAccount) {
         log(
           "refreshTokenBalances: active account changed mid-refresh, abandoning stale results",
@@ -711,14 +757,17 @@ class TokenStore {
       // else: already visible — skip
     }
     if (additions.length === 0 && unhides.length === 0) return;
-    // Stale-write guard: token storage is global, so a write here after
-    // an account switch would land in the new account's view.
+    // Stale-write guard: token storage is per-account-scoped, so a write
+    // lands in the right key even after a switch, but the in-memory
+    // append would still mix the prior account's picks into the new
+    // account's tokenList.
     if (this.qrlStore.activeAccount.accountAddress !== startAccount) {
       log(
         "addDiscoveredTokens: active account changed before write, abandoning picks",
       );
       return;
     }
+    const { blockchain, account } = this.scope;
     if (additions.length > 0) {
       await this.setTokenList([...this.tokenList, ...additions]);
     }
@@ -727,7 +776,7 @@ class TokenStore {
       // collapse the observable update into a single runInAction so the
       // UI re-renders once instead of N times.
       for (const addr of unhides) {
-        await StorageUtil.unhideToken(addr);
+        await StorageUtil.unhideToken(blockchain, account, addr);
       }
       const drop = new Set(unhides.map((a) => a.toLowerCase()));
       runInAction(() => {
@@ -748,14 +797,16 @@ class TokenStore {
   }
 
   async loadHiddenTokens() {
-    const hiddenTokens = await StorageUtil.getHiddenTokens();
+    const { blockchain, account } = this.scope;
+    const hiddenTokens = await StorageUtil.getHiddenTokens(blockchain, account);
     runInAction(() => {
       this.hiddenTokens = hiddenTokens;
     });
   }
 
   async hideToken(tokenAddress: string) {
-    await StorageUtil.hideToken(tokenAddress);
+    const { blockchain, account } = this.scope;
+    await StorageUtil.hideToken(blockchain, account, tokenAddress);
     runInAction(() => {
       const lowerCaseAddress = tokenAddress.toLowerCase();
       if (
@@ -770,7 +821,8 @@ class TokenStore {
   }
 
   async unhideToken(tokenAddress: string) {
-    await StorageUtil.unhideToken(tokenAddress);
+    const { blockchain, account } = this.scope;
+    await StorageUtil.unhideToken(blockchain, account, tokenAddress);
     runInAction(() => {
       this.hiddenTokens = this.hiddenTokens.filter(
         (addr) => addr.toLowerCase() !== tokenAddress.toLowerCase(),

--- a/src/stores/tokenStore.ts
+++ b/src/stores/tokenStore.ts
@@ -327,8 +327,16 @@ class TokenStore {
 
   async setTokenList(tokenList: TokenInterface[]) {
     const { blockchain, account } = this.scope;
+    if (!blockchain || !account) return;
     await StorageUtil.updateTokenList(blockchain, account, tokenList);
-    this.tokenList = tokenList;
+    // The active account/blockchain can change during the await; only apply the
+    // result if we're still on the same scope, and wrap the observable write in
+    // runInAction (MobX strict mode forbids mutating after an await otherwise).
+    if (this.scope.blockchain === blockchain && this.scope.account === account) {
+      runInAction(() => {
+        this.tokenList = tokenList;
+      });
+    }
   }
 
   async sendToken(

--- a/src/utils/crypto/__tests__/mnemonic.test.ts
+++ b/src/utils/crypto/__tests__/mnemonic.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Round-trip + strictness coverage for src/utils/crypto/mnemonic.ts under the
+ * upgraded post-quantum stack (@theqrl/wallet.js 6.x + @theqrl/web3 1.x).
+ *
+ * Why this exists: mnemonic.ts had ZERO direct unit coverage and was the one
+ * load-bearing path the @theqrl upgrade validation could only type-check, not
+ * runtime-verify. wallet.js 6 made the `ExtendedSeed` constructor strict (it
+ * now hard-throws on any seed that is not exactly 51 bytes with a valid
+ * ML-DSA-87 descriptor byte), so these tests pin both the happy-path round-trip
+ * and that strictness as a regression guard, and pin that the address derived
+ * via web3 `seedToAccount` equals the signing-path slice-math derivation
+ * (sign.ts: toChecksumAddress('Q' + getAddressStr().slice(1, 41))).
+ *
+ * cryptoWorkerClient is mocked: it touches `navigator` and a Vite `?worker`
+ * import at module load, neither of which exists in jest's node env. The
+ * functions under test are synchronous and never call into the worker.
+ */
+
+jest.mock('../cryptoWorkerClient', () => ({
+  deriveHexSeedAsync: jest.fn(),
+  CryptoErrorCode: {},
+  CryptoOperationError: class extends Error {},
+}));
+
+import { MLDSA87 } from '@theqrl/wallet.js';
+import Web3, { utils as web3Utils } from '@theqrl/web3';
+import {
+  getMnemonicFromHexSeed,
+  getHexSeedFromMnemonic,
+  getAddressFromMnemonic,
+} from '../mnemonic';
+
+// A pinned, well-formed 51-byte ML-DSA-87 extended seed (descriptor 0x01),
+// taken from the cross-repo signing parity fixture (canonical.json). Used to
+// confirm the strict ExtendedSeed ctor accepts a known-good seed.
+const PINNED_HEX_SEED =
+  '0x0100000580a227e1b6d5a89df7723a71e9c03535e9447ec6d160b68c0ba845c68a05c59226cce711eb3db312c022ccf9577be7';
+
+describe('mnemonic.ts under wallet.js 6 + web3 1.0', () => {
+  it('round-trips a freshly generated wallet: mnemonic <-> hexSeed', () => {
+    const wallet = MLDSA87.newWallet();
+    try {
+      const hexSeed = wallet.getHexExtendedSeed();
+      const mnemonic = wallet.getMnemonic();
+      // mnemonic -> hexSeed
+      expect(getHexSeedFromMnemonic(mnemonic)).toBe(hexSeed);
+      // hexSeed -> mnemonic (exercises the strict ExtendedSeed ctor on a good seed)
+      expect(getMnemonicFromHexSeed(hexSeed)).toBe(mnemonic);
+    } finally {
+      // Always wipe key material from memory, even if an assertion throws.
+      wallet.zeroize();
+    }
+  });
+
+  it('accepts the pinned canonical seed and round-trips it deterministically', () => {
+    const mnemonic = getMnemonicFromHexSeed(PINNED_HEX_SEED);
+    // The seed is fixed, so derivation must be deterministic and non-empty (a
+    // truncated/partial derivation would change this) and must round-trip back
+    // to the exact same seed.
+    expect(mnemonic).toBeTruthy();
+    expect(getMnemonicFromHexSeed(PINNED_HEX_SEED)).toBe(mnemonic);
+    expect(getHexSeedFromMnemonic(mnemonic)).toBe(PINNED_HEX_SEED);
+  });
+
+  it('derives the canonical checksummed Q-address, matching the signing-path slice math', () => {
+    const wallet = MLDSA87.newWallet();
+    let mnemonic: string;
+    let viaSliceMath: string;
+    try {
+      mnemonic = wallet.getMnemonic();
+      // signing path (sign.ts): signer = toChecksumAddress('Q' + getAddressStr().slice(1, 41))
+      viaSliceMath = web3Utils.toChecksumAddress('Q' + wallet.getAddressStr().slice(1, 41));
+    } finally {
+      // Wipe key material even if getAddressStr / toChecksumAddress throws.
+      wallet.zeroize();
+    }
+
+    const web3 = new Web3('http://localhost:8545');
+    const viaSeedToAccount = getAddressFromMnemonic(mnemonic, web3.qrl);
+
+    expect(viaSeedToAccount).toBe(viaSliceMath);
+    expect(viaSeedToAccount).toMatch(/^Q[0-9a-fA-F]{40}$/);
+  });
+
+  it('wallet.js 6 ExtendedSeed ctor is strict: rejects malformed seeds (regression pin)', () => {
+    // 50 bytes: one short of the required 51-byte extended seed.
+    expect(() => getMnemonicFromHexSeed('0x' + '00'.repeat(50))).toThrow(/must be 51 bytes/);
+    // 51 bytes but descriptor byte 0x00 != ML_DSA_87 (0x01).
+    expect(() => getMnemonicFromHexSeed('0x' + '00'.repeat(51))).toThrow(
+      /Invalid wallet type in descriptor/,
+    );
+  });
+});

--- a/src/utils/logout.ts
+++ b/src/utils/logout.ts
@@ -39,8 +39,12 @@ export const handleLogout = async (navigate: (path: string) => void) => {
             clearAttemptTracker();
         }
 
-        // Clear token list
-        await StorageUtil.clearTokenList();
+        // NOTE: token and NFT lists are intentionally NOT cleared here.
+        // They are public contract addresses (not secrets) keyed per
+        // account, so preserving them means re-importing the same account
+        // restores its curated token/NFT lists instead of forcing the
+        // user to re-add every contract. A full wipe (CLEAR_WALLET) does
+        // clear them.
 
         // Navigate to homepage
         navigate(ROUTES.HOME);

--- a/src/utils/storage/storage.ts
+++ b/src/utils/storage/storage.ts
@@ -143,16 +143,88 @@ class StorageUtil {
     this.setItem(BLOCKCHAIN_CREATED_TOKEN, { name, symbol, decimals, address, tx, blockNumber, gasUsed, effectiveGasPrice, blockHash });
   }
 
-  static async updateTokenList(tokenList: TokenInterface[]) {
-    this.setItem(TOKEN_LIST_IDENTIFIER, tokenList);
+  /**
+   * Token list — keyed by `${blockchain}_${account}` (mirrors the NFT
+   * list) so manually-added tokens from one wallet/chain never bleed
+   * into another and survive logout/re-import of the same account.
+   * Returns `[]` when either scope component is empty (caller bootstrap
+   * typically races init). Replaces the older global key which leaked
+   * across accounts on switch and across networks on chain switch.
+   */
+  private static tokenListKey(blockchain: string, account: string) {
+    return `${blockchain}_${account.toLowerCase()}_${TOKEN_LIST_IDENTIFIER}`;
   }
 
-  static async getTokenList() {
+  private static hiddenTokensKey(blockchain: string, account: string) {
+    return `${blockchain}_${account.toLowerCase()}_${HIDDEN_TOKENS_IDENTIFIER}`;
+  }
+
+  static async updateTokenList(blockchain: string, account: string, tokenList: TokenInterface[]) {
+    if (!blockchain || !account) return;
+    this.setItem(this.tokenListKey(blockchain, account), tokenList);
+  }
+
+  static async getTokenList(blockchain: string, account: string) {
+    if (!blockchain || !account) return [];
+    return this.getItem<TokenInterface[]>(this.tokenListKey(blockchain, account)) ?? [];
+  }
+
+  static async clearTokenList(blockchain: string, account: string) {
+    if (!blockchain || !account) return;
+    localStorage.removeItem(this.tokenListKey(blockchain, account));
+  }
+
+  /**
+   * Reads the pre-per-account global token list (legacy key). Used once
+   * by the migration that moves it under the active account's scope.
+   */
+  static getLegacyGlobalTokenList(): TokenInterface[] {
     return this.getItem<TokenInterface[]>(TOKEN_LIST_IDENTIFIER) ?? [];
   }
 
-  static async clearTokenList() {
+  /**
+   * Reads the pre-per-account global hidden-tokens list (legacy key).
+   */
+  static getLegacyGlobalHiddenTokens(): string[] {
+    return this.getItem<string[]>(HIDDEN_TOKENS_IDENTIFIER) ?? [];
+  }
+
+  /**
+   * Removes the legacy global token + hidden-token keys after migration.
+   */
+  static clearLegacyGlobalTokenData(): void {
     localStorage.removeItem(TOKEN_LIST_IDENTIFIER);
+    localStorage.removeItem(HIDDEN_TOKENS_IDENTIFIER);
+  }
+
+  /**
+   * Full-wipe helper: removes every account-scoped token + hidden-token
+   * key (plus any legacy global keys). Used by the explicit "clear
+   * wallet" flow, NOT by logout (logout intentionally preserves these so
+   * re-importing the same account restores its curated token list).
+   */
+  static clearAllTokenData(): void {
+    this.removeKeysEndingWith(`_${TOKEN_LIST_IDENTIFIER}`);
+    this.removeKeysEndingWith(`_${HIDDEN_TOKENS_IDENTIFIER}`);
+    this.clearLegacyGlobalTokenData();
+  }
+
+  /**
+   * Full-wipe helper: removes every account-scoped NFT + hidden-NFT key.
+   * Used by the explicit "clear wallet" flow.
+   */
+  static clearAllNftData(): void {
+    this.removeKeysEndingWith(`_${NFT_LIST_IDENTIFIER}`);
+    this.removeKeysEndingWith(`_${HIDDEN_NFTS_IDENTIFIER}`);
+  }
+
+  private static removeKeysEndingWith(suffix: string): void {
+    const toRemove: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key && key.endsWith(suffix)) toRemove.push(key);
+    }
+    toRemove.forEach((k) => localStorage.removeItem(k));
   }
 
   static async getBlockChain() {
@@ -440,30 +512,33 @@ class StorageUtil {
   }
 
   /**
-   * Get list of hidden token addresses
+   * Get list of hidden token addresses for an account scope.
    */
-  static async getHiddenTokens(): Promise<string[]> {
-    return this.getItem<string[]>(HIDDEN_TOKENS_IDENTIFIER) ?? [];
+  static async getHiddenTokens(blockchain: string, account: string): Promise<string[]> {
+    if (!blockchain || !account) return [];
+    return this.getItem<string[]>(this.hiddenTokensKey(blockchain, account)) ?? [];
   }
 
   /**
    * Add a token address to the hidden list
    */
-  static async hideToken(tokenAddress: string) {
-    const hiddenTokens = await this.getHiddenTokens();
+  static async hideToken(blockchain: string, account: string, tokenAddress: string) {
+    if (!blockchain || !account) return;
+    const hiddenTokens = await this.getHiddenTokens(blockchain, account);
     if (!hiddenTokens.some(addr => addr.toLowerCase() === tokenAddress.toLowerCase())) {
       hiddenTokens.push(tokenAddress.toLowerCase());
-      this.setItem(HIDDEN_TOKENS_IDENTIFIER, hiddenTokens);
+      this.setItem(this.hiddenTokensKey(blockchain, account), hiddenTokens);
     }
   }
 
   /**
    * Remove a token address from the hidden list
    */
-  static async unhideToken(tokenAddress: string) {
-    let hiddenTokens = await this.getHiddenTokens();
+  static async unhideToken(blockchain: string, account: string, tokenAddress: string) {
+    if (!blockchain || !account) return;
+    let hiddenTokens = await this.getHiddenTokens(blockchain, account);
     hiddenTokens = hiddenTokens.filter(addr => addr.toLowerCase() !== tokenAddress.toLowerCase());
-    this.setItem(HIDDEN_TOKENS_IDENTIFIER, hiddenTokens);
+    this.setItem(this.hiddenTokensKey(blockchain, account), hiddenTokens);
   }
 
   static async setBalanceCache(blockchain: string, balances: Record<string, string>) {
@@ -477,10 +552,11 @@ class StorageUtil {
   }
 
   /**
-   * Clear all hidden tokens (used when refreshing to re-show all)
+   * Clear all hidden tokens for an account scope (re-show all).
    */
-  static async clearHiddenTokens() {
-    localStorage.removeItem(HIDDEN_TOKENS_IDENTIFIER);
+  static async clearHiddenTokens(blockchain: string, account: string) {
+    if (!blockchain || !account) return;
+    localStorage.removeItem(this.hiddenTokensKey(blockchain, account));
   }
 
   /**

--- a/src/utils/web3/__tests__/txPolling.test.ts
+++ b/src/utils/web3/__tests__/txPolling.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Guards the QRL transaction-polling config: that it stays sane for a ~60s block
+ * time, that the installed web3 actually honors it (catches a config-API change
+ * on a future web3 upgrade), and that it genuinely improves on the web3 defaults.
+ */
+import Web3 from '@theqrl/web3';
+import { QRL_TX_POLLING_CONFIG } from '../txPolling';
+
+const PROVIDER = () => new Web3.providers.HttpProvider('http://localhost:8545');
+
+describe('QRL_TX_POLLING_CONFIG', () => {
+  it('polls slowly enough for a ~60s block time and waits on a single confirmation', () => {
+    expect(QRL_TX_POLLING_CONFIG.transactionPollingInterval).toBeGreaterThanOrEqual(5000);
+    expect(QRL_TX_POLLING_CONFIG.transactionConfirmationBlocks).toBeLessThanOrEqual(2);
+    expect(QRL_TX_POLLING_CONFIG.transactionPollingTimeout).toBeGreaterThanOrEqual(QRL_TX_POLLING_CONFIG.transactionPollingInterval);
+  });
+
+  it('is actually applied by the installed @theqrl/web3 (guards against a config-API change on upgrade)', () => {
+    const { qrl } = new Web3({ provider: PROVIDER(), config: QRL_TX_POLLING_CONFIG });
+    expect(qrl.transactionPollingInterval).toBe(QRL_TX_POLLING_CONFIG.transactionPollingInterval);
+    expect(qrl.transactionConfirmationBlocks).toBe(QRL_TX_POLLING_CONFIG.transactionConfirmationBlocks);
+    expect(qrl.transactionPollingTimeout).toBe(QRL_TX_POLLING_CONFIG.transactionPollingTimeout);
+  });
+
+  it('improves drastically over the web3 4.x defaults it replaces', () => {
+    // Documents the defaults that caused ~100 RPC calls/tx; if a web3 upgrade
+    // changes these, this test flags that our override math needs review.
+    const { qrl } = new Web3(PROVIDER());
+    expect(qrl.transactionPollingInterval).toBe(1000);
+    expect(qrl.transactionConfirmationBlocks).toBe(24);
+    expect(QRL_TX_POLLING_CONFIG.transactionPollingInterval).toBeGreaterThan(qrl.transactionPollingInterval);
+    expect(QRL_TX_POLLING_CONFIG.transactionConfirmationBlocks).toBeLessThan(qrl.transactionConfirmationBlocks);
+  });
+});

--- a/src/utils/web3/__tests__/units.test.ts
+++ b/src/utils/web3/__tests__/units.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Coverage for the ethers-free fixed-point unit conversion (src/utils/web3/units.ts).
+ * Expected values were verified byte-for-byte against ethers v6
+ * formatUnits/parseUnits before ethers was removed from the project.
+ */
+import { formatUnits, parseUnits } from "../units";
+
+describe("formatUnits (ethers v6 parity)", () => {
+  it.each([
+    [1500000n, 6, "1.5"],
+    [1000000n, 6, "1.0"],
+    [1230000n, 6, "1.23"],
+    [0n, 18, "0.0"],
+    [10n ** 18n, 18, "1.0"],
+    [123456789012345678n, 18, "0.123456789012345678"],
+    [999999999999999999n, 18, "0.999999999999999999"],
+    [1n, 18, "0.000000000000000001"],
+    [42n, 0, "42"],
+    [1000000n, 0, "1000000"],
+    [100000000n, 8, "1.0"],
+  ])("formatUnits(%s, %s) = %s", (value, decimals, expected) => {
+    expect(formatUnits(value, decimals)).toBe(expected);
+  });
+
+  it("accepts string and number inputs", () => {
+    expect(formatUnits("1500000", 6)).toBe("1.5");
+    expect(formatUnits(1500000, 6)).toBe("1.5");
+  });
+
+  it("throws on a non-numeric value", () => {
+    expect(() => formatUnits("not-a-number", 6)).toThrow(/invalid value/);
+  });
+});
+
+describe("parseUnits (ethers v6 parity)", () => {
+  it.each([
+    ["1.5", 6, 1500000n],
+    ["1", 6, 1000000n],
+    ["0.000001", 6, 1n],
+    ["123.456", 18, 123456000000000000000n],
+    ["0", 18, 0n],
+    ["1000000", 0, 1000000n],
+    ["999999999999.999999", 6, 999999999999999999n],
+  ])("parseUnits(%s, %s) = %s", (value, decimals, expected) => {
+    expect(parseUnits(value, decimals)).toBe(expected);
+  });
+
+  it("round-trips with formatUnits", () => {
+    const raw = parseUnits("1234.567891", 8);
+    expect(formatUnits(raw, 8)).toBe("1234.567891");
+  });
+
+  it("throws on more fractional digits than decimals allows", () => {
+    expect(() => parseUnits("1.5", 0)).toThrow(/more than 0 decimal places/);
+    expect(() => parseUnits("0.0000001", 6)).toThrow(/more than 6 decimal places/);
+  });
+
+  it("throws on a non-numeric value", () => {
+    expect(() => parseUnits("abc", 6)).toThrow(/invalid decimal value/);
+  });
+});

--- a/src/utils/web3/__tests__/units.test.ts
+++ b/src/utils/web3/__tests__/units.test.ts
@@ -58,4 +58,15 @@ describe("parseUnits (ethers v6 parity)", () => {
   it("throws on a non-numeric value", () => {
     expect(() => parseUnits("abc", 6)).toThrow(/invalid decimal value/);
   });
+
+  it("rejects non-decimal formats that bignumber.js would otherwise accept (ethers parity)", () => {
+    // bignumber.js silently parses these; ethers v6 (and now we) reject them.
+    expect(() => parseUnits("0x11", 6)).toThrow(/invalid decimal value/);
+    expect(() => parseUnits("0b101", 6)).toThrow(/invalid decimal value/);
+    expect(() => parseUnits("0o17", 6)).toThrow(/invalid decimal value/);
+    expect(() => parseUnits("1e3", 6)).toThrow(/invalid decimal value/);
+    expect(() => parseUnits("", 6)).toThrow(/invalid decimal value/);
+    expect(() => parseUnits("1.2.3", 6)).toThrow(/invalid decimal value/);
+    expect(() => parseUnits("  ", 6)).toThrow(/invalid decimal value/);
+  });
 });

--- a/src/utils/web3/txPolling.ts
+++ b/src/utils/web3/txPolling.ts
@@ -1,0 +1,20 @@
+/**
+ * web3.js transaction-polling config tuned for QRL's ~60-second block time.
+ *
+ * web3.js 4.x defaults are `transactionPollingInterval: 1000` (poll the receipt
+ * every 1s) and `transactionConfirmationBlocks: 24` (keep polling for 24
+ * confirmations after the receipt). On a 1-minute-block chain that fires ~100+
+ * `getTransactionReceipt` / block RPC calls per transaction (~60 just to see
+ * the receipt, then ~24 blocks ≈ 24 minutes of confirmation polling).
+ *
+ * These values poll every 7s and require a single confirmation, cutting it to
+ * roughly ~10 RPC calls per tx. The user-facing "confirmed" state fires on the
+ * `receipt` event (first inclusion), which is unaffected by
+ * `transactionConfirmationBlocks` — that only controls how long web3 keeps
+ * watching for additional confirmations afterward.
+ */
+export const QRL_TX_POLLING_CONFIG = {
+  transactionPollingInterval: 7000,
+  transactionConfirmationBlocks: 1,
+  transactionPollingTimeout: 7 * 60 * 1000, // ~7 blocks before giving up
+};

--- a/src/utils/web3/txPolling.ts
+++ b/src/utils/web3/txPolling.ts
@@ -12,9 +12,15 @@
  * `receipt` event (first inclusion), which is unaffected by
  * `transactionConfirmationBlocks` — that only controls how long web3 keeps
  * watching for additional confirmations afterward.
+ *
+ * NOTE on units: in web3.js 4.x BOTH `transactionPollingInterval` and
+ * `transactionPollingTimeout` are MILLISECONDS (the default timeout is
+ * `750 * 1000`, and web3 divides it by 1000 only to render the seconds in its
+ * timeout error). This differs from web3.js 1.x where the timeout was seconds —
+ * do not "convert" the timeout to seconds.
  */
 export const QRL_TX_POLLING_CONFIG = {
-  transactionPollingInterval: 7000,
+  transactionPollingInterval: 7000, // ms
   transactionConfirmationBlocks: 1,
-  transactionPollingTimeout: 7 * 60 * 1000, // ~7 blocks before giving up
+  transactionPollingTimeout: 7 * 60 * 1000, // ms (7 min, ~7 blocks) — NOT seconds
 };

--- a/src/utils/web3/units.ts
+++ b/src/utils/web3/units.ts
@@ -47,7 +47,7 @@ export function parseUnits(value: string, decimals: number = 18): bigint {
   // but bignumber.js silently parses hex/binary/octal prefixes (e.g. "0x11" ->
   // 17). For a transaction-amount parser that would be a dangerous mismatch, so
   // reject anything that is not an optionally-signed base-10 decimal here.
-  if (typeof value !== 'string' || !/^-?(\d+(\.\d+)?|\.\d+)$/.test(value.trim())) {
+  if (typeof value !== 'string' || !/^-?(\d+\.?\d*|\.\d+)$/.test(value.trim())) {
     throw new Error(`parseUnits: invalid decimal value "${value}"`);
   }
   const v = new BN(value.trim());

--- a/src/utils/web3/units.ts
+++ b/src/utils/web3/units.ts
@@ -43,7 +43,14 @@ export function formatUnits(value: bigint | string | number, decimals: number = 
  * digits than `decimals` allows.
  */
 export function parseUnits(value: string, decimals: number = 18): bigint {
-  const v = new BN(value);
+  // Strict decimal-string validation. ethers v6 rejects non-decimal formats,
+  // but bignumber.js silently parses hex/binary/octal prefixes (e.g. "0x11" ->
+  // 17). For a transaction-amount parser that would be a dangerous mismatch, so
+  // reject anything that is not an optionally-signed base-10 decimal here.
+  if (typeof value !== 'string' || !/^-?(\d+(\.\d+)?|\.\d+)$/.test(value.trim())) {
+    throw new Error(`parseUnits: invalid decimal value "${value}"`);
+  }
+  const v = new BN(value.trim());
   if (v.isNaN()) {
     throw new Error(`parseUnits: invalid decimal value "${value}"`);
   }

--- a/src/utils/web3/units.ts
+++ b/src/utils/web3/units.ts
@@ -1,0 +1,55 @@
+/**
+ * ERC20 fixed-point unit conversion, drop-in compatible with ethers v6
+ * `formatUnits` / `parseUnits`.
+ *
+ * These replace the only two `ethers` imports left in the app (token amount
+ * display + transaction amount parsing). `ethers` was otherwise unused, and its
+ * exact-pinned transitive `ws@8.17.1` was the sole reason the app needed a `ws`
+ * dependency override; removing ethers lets `ws` resolve to a patched version
+ * in-range with no override.
+ *
+ * Implemented on bignumber.js (already a dependency) with a self-contained
+ * config clone, so behavior is exact and independent of any global
+ * BigNumber.config() set elsewhere in the app.
+ */
+import { BigNumber } from "bignumber.js";
+
+// EXPONENTIAL_AT high so large/small magnitudes never render in scientific
+// notation; DECIMAL_PLACES high so no value is ever rounded.
+const BN = BigNumber.clone({ EXPONENTIAL_AT: 1e9, DECIMAL_PLACES: 100 });
+
+/**
+ * Convert a base-unit integer amount to a human-readable decimal string.
+ * Matches ethers v6: full precision, trailing zeros stripped, but always at
+ * least one fractional digit (e.g. `1.0`).
+ */
+export function formatUnits(value: bigint | string | number, decimals: number = 18): string {
+  const v = new BN(typeof value === "bigint" ? value.toString() : value);
+  if (v.isNaN()) {
+    throw new Error(`formatUnits: invalid value "${String(value)}"`);
+  }
+  let s = v.shiftedBy(-decimals).toFixed();
+  // ethers keeps at least one fractional digit when decimals > 0 (e.g. "1.0"),
+  // but renders a plain integer when decimals === 0 (e.g. "42").
+  if (decimals > 0 && !s.includes(".")) {
+    s += ".0";
+  }
+  return s;
+}
+
+/**
+ * Convert a human-readable decimal string to a base-unit BigInt.
+ * Matches ethers v6: throws on a non-numeric value or on more fractional
+ * digits than `decimals` allows.
+ */
+export function parseUnits(value: string, decimals: number = 18): bigint {
+  const v = new BN(value);
+  if (v.isNaN()) {
+    throw new Error(`parseUnits: invalid decimal value "${value}"`);
+  }
+  const scaled = v.shiftedBy(decimals);
+  if (!scaled.isInteger()) {
+    throw new Error(`parseUnits: "${value}" has more than ${decimals} decimal places`);
+  }
+  return BigInt(scaled.toFixed(0));
+}


### PR DESCRIPTION
Promotes the accumulated `dev` work to production (`qrlwallet.com`). 19 commits, 16 files. Clean fast-forward (main is an ancestor of dev). Merging auto-deploys prod via the cicd webhook.

## What ships

**Core library upgrade (smoke-tested on dev.qrlwallet.com — import + send tx confirmed working)**
- `@theqrl/web3` 0.4 → **1.0** + `@theqrl/wallet.js` 3 → **6.1** (#159). Validated via adversarial workflow: signing parity vectors stayed byte-green (our PQ signing calls `@theqrl/mldsa87` directly + slices the address, so the address/ctx changes are inert). New `mnemonic.test.ts` pins the round-trip + strict `ExtendedSeed` ctor.

**Security**
- **react-router 7.16** (#160) — fixes 2 HIGH (turbo-stream RCE, open-redirect, 2 XSS).
- **Drop `ethers`** (#161) — replaced `formatUnits`/`parseUnits` with a bignumber.js helper proven byte-identical to ethers v6; removes the dead Node-only WS transport.
- **`ws` patched** via override (8.21.0) — closes dependabot #75 (upstream theQRL/web3.js#76 will let us drop the override later).
- **`parseUnits` hardened** (#162) — rejects hex/non-decimal input (ethers-parity gap).
- **CSP** — removed invalid `192.168.*` wildcards from the meta tag.

**Performance**
- **tx receipt polling** (#163) — ~100 → ~10 RPC calls/tx (7s interval, 1 confirmation; was web3's 1s/24-block defaults).

**Features**
- **Token list per-account scoped** (#164) — matches NFT-list behavior, with a one-shot legacy migration; includes the review fix (scope-guard + `runInAction` in `setTokenList`).
- **Tokens empty-state card** (#165) — mirrors the NFT gallery's empty state.

## Validation
Each piece merged to dev gate-green (lint / 104 tests / build) and was reviewed (Gemini findings processed). The headline `@theqrl` upgrade was runtime-smoke-tested on dev. CI must pass here too (`lint-and-build` is a required check on main).

After this lands, Dependabot security/patch fixes auto-merge to main → prod going forward (majors stay manual).
