### PR TITLE
chore(deps): drop unused `path` shim dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "lucide-react": "^0.562.0",
         "mobx": "^6.13.0",
         "mobx-react-lite": "^4.0.7",
-        "path": "^0.12.7",
         "qrcode.react": "^4.1.0",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
@@ -12908,16 +12907,6 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
-    "node_modules/path": {
-      "version": "0.12.7",
-      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
-      "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
-      "license": "MIT",
-      "dependencies": {
-        "process": "^0.11.1",
-        "util": "^0.10.3"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -12978,21 +12967,6 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/path/node_modules/inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
-      "license": "ISC"
-    },
-    "node_modules/path/node_modules/util": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "2.0.3"
-      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -13217,15 +13191,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
       }
     },
     "node_modules/prop-types": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "lucide-react": "^0.562.0",
     "mobx": "^6.13.0",
     "mobx-react-lite": "^4.0.7",
-    "path": "^0.12.7",
     "qrcode.react": "^4.1.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",


### PR DESCRIPTION
## What
Remove `path@0.12.7` from `dependencies`.

## Why
Surfaced by the dependency security audit. `path@0.12.7` is an abandoned browser shim (last npm publish 2023) and is dead weight in this repo:

- No file under `src/` imports `path` (verified: `grep -rn "from 'path'" src/` returns nothing).
- The only `import path from 'path'` is in `config/vite.config.ts`, which runs in Node at build time and resolves to Node's **built-in** `path`, not this package. `vite.config.ts` aliases `stream`/`buffer`/`events`/`util`/`process` to `rollup-plugin-node-polyfills` but never aliases `path` to this shim.
- `npm ls path` after removal returns empty (no transitive requirer).

Removing it reduces the supply-chain surface for zero functional cost.

## Verification
- `npm ls path`: empty (gone from tree).
- `npm run build`: green (the `vite.config.ts` path import still resolves via the Node builtin).
- `npm run lint`: clean.
- `npm test`: 104/104.