### PR TITLE
fix(tokens): fix multi-token addition race and Transfer asset list

### DIFF
--- a/src/components/Core/Body/Transfer/Transfer.tsx
+++ b/src/components/Core/Body/Transfer/Transfer.tsx
@@ -66,7 +66,7 @@ const Transfer = observer(() => {
     resetTransactionStatus,
     estimateNativeTransferFee,
   } = qrlStore;
-  const { tokenList, sendToken: sendTokenToStore } = tokenStore;
+  const { visibleTokenList, sendToken: sendTokenToStore } = tokenStore;
   const { blockchain } = qrlConnection;
   const { accountAddress } = activeAccount;
 
@@ -153,7 +153,7 @@ const Transfer = observer(() => {
 
   // Get selected token info
   const selectedToken = !isNativeTransfer
-    ? tokenList.find(t => t.address === selectedAsset)
+    ? visibleTokenList.find(t => t.address === selectedAsset)
     : null;
 
   // Get balance based on selected asset
@@ -172,7 +172,7 @@ const Transfer = observer(() => {
             accountAddress,
             QRL_PROVIDER[selectedBlockChain as keyof typeof QRL_PROVIDER].url
           );
-          const token = tokenList.find(t => t.address === selectedAsset);
+          const token = visibleTokenList.find(t => t.address === selectedAsset);
           setTokenBalance(formatUnits(balance, token?.decimals || 18));
         } catch (error) {
           console.error("Error fetching token balance:", error);
@@ -181,7 +181,7 @@ const Transfer = observer(() => {
       }
     };
     fetchTokenBalance();
-  }, [selectedAsset, accountAddress, isNativeTransfer, tokenList]);
+  }, [selectedAsset, accountAddress, isNativeTransfer, visibleTokenList]);
 
   // Reset amount when asset changes
   useEffect(() => {
@@ -619,7 +619,7 @@ const Transfer = observer(() => {
                                 <span>QRL (Native)</span>
                               </div>
                             </SelectItem>
-                            {tokenList.map((token) => (
+                            {visibleTokenList.map((token) => (
                               <SelectItem key={token.address} value={token.address}>
                                 <div className="flex items-center gap-2">
                                   <span className="font-medium">{token.symbol}</span>

--- a/src/stores/tokenStore.ts
+++ b/src/stores/tokenStore.ts
@@ -813,6 +813,13 @@ class TokenStore {
         await StorageUtil.unhideToken(blockchain, account, addr);
       }
       
+      // Stale-write guard: if the account changed while we were awaiting
+      // storage writes, don't prune the current account's hiddenTokens.
+      if (this.qrlStore.activeAccount.accountAddress !== startAccount) {
+        log("addDiscoveredTokens: active account changed before unhide write, abandoning memory prune");
+        return;
+      }
+
       const drop = new Set(unhides.map((a) => a.toLowerCase()));
       runInAction(() => {
         this.hiddenTokens = this.hiddenTokens.filter(

--- a/src/stores/tokenStore.ts
+++ b/src/stores/tokenStore.ts
@@ -146,14 +146,26 @@ class TokenStore {
     await this.migrateGlobalTokenListToAccount();
     const { blockchain, account } = this.scope;
     const persistedList = await StorageUtil.getTokenList(blockchain, account);
-    runInAction(() => {
-      this.tokenList = persistedList;
-    });
-    await this.loadHiddenTokens();
-
+    
+    // Seed KNOWN_TOKEN_LIST into the persisted list if not already present.
+    // Use a local copy to avoid multiple re-renders and potential races
+    // during the loop.
+    const initialList = [...persistedList];
+    const seen = new Set(initialList.map((t) => t.address.toLowerCase()));
     for (const token of KNOWN_TOKEN_LIST) {
-      await this.addToken(token);
+      if (!seen.has(token.address.toLowerCase())) {
+        initialList.push(token);
+        seen.add(token.address.toLowerCase());
+      }
     }
+
+    runInAction(() => {
+      this.tokenList = initialList;
+    });
+
+    // Also persist the merged list so KNOWN_TOKEN_LIST entries land in storage
+    await StorageUtil.updateTokenList(blockchain, account, initialList);
+    await this.loadHiddenTokens();
   }
 
   // One-shot migration: pre-gate (before PR #142), the wallet auto-merged
@@ -230,17 +242,27 @@ class TokenStore {
     const blockchain = this.qrlStore.qrlConnection.blockchain;
     const persisted = await StorageUtil.getTokenList(blockchain, newActiveAccount);
     const hidden = await StorageUtil.getHiddenTokens(blockchain, newActiveAccount);
+
+    // Sync KNOWN_TOKEN_LIST into the persisted list for the new account.
+    const initialList = [...persisted];
+    const seen = new Set(initialList.map((t) => t.address.toLowerCase()));
+    for (const token of KNOWN_TOKEN_LIST) {
+      if (!seen.has(token.address.toLowerCase())) {
+        initialList.push(token);
+        seen.add(token.address.toLowerCase());
+      }
+    }
+
     runInAction(() => {
-      this.tokenList = persisted;
+      this.tokenList = initialList;
       this.hiddenTokens = hidden;
       // Discovered list is per-address; drop it so a picker opened
       // after the switch can't leak the prior account's results.
       this.discoveredTokens = [];
     });
 
-    for (const token of KNOWN_TOKEN_LIST) {
-      await this.addToken(token);
-    }
+    // Persist the merged list for the new account scope
+    await StorageUtil.updateTokenList(blockchain, newActiveAccount, initialList);
 
     // Refresh balances on whatever is in the list now (persisted picks +
     // KNOWN_TOKEN_LIST entries). No explorer call.
@@ -328,15 +350,15 @@ class TokenStore {
   async setTokenList(tokenList: TokenInterface[]) {
     const { blockchain, account } = this.scope;
     if (!blockchain || !account) return;
+
+    // Update the observable immediately so concurrent calls see the new state.
+    // Wrap in runInAction because we are in an async method.
+    runInAction(() => {
+      this.tokenList = tokenList;
+    });
+
+    // Persist to storage.
     await StorageUtil.updateTokenList(blockchain, account, tokenList);
-    // The active account/blockchain can change during the await; only apply the
-    // result if we're still on the same scope, and wrap the observable write in
-    // runInAction (MobX strict mode forbids mutating after an await otherwise).
-    if (this.scope.blockchain === blockchain && this.scope.account === account) {
-      runInAction(() => {
-        this.tokenList = tokenList;
-      });
-    }
   }
 
   async sendToken(
@@ -749,43 +771,48 @@ class TokenStore {
   async addDiscoveredTokens(picks: TokenInterface[]) {
     if (picks.length === 0) return;
     const startAccount = this.qrlStore.activeAccount.accountAddress;
-    const owned = new Set(
-      this.tokenList.map((t) => t.address.toLowerCase()),
-    );
-    const hidden = new Set(this.hiddenTokens.map((a) => a.toLowerCase()));
+    
+    // Capture state once to ensure consistency during the loop
+    const currentTokenList = [...this.tokenList];
+    const currentHiddenTokens = [...this.hiddenTokens];
+    
+    const owned = new Set(currentTokenList.map((t) => t.address.toLowerCase()));
+    const hidden = new Set(currentHiddenTokens.map((a) => a.toLowerCase()));
+    
     const additions: TokenInterface[] = [];
     const unhides: string[] = [];
+    
     for (const pick of picks) {
       const lower = pick.address.toLowerCase();
       if (!owned.has(lower)) {
         additions.push(pick);
+        owned.add(lower); // Prevent duplicate additions within the same batch
       } else if (hidden.has(lower)) {
         unhides.push(pick.address);
       }
-      // else: already visible — skip
     }
+    
     if (additions.length === 0 && unhides.length === 0) return;
-    // Stale-write guard: token storage is per-account-scoped, so a write
-    // lands in the right key even after a switch, but the in-memory
-    // append would still mix the prior account's picks into the new
-    // account's tokenList.
+    
     if (this.qrlStore.activeAccount.accountAddress !== startAccount) {
-      log(
-        "addDiscoveredTokens: active account changed before write, abandoning picks",
-      );
+      log("addDiscoveredTokens: active account changed before write, abandoning picks");
       return;
     }
+    
     const { blockchain, account } = this.scope;
+    
+    // 1. Handle additions (new tokens)
     if (additions.length > 0) {
       await this.setTokenList([...this.tokenList, ...additions]);
     }
+    
+    // 2. Handle unhides (existing but hidden tokens)
     if (unhides.length > 0) {
-      // Persist each unhide (StorageUtil.unhideToken is small) and
-      // collapse the observable update into a single runInAction so the
-      // UI re-renders once instead of N times.
+      // Persist unhides in storage
       for (const addr of unhides) {
         await StorageUtil.unhideToken(blockchain, account, addr);
       }
+      
       const drop = new Set(unhides.map((a) => a.toLowerCase()));
       runInAction(() => {
         this.hiddenTokens = this.hiddenTokens.filter(
@@ -793,9 +820,8 @@ class TokenStore {
         );
       });
     }
-    log(
-      `addDiscoveredTokens: added ${additions.length}, unhid ${unhides.length}`,
-    );
+    
+    log(`addDiscoveredTokens: added ${additions.length}, unhid ${unhides.length}`);
   }
 
   clearDiscoveredTokens() {


### PR DESCRIPTION
Fixes two bugs:
1. Multi-token addition from discovery modal was dropping items due to race conditions in TokenStore.
2. Transfer page was listing hidden tokens in the asset selector.

Changes:
- Refactored TokenStore to update observable state synchronously before persisting.
- Batched token seeding in initialize and account switch.
- Updated Transfer.tsx to use visibleTokenList.
- Hardened addDiscoveredTokens with consistency snapshots.