### PR TITLE
Release: token balance card cleanup

### DIFF
--- a/src/components/Core/Body/Tokens/TokenForm/TokenForm.tsx
+++ b/src/components/Core/Body/Tokens/TokenForm/TokenForm.tsx
@@ -1,4 +1,3 @@
-import { TokenInterface } from "@/constants";
 import {
     Card,
     CardContent,
@@ -9,14 +8,10 @@ import { observer } from "mobx-react-lite";
 import { columns } from "./columns"
 import { DataTable } from "./data-table"
 import { useEffect, useState } from "react";
-import { fetchBalance } from "@/utils/web3";
 import { useStore } from "@/stores/store";
 import { Button } from "@/components/UI/Button";
 import { Check, Plus, RefreshCw, Import, Coins, Sparkles } from "lucide-react";
 import { AddTokenModal } from "../AddTokenModal/AddTokenModal";
-import { formatUnits } from "@/utils/web3/units";
-import { QRL_PROVIDER } from "@/config";
-import { StorageUtil } from "@/utils/storage";
 
 import {
     DropdownMenu,
@@ -32,7 +27,6 @@ import {
 } from "@/components/UI/Tooltip";
 import { useNavigate } from "react-router-dom";
 import { ROUTES } from "@/router/router";
-import { getOptimalTokenBalance } from "@/utils/formatting";
 
 const TokenForm = observer(() => {
     const { qrlStore, tokenStore } = useStore();
@@ -40,9 +34,7 @@ const TokenForm = observer(() => {
     const { accountAddress: activeAccountAddress } = qrlStore.activeAccount;
     const { visibleTokenList, pendingDiscoveredTokens } = tokenStore;
 
-    const [tokenList, setTokenList] = useState<TokenInterface[]>(visibleTokenList);
     const [isAddTokenModalOpen, setIsAddTokenModalOpen] = useState(false);
-    const [isLoading, setIsLoading] = useState(true);
     const [isRefreshing, setIsRefreshing] = useState(false);
     const [refreshSuccess, setRefreshSuccess] = useState(false);
 
@@ -80,38 +72,6 @@ const TokenForm = observer(() => {
         if (!activeAccountAddress) return;
         void tokenStore.discoverTokensForReview(activeAccountAddress);
     }, [activeAccountAddress, tokenStore]);
-
-    useEffect(() => {
-        const init = async () => {
-            setIsLoading(true);
-            try {
-                const selectedBlockChain = await StorageUtil.getBlockChain();
-                const promises = visibleTokenList.map(async (token) => {
-                    try {
-                        const balance = await fetchBalance(token.address, activeAccountAddress, QRL_PROVIDER[selectedBlockChain].url);
-                        const balanceStr = formatUnits(balance, token.decimals);
-                        return { ...token, amount: getOptimalTokenBalance(balanceStr, token.symbol, false) };
-                    } catch (err) {
-                        console.error(`Failed to fetch balance for token ${token.symbol}:`, err);
-                        return { ...token, amount: "Error" };
-                    }
-                });
-                const updatedTokenList = await Promise.all(promises);
-                setTokenList(updatedTokenList);
-            } catch (err) {
-                console.error("Failed to initialize token list:", err);
-            } finally {
-                setIsLoading(false);
-            }
-        };
-
-        init();
-    }, [activeAccountAddress, visibleTokenList]);
-
-    // Update local state when store changes
-    useEffect(() => {
-        setTokenList(visibleTokenList);
-    }, [visibleTokenList]);
 
     return (
         <Card className="border-l-4 border-l-secondary">
@@ -163,8 +123,7 @@ const TokenForm = observer(() => {
             <CardContent>
                 <DataTable
                     columns={columns}
-                    data={tokenList}
-                    isLoading={isLoading}
+                    data={visibleTokenList}
                     emptyMessage={
                         <TokensEmptyState
                             discoveredCount={pendingDiscoveredTokens.length}

--- a/src/components/Core/Body/Tokens/TokenForm/TokenForm.tsx
+++ b/src/components/Core/Body/Tokens/TokenForm/TokenForm.tsx
@@ -90,7 +90,7 @@ const TokenForm = observer(() => {
                     try {
                         const balance = await fetchBalance(token.address, activeAccountAddress, QRL_PROVIDER[selectedBlockChain].url);
                         const balanceStr = formatUnits(balance, token.decimals);
-                        return { ...token, amount: getOptimalTokenBalance(balanceStr, token.symbol) };
+                        return { ...token, amount: getOptimalTokenBalance(balanceStr, token.symbol, false) };
                     } catch (err) {
                         console.error(`Failed to fetch balance for token ${token.symbol}:`, err);
                         return { ...token, amount: "Error" };

--- a/src/components/Core/Body/Tokens/TokenForm/columns.tsx
+++ b/src/components/Core/Body/Tokens/TokenForm/columns.tsx
@@ -141,7 +141,7 @@ export const columns: ColumnDef<TokenInterface>[] = [
     },
     {
         accessorKey: 'amount',
-        header: 'Amount',
+        header: 'Balance',
         cell: ({ row }) => {
             const amount: string = row.getValue('amount')
             return <BalanceCell amount={amount} />;

--- a/src/stores/tokenStore.ts
+++ b/src/stores/tokenStore.ts
@@ -644,29 +644,23 @@ class TokenStore {
       // reflects what we set out to refresh.
       const snapshot = [...this.tokenList];
       const selectedBlockChain = await StorageUtil.getBlockChain();
-      const updatedTokenList = [...snapshot];
+      const rpcUrl = QRL_PROVIDER[selectedBlockChain as keyof typeof QRL_PROVIDER].url;
 
-      for (let i = 0; i < snapshot.length; i++) {
-        const token = snapshot[i];
-        try {
-          const balance = await fetchBalance(
-            token.address,
-            startAccount,
-            QRL_PROVIDER[selectedBlockChain as keyof typeof QRL_PROVIDER].url,
-          );
-          const balanceStr = formatUnits(balance, token.decimals);
-          updatedTokenList[i] = {
-            ...token,
-            amount: getOptimalTokenBalance(balanceStr, token.symbol, false),
-          };
-        } catch (err) {
-          console.error(
-            `Error fetching balance for token ${token.symbol}:`,
-            err,
-          );
-          updatedTokenList[i] = { ...token, amount: "Error" };
-        }
-      }
+      const updatedTokenList = await Promise.all(
+        snapshot.map(async (token) => {
+          try {
+            const balance = await fetchBalance(token.address, startAccount, rpcUrl);
+            const balanceStr = formatUnits(balance, token.decimals);
+            return {
+              ...token,
+              amount: getOptimalTokenBalance(balanceStr, token.symbol, false),
+            };
+          } catch (err) {
+            console.error(`Error fetching balance for token ${token.symbol}:`, err);
+            return { ...token, amount: "Error" };
+          }
+        })
+      );
 
       // Stale-write guard: if the active account changed under us,
       // abandon the result. setTokenList writes to the current scope, so

--- a/src/stores/tokenStore.ts
+++ b/src/stores/tokenStore.ts
@@ -657,7 +657,7 @@ class TokenStore {
           const balanceStr = formatUnits(balance, token.decimals);
           updatedTokenList[i] = {
             ...token,
-            amount: getOptimalTokenBalance(balanceStr, token.symbol),
+            amount: getOptimalTokenBalance(balanceStr, token.symbol, false),
           };
         } catch (err) {
           console.error(

--- a/src/utils/formatting/balance.ts
+++ b/src/utils/formatting/balance.ts
@@ -65,11 +65,14 @@ export const getOptimalGasFee = (gas: string, tokenSymbol?: string) => {
 export const getOptimalTokenBalance = (
     balance: string,
     tokenSymbol?: string,
+    includeSymbol: boolean = true,
 ) => {
     const symbol = tokenSymbol ?? NATIVE_TOKEN.symbol;
     try {
         const bigNumber = new BigNumber(balance);
-        if (bigNumber.isNaN() || bigNumber.isZero()) return `0.0 ${symbol}`;
+        if (bigNumber.isNaN() || bigNumber.isZero()) {
+            return includeSymbol ? `0.0 ${symbol}` : "0.0";
+        }
 
         let formatted = bigNumber
             .toFormat(4, BigNumber.ROUND_DOWN)
@@ -79,9 +82,9 @@ export const getOptimalTokenBalance = (
             formatted += ".0";
         }
 
-        return `${formatted} ${symbol}`;
+        return includeSymbol ? `${formatted} ${symbol}` : formatted;
     } catch {
-        return `0.0 ${symbol}`;
+        return includeSymbol ? `0.0 ${symbol}` : "0.0";
     }
 };
 


### PR DESCRIPTION
## Summary
- Promote dev to main after PR #175
- Rename Tokens card Amount column to Balance
- Remove redundant token balance symbols and duplicate balance fetching

## Validation
- Diff reviewed: origin/main..origin/dev
- npm run lint: passed
- npm test -- --runInBand: passed, 114 tests
- npm run build: passed

## Risk
- Low: UI formatting and token balance refresh behavior only
- Runtime impact: token balances now refresh through tokenStore only; tokenStore fetches balances in parallel