### PR TITLE
chore(deps): @theqrl/web3 1.0.1, drop ws override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@tailwindcss/typography": "^0.5.19",
         "@tanstack/react-table": "^8.21.2",
         "@theqrl/wallet.js": "^6.1.0",
-        "@theqrl/web3": "^1.0.0",
+        "@theqrl/web3": "^1.0.1",
         "@types/crypto-js": "^4.2.2",
         "axios": "^1.16.0",
         "bignumber.js": "^9.3.1",
@@ -107,9 +107,9 @@
       "license": "MIT"
     },
     "node_modules/@adraffy/ens-normalize": {
-      "version": "1.8.8",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.8.8.tgz",
-      "integrity": "sha512-QbJczL+zOCNUBkfjCww1DfhL+KNYgC/yCBApqT3d8b9BHg7CFw4O3bTY0BOogiMhw/vGnV2FD17bstxXWn61EA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
       "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
@@ -6045,9 +6045,9 @@
       }
     },
     "node_modules/@theqrl/abi": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/abi/-/abi-1.0.0.tgz",
-      "integrity": "sha512-cZr1gGCRTDCkb6ND7wCKDclj149+nO1YMovVI9z9TBXdlNLLFfG+s90m5g5DyPIpCV4d2SfTxottAdYyJ3TRKA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/abi/-/abi-1.0.1.tgz",
+      "integrity": "sha512-QvM+8QCSw8OSo/WpevJlkwytEdnDK99QpCm7cmyVMDjLgNnMpO7id9Tgj901WELdzGq/rWLEJCDevUGJF3m+YQ==",
       "license": "MIT",
       "dependencies": {
         "@ethersproject/address": "5.8.0",
@@ -6059,7 +6059,7 @@
         "@ethersproject/logger": "5.8.0",
         "@ethersproject/properties": "5.8.0",
         "@ethersproject/strings": "5.8.0",
-        "@theqrl/web3-utils": "1.0.0"
+        "@theqrl/web3-utils": "1.0.1"
       },
       "engines": {
         "node": ">=20"
@@ -6164,88 +6164,88 @@
       }
     },
     "node_modules/@theqrl/web3": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3/-/web3-1.0.0.tgz",
-      "integrity": "sha512-KV5H94nmXoZrZqukY9sOg7a8n6sKiPZAxJvMWa7UZqdkJQJmVU1aCp9owHufPE8ZrBCmcZb4+3bo05IRTgbpXQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3/-/web3-1.0.1.tgz",
+      "integrity": "sha512-ykqJFoYhl83RsiD4QdMUsjHGMTi1DlJm70MjSJamtisfuE1T6WDgDoXohPHR8NL3sStn1os/4+cUAPiOu7sWRw==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-core": "1.0.0",
-        "@theqrl/web3-errors": "1.0.0",
-        "@theqrl/web3-net": "1.0.0",
-        "@theqrl/web3-providers-http": "1.0.0",
-        "@theqrl/web3-providers-ws": "1.0.0",
-        "@theqrl/web3-qrl": "1.0.0",
-        "@theqrl/web3-qrl-abi": "1.0.0",
-        "@theqrl/web3-qrl-accounts": "1.0.0",
-        "@theqrl/web3-qrl-contract": "1.0.0",
-        "@theqrl/web3-qrl-iban": "1.0.0",
-        "@theqrl/web3-qrl-qrns": "1.0.0",
-        "@theqrl/web3-rpc-methods": "1.0.0",
-        "@theqrl/web3-types": "1.0.0",
-        "@theqrl/web3-utils": "1.0.0",
-        "@theqrl/web3-validator": "1.0.0"
+        "@theqrl/web3-core": "1.0.1",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-net": "1.0.1",
+        "@theqrl/web3-providers-http": "1.0.1",
+        "@theqrl/web3-providers-ws": "1.0.1",
+        "@theqrl/web3-qrl": "1.0.1",
+        "@theqrl/web3-qrl-abi": "1.0.1",
+        "@theqrl/web3-qrl-accounts": "1.0.1",
+        "@theqrl/web3-qrl-contract": "1.0.1",
+        "@theqrl/web3-qrl-iban": "1.0.1",
+        "@theqrl/web3-qrl-qrns": "1.0.1",
+        "@theqrl/web3-rpc-methods": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-utils": "1.0.1",
+        "@theqrl/web3-validator": "1.0.1"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-core": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-core/-/web3-core-1.0.0.tgz",
-      "integrity": "sha512-oxs4mR4hC3tXWnan+fcWIIQP+/O9Ysb7M47jGj/NWRaix0SF70v2RKELPy57Rn/f5fsdJb8GyUCsJmOaSbDqrw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-core/-/web3-core-1.0.1.tgz",
+      "integrity": "sha512-oiT+RlEIMTDSYSpPp0i80T55vmuoBXbkGaVao338+6jlemO3zW0NYmnkqrNqxkMk1HO4cePnPCUxFvMj9h9QMg==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-errors": "1.0.0",
-        "@theqrl/web3-providers-http": "1.0.0",
-        "@theqrl/web3-providers-ws": "1.0.0",
-        "@theqrl/web3-qrl-iban": "1.0.0",
-        "@theqrl/web3-types": "1.0.0",
-        "@theqrl/web3-utils": "1.0.0",
-        "@theqrl/web3-validator": "1.0.0"
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-providers-http": "1.0.1",
+        "@theqrl/web3-providers-ws": "1.0.1",
+        "@theqrl/web3-qrl-iban": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-utils": "1.0.1",
+        "@theqrl/web3-validator": "1.0.1"
       },
       "engines": {
         "node": ">=20"
       },
       "optionalDependencies": {
-        "@theqrl/web3-providers-ipc": "1.0.0"
+        "@theqrl/web3-providers-ipc": "1.0.1"
       }
     },
     "node_modules/@theqrl/web3-errors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-1.0.0.tgz",
-      "integrity": "sha512-WTfkfQ0gnHy7yCXwEBaqgxjiQI6IlnAOeCS3YX76vkz69IJgtooYHM4jx95QMN0NCuKh3bOIyMaTPyzebYfoEg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-1.0.1.tgz",
+      "integrity": "sha512-aAirwyS84SA8e4LYkpJ4BF1mut4jSrIt1HksveTmKHZgojJr4y/D/o4bP4w+MgBMymrmdXRzZUJHhk1N3pRktQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-types": "1.0.0"
+        "@theqrl/web3-types": "1.0.1"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-net": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-net/-/web3-net-1.0.0.tgz",
-      "integrity": "sha512-kMdyX3P3Qb9toGAw8w+tVLvYIWm+ccXHVo4ZjBDJkEyErKd+WtuOdkDLeB0W7rY3wWdIrYP5bq/sp33KfvAjzw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-net/-/web3-net-1.0.1.tgz",
+      "integrity": "sha512-F+DDxtqRf1DnD8B6rLRn/L0NJslaF71CcexWBOmeDVlhiUJ2bL2Jd497QZGcya96atobqa/RUGcBxIrjerA29Q==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-core": "1.0.0",
-        "@theqrl/web3-rpc-methods": "1.0.0",
-        "@theqrl/web3-types": "1.0.0",
-        "@theqrl/web3-utils": "1.0.0"
+        "@theqrl/web3-core": "1.0.1",
+        "@theqrl/web3-rpc-methods": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-utils": "1.0.1"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-providers-http": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-http/-/web3-providers-http-1.0.0.tgz",
-      "integrity": "sha512-4f6C+zaLidNe8tx4jTS89opf0B1LTHKzNqqkO6tOaBkKAWwhQG4P+YUHxF3bR7FdD1x9cV2MO0ReDo5Mt5sG4Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-http/-/web3-providers-http-1.0.1.tgz",
+      "integrity": "sha512-XhhvPROFEoeVSOyXXxM+kP0fe/M31LpOOwtbeKcc+1VfEdfy1CqFrdAK0VkFT9aXu58Kc96cFJPA1FcQyID1ew==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-errors": "1.0.0",
-        "@theqrl/web3-types": "1.0.0",
-        "@theqrl/web3-utils": "1.0.0",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-utils": "1.0.1",
         "cross-fetch": "4.1.0"
       },
       "engines": {
@@ -6253,54 +6253,54 @@
       }
     },
     "node_modules/@theqrl/web3-providers-ipc": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-ipc/-/web3-providers-ipc-1.0.0.tgz",
-      "integrity": "sha512-8SNNkZkoIyrwk2as45idvOKOPyIMeRxIIIaizz5pZTF4jIVdL7Fay2Xq2AtugzTns9mT/aXEoAlucLM87+Ftdg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-ipc/-/web3-providers-ipc-1.0.1.tgz",
+      "integrity": "sha512-rbsWTbM+nWXljibMFESXYqZ3v6vk8QL6KYjMb75WGPShjur8s3fhkTDbttJ1GaFJNzguJ7pmCNitnJPBQFTFig==",
       "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
-        "@theqrl/web3-errors": "1.0.0",
-        "@theqrl/web3-types": "1.0.0",
-        "@theqrl/web3-utils": "1.0.0"
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-utils": "1.0.1"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-providers-ws": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-ws/-/web3-providers-ws-1.0.0.tgz",
-      "integrity": "sha512-Ja0WD2ettZD1KbkgBmX5of9Xm+m0D0SBfTMKo7md++EIYKE52QLfOX9Qv8FPG90H4rlnNg5OMJDsLK3tzOlwFg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-ws/-/web3-providers-ws-1.0.1.tgz",
+      "integrity": "sha512-2k+LYAmK6F93Ydh4EBaQ+LGsyQKiCqgiMT6WimV/j0GYxaXfZQoBabvg8dkVtMPLZOXEcUkqPGSs+6DfHNvPdQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-errors": "1.0.0",
-        "@theqrl/web3-types": "1.0.0",
-        "@theqrl/web3-utils": "1.0.0",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-utils": "1.0.1",
         "@types/ws": "8.18.1",
         "isomorphic-ws": "5.0.0",
-        "ws": "8.20.0"
+        "ws": "8.21.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl/-/web3-qrl-1.0.0.tgz",
-      "integrity": "sha512-sda6prwQMjkzPrommwncCfmkpXWuKg0VZ8JQKHFbbqZiqOmJwZ9sRKqHsag3eEUykDhMYQCu4ztkfom/bc7rTw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl/-/web3-qrl-1.0.1.tgz",
+      "integrity": "sha512-9pEYoxJ1hs76D0rWrFdCKNV+teu6VtKLo3ELt0u/5E3T7p+i6PmFy1SAwTftlT6RePmnj01ohI5w8jF/JIAZrg==",
       "license": "LGPL-3.0",
       "dependencies": {
         "@theqrl/wallet.js": "2.0.2",
-        "@theqrl/web3-core": "1.0.0",
-        "@theqrl/web3-errors": "1.0.0",
-        "@theqrl/web3-net": "1.0.0",
-        "@theqrl/web3-providers-ws": "1.0.0",
-        "@theqrl/web3-qrl-abi": "1.0.0",
-        "@theqrl/web3-qrl-accounts": "1.0.0",
-        "@theqrl/web3-rpc-methods": "1.0.0",
-        "@theqrl/web3-types": "1.0.0",
-        "@theqrl/web3-utils": "1.0.0",
-        "@theqrl/web3-validator": "1.0.0",
+        "@theqrl/web3-core": "1.0.1",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-net": "1.0.1",
+        "@theqrl/web3-providers-ws": "1.0.1",
+        "@theqrl/web3-qrl-abi": "1.0.1",
+        "@theqrl/web3-qrl-accounts": "1.0.1",
+        "@theqrl/web3-rpc-methods": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-utils": "1.0.1",
+        "@theqrl/web3-validator": "1.0.1",
         "setimmediate": "1.0.5"
       },
       "engines": {
@@ -6308,18 +6308,18 @@
       }
     },
     "node_modules/@theqrl/web3-qrl-abi": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-abi/-/web3-qrl-abi-1.0.0.tgz",
-      "integrity": "sha512-fd2/u3NBGk3VwKsnsOxT+tGkN3qC7QvZAZaz7LcjHq5N/mwqryUZaTO/kYB0i+SnhuQCiT2pLP/k8zAb8qvWYQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-abi/-/web3-qrl-abi-1.0.1.tgz",
+      "integrity": "sha512-i+vZ9Rtoz0lfDa/fJm/XxkLr76WyXJWkNx7VoVrZYDzzoSnCuouKOVVSVRSy/5bm1a6XHtMelfv/v3CYQX39jQ==",
       "license": "LGPL-3.0",
       "dependencies": {
         "@ethersproject/bignumber": "5.8.0",
-        "@theqrl/abi": "1.0.0",
+        "@theqrl/abi": "1.0.1",
         "@theqrl/wallet.js": "2.0.2",
-        "@theqrl/web3-errors": "1.0.0",
-        "@theqrl/web3-types": "1.0.0",
-        "@theqrl/web3-utils": "1.0.0",
-        "@theqrl/web3-validator": "1.0.0",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-utils": "1.0.1",
+        "@theqrl/web3-validator": "1.0.1",
         "crc-32": "1.2.2",
         "sha3": "2.1.4"
       },
@@ -6350,19 +6350,19 @@
       }
     },
     "node_modules/@theqrl/web3-qrl-accounts": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-accounts/-/web3-qrl-accounts-1.0.0.tgz",
-      "integrity": "sha512-53Rwd3oJT45eE1N1NbTFxMZWE0VelIJ+XWgSIx3HRrcd22TsSTNF7ixSqO++ktkcG4BmZ/edHV0m+OHvkBLMRQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-accounts/-/web3-qrl-accounts-1.0.1.tgz",
+      "integrity": "sha512-A+07dRhMynD0xCbJI5/M/TAxbhgpaJV9m2VjtZXqq4SG78TOICqveJ7cSaz7rkS1aQFTtKKaVqkR0EES34jkxA==",
       "license": "LGPL-3.0",
       "dependencies": {
         "@ethereumjs/rlp": "10.1.1",
         "@theqrl/mldsa87": "2.0.4",
         "@theqrl/qrl-cryptography": "0.1.3",
         "@theqrl/wallet.js": "2.0.2",
-        "@theqrl/web3-errors": "1.0.0",
-        "@theqrl/web3-types": "1.0.0",
-        "@theqrl/web3-utils": "1.0.0",
-        "@theqrl/web3-validator": "1.0.0",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-utils": "1.0.1",
+        "@theqrl/web3-validator": "1.0.1",
         "crc-32": "1.2.2",
         "sha3": "2.1.4"
       },
@@ -6405,53 +6405,53 @@
       }
     },
     "node_modules/@theqrl/web3-qrl-contract": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-contract/-/web3-qrl-contract-1.0.0.tgz",
-      "integrity": "sha512-Fl5tPcmBYnskT5KikmE7QNvterct4vszVWTa5hAgXi+GdBB/CbbhKLg4MBEowuXdD9WYW3llJsdlY/d9HdXpTQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-contract/-/web3-qrl-contract-1.0.1.tgz",
+      "integrity": "sha512-9Pv/5l2IsXg9BgUJgHeMQ5m9WgxRB/zsqHBwtBHD7aiK3f/bEQH7wKq2lkFLg9c8GbzulmUIbMDAjEy0waUVOw==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-core": "1.0.0",
-        "@theqrl/web3-errors": "1.0.0",
-        "@theqrl/web3-qrl": "1.0.0",
-        "@theqrl/web3-qrl-abi": "1.0.0",
-        "@theqrl/web3-types": "1.0.0",
-        "@theqrl/web3-utils": "1.0.0",
-        "@theqrl/web3-validator": "1.0.0"
+        "@theqrl/web3-core": "1.0.1",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-qrl": "1.0.1",
+        "@theqrl/web3-qrl-abi": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-utils": "1.0.1",
+        "@theqrl/web3-validator": "1.0.1"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl-iban": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-iban/-/web3-qrl-iban-1.0.0.tgz",
-      "integrity": "sha512-ggFrr7A8RVFKhMqhDAnl1c77shAea4vfSuRWvHbOqLkhAxiEakjVhjVhMJxu24epXru4JT4wQiDDNYw9dGTKBQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-iban/-/web3-qrl-iban-1.0.1.tgz",
+      "integrity": "sha512-Ag+I8OfL6m8mDMjd3/TH0jdi0e0/77n4ecDCRp1yeQw6d1EbIgL3ACkLdOO+xSgu6Ho1c6ebP54vMHvjxSAiSw==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-errors": "1.0.0",
-        "@theqrl/web3-types": "1.0.0",
-        "@theqrl/web3-utils": "1.0.0",
-        "@theqrl/web3-validator": "1.0.0"
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-utils": "1.0.1",
+        "@theqrl/web3-validator": "1.0.1"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl-qrns": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-qrns/-/web3-qrl-qrns-1.0.0.tgz",
-      "integrity": "sha512-WV1O9e7VUw/BD5604C9xLU8qG3e04s7aMgpNy/Sz23N9bksZoskRJ/fTyZSWSsITSlzh4W3k4IoAi8pMg6yB5w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-qrns/-/web3-qrl-qrns-1.0.1.tgz",
+      "integrity": "sha512-QOMYaLHzQyyjKhiQ2vjDP/CwSBghG2GAzbMKLwLj1/bRLepzvXVYB/SMD8N3TZxZhzdni/DtiQg1OrbkdAfjcA==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@adraffy/ens-normalize": "1.8.8",
-        "@theqrl/web3-core": "1.0.0",
-        "@theqrl/web3-errors": "1.0.0",
-        "@theqrl/web3-net": "1.0.0",
-        "@theqrl/web3-qrl": "1.0.0",
-        "@theqrl/web3-qrl-contract": "1.0.0",
-        "@theqrl/web3-types": "1.0.0",
-        "@theqrl/web3-utils": "1.0.0",
-        "@theqrl/web3-validator": "1.0.0"
+        "@adraffy/ens-normalize": "1.11.1",
+        "@theqrl/web3-core": "1.0.1",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-net": "1.0.1",
+        "@theqrl/web3-qrl": "1.0.1",
+        "@theqrl/web3-qrl-contract": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-utils": "1.0.1",
+        "@theqrl/web3-validator": "1.0.1"
       },
       "engines": {
         "node": ">=20"
@@ -6480,52 +6480,52 @@
       }
     },
     "node_modules/@theqrl/web3-rpc-methods": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-rpc-methods/-/web3-rpc-methods-1.0.0.tgz",
-      "integrity": "sha512-iLgor2K+YEQrfzaIE88a63CBZkR8YqecRWUk//g1IVpTwEofhyXhRYsMAk7JjoYClcQD/IEe0VdY5H8xVpdcOQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-rpc-methods/-/web3-rpc-methods-1.0.1.tgz",
+      "integrity": "sha512-elgQ7tg4vqRf0je9hQ5mM4N7VdX6jUUOHnYv2NGovDPMMuVJisNbl8itDqRk50/7cUNRrp9lNEPiSbdqHLIxSw==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-core": "1.0.0",
-        "@theqrl/web3-types": "1.0.0",
-        "@theqrl/web3-validator": "1.0.0"
+        "@theqrl/web3-core": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-validator": "1.0.1"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-types": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-1.0.0.tgz",
-      "integrity": "sha512-e3RL2TN3UNsvoPe4BVM1DY98YUiuReq5qrqUkSNp7spdFo5snxqUt2FQtRM1QDdv9qJl5tZ3ccbBt0hLHD6TCg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-1.0.1.tgz",
+      "integrity": "sha512-uc+HBs7nMQjM7eD+39Gz/lDQ/1+o98y5xAaPApSvDYfcpDobMW+uV+LrMgBgak0y//OO0w0gtzzd7ohEk7OJmA==",
       "license": "LGPL-3.0",
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-1.0.0.tgz",
-      "integrity": "sha512-TzTQBaVgCY7ZtgAPohSox5Od9ldqAOPg0JDY3oqnskguODDy7ptiWuzSZ5FYpeJOk+AhMKSJ+B8ejqGmdaZB1Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-1.0.1.tgz",
+      "integrity": "sha512-X5H3RIWu3fUXkBz3B6T5pJlGnyUbh414I1HpQ9zUKj/ZZ8Z+EMgO/UMHWSblDRgeucI8DFFjIFGVSuD2ChB5mA==",
       "license": "LGPL-3.0",
       "dependencies": {
         "@theqrl/qrl-cryptography": "0.1.3",
-        "@theqrl/web3-errors": "1.0.0",
-        "@theqrl/web3-types": "1.0.0",
-        "@theqrl/web3-validator": "1.0.0"
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-validator": "1.0.1"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-validator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-1.0.0.tgz",
-      "integrity": "sha512-77Jd6nipdVlZw4eBuCBN1zqUwbhp3rWKsakOtqsgsAk7PlnFYYQ+MOVe7HF2G1eH3N6H5XMobo5jZudB3pBlvw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-1.0.1.tgz",
+      "integrity": "sha512-uwzArtbrk9/JByyPph/ZPeuYs8f5jp8TtXU8BN5yTMOO+WpGDYpqMiaUshLzQdslpUC5vlQqlTW0+3oac1DYxQ==",
       "license": "LGPL-3.0",
       "dependencies": {
         "@theqrl/qrl-cryptography": "0.1.3",
-        "@theqrl/web3-errors": "1.0.0",
-        "@theqrl/web3-types": "1.0.0",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
         "util": "0.12.5",
         "zod": "3.22.3"
       },
@@ -8755,6 +8755,27 @@
         "engine.io-parser": "~5.2.1",
         "ws": "~8.20.1",
         "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/engine.io-parser": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-table": "^8.21.2",
     "@theqrl/wallet.js": "^6.1.0",
-    "@theqrl/web3": "^1.0.0",
+    "@theqrl/web3": "^1.0.1",
     "@types/crypto-js": "^4.2.2",
     "axios": "^1.16.0",
     "bignumber.js": "^9.3.1",
@@ -103,8 +103,5 @@
     "typescript": "^5.2.2",
     "typescript-eslint": "^8.48.0",
     "vite": "^7.3.2"
-  },
-  "overrides": {
-    "ws": "^8.21.0"
   }
 }


### PR DESCRIPTION
## What

- Bump `@theqrl/web3` `^1.0.0` -> `^1.0.1`.
- Remove the `overrides: { "ws": "^8.21.0" }` block (no longer needed).

## Why

theQRL shipped the whole `@theqrl/web3` stack at `1.0.1` (resolves theQRL/web3.js#75, JP Lomas' patch in #76). `web3-providers-ws@1.0.1` now exact-pins `ws@8.21.0` (was `8.20.0` in `1.0.0`, which sat below the `<8.20.1` advisory line and was the entire reason we carried a `ws` override).

With the stack at `1.0.1`, every transitive `ws` path resolves at or above the advisory line on its own:

| consumer | range | resolves |
|---|---|---|
| `@theqrl/web3-providers-ws@1.0.1` | `8.21.0` (exact) | `8.21.0` |
| `engine.io-client@6.6.5` (relay, prod) | `~8.20.1` | `8.20.1` |
| `jsdom@26.1.0` (jest, dev) | `^8.18.0` | `8.21.0` |

So the override is dead weight and is removed. (Per the issue thread we agreed to drop it once the patched release landed; it has.)

## Verification

- `npm audit`: **0 high / 0 critical**, ws advisory gone. Remaining 12 low are the pre-existing upstream `elliptic <=6.6.1` advisory inside `@theqrl/web3-qrl-*` (not fixable without an upstream bump, unrelated to this change).
- `npm run lint`: clean (0 warnings).
- `npm test`: 104/104 pass.
- `npm run build`: green.

## Notes

JP recommended optionally keeping an exact `ws` override "for hygiene", but dropping it is what we settled on in the thread and it leaves the tree clean with no advisory. Easy to re-add a one-line exact override later if we want a single flattened `ws`.