### PR TITLE
fix(crypto): remove leftover legacy pin_v1 (5000-iter) decrypt fallback

### DIFF
--- a/src/utils/crypto/__tests__/walletEncryption.test.ts
+++ b/src/utils/crypto/__tests__/walletEncryption.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Coverage for the PIN-based seed encryption in walletEncryption.ts, focused on
+ * the removal of the legacy pre-v3 PBKDF2 iteration fallback.
+ *
+ * Context: ce0b802 ("remove legacy PIN encryption versions (v1, v2)") retired
+ * legacy support on the basis that "all users have migrated", but it only
+ * dropped the explicit pin_v2 branch and left a `: 5000` else-fallback in the
+ * sync decryptSeedWithPin. That made the sync path inconsistent with
+ * cryptoWorker.ts, which already ignores the stored version label and always
+ * derives at 600k iterations. This suite pins (a) the real v3 round-trip still
+ * works end-to-end and (b) decrypt now derives at 600k for ANY stored version,
+ * so a pre-v3 blob can no longer be unlocked (matching the async unlock path).
+ *
+ * The version-fallback cases spy on PBKDF2 instead of running the real 600k
+ * derivation, so they assert the iteration count in milliseconds rather than
+ * the ~10s a real pure-JS 600k PBKDF2 costs per call in the node test env.
+ *
+ * nativeApp is mocked: walletEncryption imports it for download/share helpers
+ * (unused by the functions under test) and it touches window/navigator, which
+ * are absent in jest's node environment.
+ */
+
+jest.mock('@/utils/nativeApp', () => ({
+  isInNativeApp: () => false,
+  shareContent: jest.fn(),
+}));
+
+import CryptoJS from 'crypto-js';
+import { WalletEncryptionUtil, PinDecryptionError } from '../walletEncryption';
+
+const MNEMONIC =
+  'absorb absurd abuse access accident account accuse achieve acid acoustic acquire across';
+const HEX_SEED = '0x' + 'ab'.repeat(48);
+const PIN = '123456';
+
+describe('WalletEncryptionUtil PIN seed encryption', () => {
+  it('writes pin_v3 and round-trips with the correct PIN (real 600k path)', () => {
+    const blob = WalletEncryptionUtil.encryptSeedWithPin(MNEMONIC, HEX_SEED, PIN);
+    expect(JSON.parse(blob).version).toBe('pin_v3');
+
+    const out = WalletEncryptionUtil.decryptSeedWithPin(blob, PIN);
+    expect(out).toEqual({ mnemonic: MNEMONIC, hexSeed: HEX_SEED });
+  });
+
+  describe('decrypt always derives at 600k iterations, regardless of stored version', () => {
+    // Regression guard for the removed legacy fallback. Spied so the assertion
+    // is on the iteration count, not the (mocked, therefore failing) decrypt
+    // result, which keeps it fast.
+    let spy: ReturnType<typeof jest.spyOn>;
+
+    beforeEach(() => {
+      spy = jest
+        .spyOn(CryptoJS, 'PBKDF2')
+        .mockReturnValue(CryptoJS.lib.WordArray.random(256 / 8));
+    });
+    afterEach(() => {
+      spy.mockRestore();
+    });
+
+    it.each(['pin_v1', 'pin_v2', 'pin_v3', 'unlabeled'])(
+      'uses 600000 iterations for a %s blob',
+      (label) => {
+        const blob = JSON.stringify({
+          encryptedData: 'deadbeefdeadbeef',
+          salt: 'aa'.repeat(16),
+          iv: 'bb'.repeat(16),
+          version: label === 'unlabeled' ? undefined : label,
+          timestamp: 0,
+        });
+
+        // Decrypt fails (the mocked key yields garbage), which is fine: the
+        // assertion below is what matters, not the throw.
+        try {
+          WalletEncryptionUtil.decryptSeedWithPin(blob, PIN);
+        } catch (e) {
+          expect(e).toBeInstanceOf(PinDecryptionError);
+        }
+
+        expect(spy).toHaveBeenCalledWith(
+          PIN,
+          expect.anything(),
+          expect.objectContaining({ iterations: 600000 }),
+        );
+      },
+    );
+  });
+});

--- a/src/utils/crypto/__tests__/walletEncryption.test.ts
+++ b/src/utils/crypto/__tests__/walletEncryption.test.ts
@@ -68,13 +68,11 @@ describe('WalletEncryptionUtil PIN seed encryption', () => {
           timestamp: 0,
         });
 
-        // Decrypt fails (the mocked key yields garbage), which is fine: the
-        // assertion below is what matters, not the throw.
-        try {
-          WalletEncryptionUtil.decryptSeedWithPin(blob, PIN);
-        } catch (e) {
-          expect(e).toBeInstanceOf(PinDecryptionError);
-        }
+        // Decrypt throws (the mocked key yields garbage), which is expected;
+        // the iteration-count assertion below is the actual regression guard.
+        expect(() => WalletEncryptionUtil.decryptSeedWithPin(blob, PIN)).toThrow(
+          PinDecryptionError,
+        );
 
         expect(spy).toHaveBeenCalledWith(
           PIN,

--- a/src/utils/crypto/walletEncryption.ts
+++ b/src/utils/crypto/walletEncryption.ts
@@ -222,12 +222,15 @@ export class WalletEncryptionUtil {
       const salt = CryptoJS.enc.Hex.parse(parsed.salt);
       const iv = CryptoJS.enc.Hex.parse(parsed.iv);
 
-      // Support v1 (5k) and v3 (600k) iterations for backward compatibility
-      const iterations = parsed.version === 'pin_v3' ? 600000 : 5000;
-
+      // All wallets use pin_v3 (600k PBKDF2 iterations). Legacy v1/v2 support
+      // was retired in ce0b802 ("all users have migrated"); this drops the
+      // leftover 5000-iteration fallback so the sync path matches the async
+      // worker (cryptoWorker.ts), which already always uses 600k regardless
+      // of the stored version label. A pre-v3 blob fails to decrypt here just
+      // as it already does on the async unlock path, and must be re-imported.
       const key = CryptoJS.PBKDF2(pin, salt, {
         keySize: 256/32,
-        iterations
+        iterations: 600000
       });
 
       const decrypted = CryptoJS.AES.decrypt(

--- a/src/utils/crypto/walletEncryption.ts
+++ b/src/utils/crypto/walletEncryption.ts
@@ -191,10 +191,11 @@ export class WalletEncryptionUtil {
     const salt = CryptoJS.lib.WordArray.random(128/8);
     const iv = CryptoJS.lib.WordArray.random(128/8);
 
-    // Use PBKDF2 to derive key from PIN
+    // Use PBKDF2 to derive key from PIN. 600k iterations (PBKDF2_ITERATIONS)
+    // is the OWASP 2023 recommended minimum for brute-force resistance.
     const key = CryptoJS.PBKDF2(pin, salt, {
       keySize: 256/32,
-      iterations: 600000 // OWASP 2023 recommended minimum for brute force resistance
+      iterations: PBKDF2_ITERATIONS
     });
 
     const encrypted = CryptoJS.AES.encrypt(
@@ -230,7 +231,7 @@ export class WalletEncryptionUtil {
       // as it already does on the async unlock path, and must be re-imported.
       const key = CryptoJS.PBKDF2(pin, salt, {
         keySize: 256/32,
-        iterations: 600000
+        iterations: PBKDF2_ITERATIONS
       });
 
       const decrypted = CryptoJS.AES.decrypt(


### PR DESCRIPTION
## What
Pin `decryptSeedWithPin` to 600k PBKDF2 iterations unconditionally, removing the leftover `: 5000` legacy fallback.

## Why (this answers "wasn't v1 already removed?")
`ce0b802` ("remove legacy PIN encryption versions (v1, v2)") retired legacy PIN support because "all users have migrated", but it only **half** did it:
- It dropped the explicit `pin_v2` branch and made the **async worker** (`cryptoWorker.ts` `getIterations`) ignore the version label and always derive at 600k.
- But it **left a `: 5000` else-fallback** in the sync `walletEncryption.ts`:
  ```ts
  const iterations = parsed.version === 'pin_v3' ? 600000 : 5000;
  ```
So any non-`pin_v3` blob still decrypted at **5,000 iterations** on the sync path.

### Impact of the leftover
- **Unreachable for real users:** web unlock / PIN setup / account creation all go through the async worker (600k-only), so a pre-v3 wallet cannot pass unlock at all. The 5,000-iter sync path was dead weight.
- But it left the **sync path** (transaction-time decrypt in Transfer / NftDetail / DAppApprovalModal / TokenCreationForm, and native `VERIFY_PIN`) weaker on paper and **inconsistent** with the async path.

This completes `ce0b802`'s stated intent: the sync path now matches the worker. A pre-v3 blob (if any still exists) now fails to decrypt here too, exactly as the async unlock gate already enforces, and must be re-imported.

## Tests (new `walletEncryption.test.ts`)
- Real end-to-end 600k `pin_v3` round-trip (encrypt then decrypt).
- Fast spied regression: decrypt derives at **600000** iterations for `pin_v1` / `pin_v2` / `pin_v3` / unlabeled blobs (proves the legacy 5000/100000 paths are gone). Spied so it runs in ms instead of paying a real 600k derivation per case.

## Verification
- `npm run lint`: clean.
- `npm test`: 109/109 (8 suites).
- `npm run build`: green (tsc type-checks the new test under `src/**/*.ts`).

## Note (separate, larger item)
The audit also flagged that crypto-js PBKDF2 here uses the **SHA-1** default PRF (no `hasher`) and **unauthenticated AES-CBC**. That is a bigger WebCrypto (AES-GCM + PBKDF2-SHA256) migration, tracked separately, not in this PR.