### PR TITLE
fix(tokens): format token balance on add to avoid raw value flash

### DIFF
--- a/src/components/Core/Body/Tokens/AddTokenModal/AddTokenModal.tsx
+++ b/src/components/Core/Body/Tokens/AddTokenModal/AddTokenModal.tsx
@@ -115,13 +115,13 @@ export const AddTokenModal = observer(({ isOpen, onClose }: { isOpen: boolean, o
                     const selectedBlockChain = await StorageUtil.getBlockChain();
                     const { name, symbol, decimals } = await fetchTokenInfo(tokenAddress, QRL_PROVIDER[selectedBlockChain].url);
                     const balance = await fetchBalance(tokenAddress, activeAccountAddress, QRL_PROVIDER[selectedBlockChain].url);
-                    const parsedDecimals = parseInt(decimals.toString());
+                    const parsedDecimals = parseInt(decimals?.toString() ?? "18");
                     // Store the display-formatted balance (decimals applied) so the
                     // token list doesn't flash the raw base-unit integer until the
                     // next refreshTokenBalances cycle reformats it.
                     let amount = "0.0";
                     try {
-                        amount = getOptimalTokenBalance(formatUnits(balance.toString(), parsedDecimals), symbol, false);
+                        amount = getOptimalTokenBalance(formatUnits(balance?.toString() ?? "0", parsedDecimals), symbol, false);
                     } catch {
                         amount = "0.0";
                     }

--- a/src/components/Core/Body/Tokens/AddTokenModal/AddTokenModal.tsx
+++ b/src/components/Core/Body/Tokens/AddTokenModal/AddTokenModal.tsx
@@ -15,6 +15,8 @@ import { observer } from "mobx-react-lite";
 import { Loader2, Sparkles } from "lucide-react";
 import { useStore } from "@/stores/store";
 import { fetchTokenInfo, fetchBalance } from "@/utils/web3";
+import { formatUnits } from "@/utils/web3/units";
+import { getOptimalTokenBalance } from "@/utils/formatting";
 import type { TokenInterface } from "@/constants";
 import { QRL_PROVIDER } from "@/config";
 import { StorageUtil } from "@/utils/storage";
@@ -113,7 +115,17 @@ export const AddTokenModal = observer(({ isOpen, onClose }: { isOpen: boolean, o
                     const selectedBlockChain = await StorageUtil.getBlockChain();
                     const { name, symbol, decimals } = await fetchTokenInfo(tokenAddress, QRL_PROVIDER[selectedBlockChain].url);
                     const balance = await fetchBalance(tokenAddress, activeAccountAddress, QRL_PROVIDER[selectedBlockChain].url);
-                    setTokenInfo({ name, symbol, decimals: parseInt(decimals.toString()), address: tokenAddress, amount: balance.toString() });
+                    const parsedDecimals = parseInt(decimals.toString());
+                    // Store the display-formatted balance (decimals applied) so the
+                    // token list doesn't flash the raw base-unit integer until the
+                    // next refreshTokenBalances cycle reformats it.
+                    let amount = "0.0";
+                    try {
+                        amount = getOptimalTokenBalance(formatUnits(balance.toString(), parsedDecimals), symbol, false);
+                    } catch {
+                        amount = "0.0";
+                    }
+                    setTokenInfo({ name, symbol, decimals: parsedDecimals, address: tokenAddress, amount });
                 } catch (err) {
                     console.error("Error fetching token info", err);
                     setTokenInfo(null);

--- a/src/utils/web3/tokenDiscovery.ts
+++ b/src/utils/web3/tokenDiscovery.ts
@@ -59,7 +59,9 @@ export async function discoverTokens(
       .filter((token) => token.contractAddress)
       .map((token) => {
         const symbol = token.symbol || "UNK";
-        const decimals = token.decimals || 18;
+        // Nullish coalescing, not ||: 0 is a valid decimals value and must
+        // not fall through to 18.
+        const decimals = token.decimals ?? 18;
         // Explorer returns the raw base-unit balance. Pre-format it to the
         // same display string refreshTokenBalances would produce, so the
         // picker (and the token list once added) never flashes the raw

--- a/src/utils/web3/tokenDiscovery.ts
+++ b/src/utils/web3/tokenDiscovery.ts
@@ -1,6 +1,8 @@
 import { getTokenDiscoveryApiUrl } from "@/config";
 import type { TokenInterface } from "@/constants";
 import { log } from "@/utils";
+import { formatUnits } from "@/utils/web3/units";
+import { getOptimalTokenBalance } from "@/utils/formatting";
 
 // Token info from Explorer API
 interface ExplorerToken {
@@ -55,17 +57,35 @@ export async function discoverTokens(
 
     const tokens: TokenInterface[] = data.tokens
       .filter((token) => token.contractAddress)
-      .map((token) => ({
-        name: token.name || "Unknown Token",
-        symbol: token.symbol || "UNK",
-        address: token.contractAddress.startsWith("Q")
-          ? token.contractAddress
-          : token.contractAddress.startsWith("q")
-            ? `Q${token.contractAddress.slice(1)}`
-            : `Q${token.contractAddress.replace(/^0x/i, "")}`,
-        amount: token.balance || "0",
-        decimals: token.decimals || 18,
-      }));
+      .map((token) => {
+        const symbol = token.symbol || "UNK";
+        const decimals = token.decimals || 18;
+        // Explorer returns the raw base-unit balance. Pre-format it to the
+        // same display string refreshTokenBalances would produce, so the
+        // picker (and the token list once added) never flashes the raw
+        // integer before the next 30s refresh cycle reformats it.
+        let amount = "0.0";
+        try {
+          amount = getOptimalTokenBalance(
+            formatUnits(token.balance || "0", decimals),
+            symbol,
+            false,
+          );
+        } catch {
+          amount = "0.0";
+        }
+        return {
+          name: token.name || "Unknown Token",
+          symbol,
+          address: token.contractAddress.startsWith("Q")
+            ? token.contractAddress
+            : token.contractAddress.startsWith("q")
+              ? `Q${token.contractAddress.slice(1)}`
+              : `Q${token.contractAddress.replace(/^0x/i, "")}`,
+          amount,
+          decimals,
+        };
+      });
 
     log(`Discovered ${tokens.length} tokens for ${address}`);
     return tokens;


### PR DESCRIPTION
## Problem
When adding a token (discovered-token picker or manual address entry), the token list briefly showed the **raw base-unit balance** (e.g. `500000000000`) for a few seconds before reformatting to the correct decimal value (`50`).

## Root cause
Both add entry points stored the raw balance as the display `amount`:
- `discoverTokens` (`tokenDiscovery.ts`): `amount: token.balance || "0"` (raw from Explorer API)
- `AddTokenModal.tsx`: `amount: balance.toString()` (raw)

The value stayed raw until the next `tokenStore.refreshTokenBalances()` run (Home mount / every 30s), which applies `formatUnits(raw, decimals)` + `getOptimalTokenBalance(...)`. That delayed reformat is the visible flash.

## Fix
Pre-format the balance at the point of add in both entry points using the exact same pipeline `refreshTokenBalances` uses, so the stored `amount` is display-correct immediately and identical to what the periodic refresh would produce (no visible change when it later runs). Both wrap formatting in try/catch falling back to `"0.0"`.

## Validation
- `npm run lint` clean (zero-warnings)
- `npm run build` passes (incl. tsc typecheck)
- `npx jest units tokenDiscovery` 24/24 pass