### PR TITLE
feat(bridge): SET_DISPLAY_PREFS to drive Home card toggles from native settings

### DIFF
--- a/src/components/NativeAppBridge.tsx
+++ b/src/components/NativeAppBridge.tsx
@@ -230,6 +230,31 @@ const NativeAppBridge: React.FC = () => {
           break;
         }
 
+        case 'SET_DISPLAY_PREFS' as NativeToWebMessageType: {
+          // The native app's own Settings tab drives the Home Tokens/NFTs card
+          // toggles. Merge the provided booleans into wallet settings;
+          // setWalletSettings dispatches STORAGE_EVENT_WALLET_SETTINGS, which
+          // Home listens for, so the cards update without a reload.
+          (async () => {
+            try {
+              const current = await StorageUtil.getWalletSettings();
+              const next = { ...current };
+              if (typeof payload?.showTokensCard === 'boolean') {
+                next.showTokensCard = payload.showTokensCard;
+              }
+              if (typeof payload?.showNftsCard === 'boolean') {
+                next.showNftsCard = payload.showNftsCard;
+              }
+              await StorageUtil.setWalletSettings(next);
+            } catch (error) {
+              const errorMsg = error instanceof Error ? error.message : String(error);
+              console.error('[Bridge] Error applying SET_DISPLAY_PREFS:', error);
+              logToNative(`Error applying display prefs: ${errorMsg}`);
+            }
+          })();
+          break;
+        }
+
         case 'CLIPBOARD_SUCCESS':
           // Could show a toast notification
           console.log('[Bridge] Clipboard success');

--- a/src/components/NativeAppBridge.tsx
+++ b/src/components/NativeAppBridge.tsx
@@ -237,13 +237,15 @@ const NativeAppBridge: React.FC = () => {
           // Home listens for, so the cards update without a reload.
           (async () => {
             try {
+              const { showTokensCard, showNftsCard } = (payload || {}) as Record<string, unknown>;
               const current = await StorageUtil.getWalletSettings();
               const next = { ...current };
-              if (typeof payload?.showTokensCard === 'boolean') {
-                next.showTokensCard = payload.showTokensCard;
+
+              if (typeof showTokensCard === 'boolean') {
+                next.showTokensCard = showTokensCard;
               }
-              if (typeof payload?.showNftsCard === 'boolean') {
-                next.showNftsCard = payload.showNftsCard;
+              if (typeof showNftsCard === 'boolean') {
+                next.showNftsCard = showNftsCard;
               }
               await StorageUtil.setWalletSettings(next);
             } catch (error) {

--- a/src/utils/nativeApp.ts
+++ b/src/utils/nativeApp.ts
@@ -52,7 +52,9 @@ export type NativeToWebMessageType =
   | 'CHANGE_PIN'            // Native requests web to re-encrypt seeds with new PIN
   // DApp Connect messages
   | 'DAPP_URI'              // Deep link URI received by native, forwarded to WebView
-  | 'DAPP_DISCONNECT';      // Native requests web to disconnect a specific dApp session
+  | 'DAPP_DISCONNECT'       // Native requests web to disconnect a specific dApp session
+  // Display preferences (native settings drives the Home card toggles)
+  | 'SET_DISPLAY_PREFS';    // Native sets showTokensCard / showNftsCard in wallet settings
 
 export interface NativeMessage {
   type: NativeToWebMessageType;


### PR DESCRIPTION
## Why
The mobile app has its own native Settings tab, and in-app the web Settings screen is bypassed (`navigation.ts` -> `openNativeSettings()`). So the **Show Tokens Card** / **Show NFTs Card** toggles (which are wired to `Home.tsx`) had no way to be controlled from the app. This adds the web side of the bridge so the native toggles can drive them.

## What
- `nativeApp.ts`: new native->web message type `SET_DISPLAY_PREFS`.
- `NativeAppBridge.tsx`: handler merges `showTokensCard` / `showNftsCard` from the payload into `WalletSettings` via `StorageUtil.setWalletSettings`.

`setWalletSettings` dispatches `STORAGE_EVENT_WALLET_SETTINGS`, which `Home.tsx` already subscribes to (it re-reads the card prefs on that event), so the cards toggle **live, no reload**. This sidesteps the documented WebView-throttling gotcha: it's a fire-and-forget native->web push applied when the WebView is active.

## Pairing
Pairs with the `myqrlwallet-app` PR that adds the two native toggles + sends this message. Backward-safe: unknown message types hit the switch `default` and are ignored, so deploy order doesn't matter.

## Verification
- `npm run lint` clean, `npm run build` green.
- Device verification happens with the app PR.