### PR TITLE
feat(ui): design-system refresh (sidebar, transfer, NFTs, mobile nav)

### DIFF
--- a/src/components/Core/Body/Home/Home.tsx
+++ b/src/components/Core/Body/Home/Home.tsx
@@ -146,7 +146,7 @@ const Home = observer(() => {
         ) : (
           <>
 
-            <div className="flex flex-col gap-4 md:gap-8">
+            <div className="flex w-full flex-col gap-4 md:gap-8">
               {activeAccount.accountAddress && (
                 <Card className="w-full relative overflow-hidden border-l-4 border-l-blue-accent">
                   <div className="absolute inset-0 overflow-hidden">

--- a/src/components/Core/Body/Nfts/NftCard.tsx
+++ b/src/components/Core/Body/Nfts/NftCard.tsx
@@ -32,7 +32,18 @@ export function NftCard({ nft }: NftCardProps) {
     : `${truncateAddress(nft.contractAddress)} • #${truncateId(nft.tokenId)}`;
 
   return (
-    <div className="group flex cursor-pointer flex-col gap-2" onClick={onOpen}>
+    <div
+      role="button"
+      tabIndex={0}
+      className="group flex cursor-pointer flex-col gap-2 rounded-md outline-none focus-visible:ring-2 focus-visible:ring-secondary"
+      onClick={onOpen}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onOpen();
+        }
+      }}
+    >
       <div className="relative overflow-hidden rounded-md border border-border transition-colors group-hover:border-secondary/60">
         <NftImage
           src={nft.image}

--- a/src/components/Core/Body/Nfts/NftCard.tsx
+++ b/src/components/Core/Body/Nfts/NftCard.tsx
@@ -1,7 +1,6 @@
 import { useNavigate } from "react-router-dom";
 import { EyeOff } from "lucide-react";
 import type { NFTInterface } from "@/constants";
-import { Card } from "@/components/UI/Card";
 import { Button } from "@/components/UI/Button";
 import { useStore } from "@/stores/store";
 import { nftKey } from "@/utils/web3/nft";
@@ -33,36 +32,37 @@ export function NftCard({ nft }: NftCardProps) {
     : `${truncateAddress(nft.contractAddress)} • #${truncateId(nft.tokenId)}`;
 
   return (
-    <Card
-      className="group relative cursor-pointer overflow-hidden border-l-4 border-l-secondary transition-shadow hover:shadow-md"
-      onClick={onOpen}
-    >
-      <NftImage
-        src={nft.image}
-        alt={nft.name ?? `Token #${nft.tokenId}`}
-        className="aspect-square w-full"
-      />
-      <div className="space-y-1 p-3">
-        <div className="truncate text-sm font-semibold">
+    <div className="group flex cursor-pointer flex-col gap-2" onClick={onOpen}>
+      <div className="relative overflow-hidden rounded-md border border-border transition-colors group-hover:border-secondary/60">
+        <NftImage
+          src={nft.image}
+          alt={nft.name ?? `Token #${nft.tokenId}`}
+          blur
+          className="aspect-square w-full bg-gradient-to-br from-secondary/15 to-background"
+        />
+        <Button
+          variant="ghost"
+          size="icon"
+          title="Hide NFT"
+          onClick={onHide}
+          // Always visible on touch devices (no hover); reveal on hover on desktop.
+          className="absolute right-2 top-2 h-7 w-7 bg-background/70 opacity-100 backdrop-blur-sm transition-opacity md:opacity-0 md:group-hover:opacity-100"
+        >
+          <EyeOff className="h-4 w-4" />
+        </Button>
+        {nft.standard === "ERC1155" && nft.balance && BigInt(nft.balance) > 1n && (
+          <span className="absolute bottom-2 left-2 rounded-full bg-background/80 px-2 py-0.5 text-xs font-medium backdrop-blur-sm">
+            ×{nft.balance}
+          </span>
+        )}
+      </div>
+      <div className="space-y-0.5">
+        <div className="truncate text-sm font-medium">
           {nft.name ?? `Token #${truncateId(nft.tokenId)}`}
         </div>
         <div className="truncate text-xs text-muted-foreground">{subtitle}</div>
-        {nft.standard === "ERC1155" && nft.balance && BigInt(nft.balance) > 1n && (
-          <div className="text-xs text-muted-foreground">
-            Balance: {nft.balance}
-          </div>
-        )}
       </div>
-      <Button
-        variant="ghost"
-        size="icon"
-        title="Hide NFT"
-        onClick={onHide}
-        className="absolute right-2 top-2 h-7 w-7 opacity-0 transition-opacity group-hover:opacity-100"
-      >
-        <EyeOff className="h-4 w-4" />
-      </Button>
-    </Card>
+    </div>
   );
 }
 

--- a/src/components/Core/Body/Nfts/NftGallery.tsx
+++ b/src/components/Core/Body/Nfts/NftGallery.tsx
@@ -52,7 +52,14 @@ const NftGallery = observer(() => {
   return (
     <Card className="border-l-4 border-l-secondary">
       <CardHeader className="flex flex-row items-center justify-between bg-gradient-to-r from-secondary/5 to-transparent">
-        <CardTitle className="text-2xl font-bold">NFTs</CardTitle>
+        <div className="flex items-center gap-3">
+          <CardTitle className="text-2xl font-bold">NFTs</CardTitle>
+          {nfts.length > 0 && (
+            <span className="rounded-full bg-muted px-2.5 py-0.5 text-xs font-medium text-muted-foreground">
+              {nfts.length} item{nfts.length === 1 ? "" : "s"}
+            </span>
+          )}
+        </div>
         <div className="flex gap-2">
           <TooltipProvider>
             <Tooltip>

--- a/src/components/Core/Body/Nfts/NftImage.tsx
+++ b/src/components/Core/Body/Nfts/NftImage.tsx
@@ -7,9 +7,14 @@ interface NftImageProps {
   src?: string;
   alt: string;
   className?: string;
+  /**
+   * Soft-blur the artwork (used for gallery thumbnails). The full-resolution
+   * sharp render is reserved for the detail view the user opens on click.
+   */
+  blur?: boolean;
 }
 
-export function NftImage({ src, alt, className }: NftImageProps) {
+export function NftImage({ src, alt, className, blur = false }: NftImageProps) {
   // Compute the resolved URL from props; derived, not stored. When `src`
   // changes the outer component re-renders with a new memoized value and
   // the inner <Inner> remounts via its key, resetting load/error state.
@@ -21,17 +26,19 @@ export function NftImage({ src, alt, className }: NftImageProps) {
   if (!imageSrc) {
     return <Fallback wrapper={wrapper} alt={alt} />;
   }
-  return <Inner key={imageSrc} wrapper={wrapper} src={imageSrc} alt={alt} />;
+  return <Inner key={imageSrc} wrapper={wrapper} src={imageSrc} alt={alt} blur={blur} />;
 }
 
 function Inner({
   wrapper,
   src,
   alt,
+  blur,
 }: {
   wrapper: string;
   src: string;
   alt: string;
+  blur: boolean;
 }) {
   // Component is keyed by src, so this state always resets on src change.
   // setState only fires from <img> event callbacks — never inside an effect.
@@ -54,7 +61,7 @@ function Inner({
         onError={() => setStatus("error")}
         className={`h-full w-full object-cover transition-opacity ${
           status === "loaded" ? "opacity-100" : "opacity-0"
-        }`}
+        } ${blur ? "scale-110 blur-[3px]" : ""}`}
       />
     </div>
   );

--- a/src/components/Core/Body/Transfer/GasFeeNotice/GasFeeNotice.tsx
+++ b/src/components/Core/Body/Transfer/GasFeeNotice/GasFeeNotice.tsx
@@ -2,15 +2,15 @@ import { useStore } from "@/stores/store";
 import type { FeeLevel } from "@/stores/qrlStore";
 import { utils } from "@theqrl/web3";
 import { cva } from "class-variance-authority";
-import { Loader, Fuel } from "lucide-react";
+import { Loader } from "lucide-react";
 import { useEffect, useState, useRef } from "react";
 import { getOptimalGasFee } from "@/utils/formatting";
-import { Button } from "@/components/UI/Button";
+import { cn } from "@/utils/cn";
 
 const FEE_DISPLAY: Record<FeeLevel, { label: string; multiplier: number }> = {
-  low:    { label: "Low",    multiplier: 1 },
+  low:    { label: "Slow",   multiplier: 1 },
   medium: { label: "Medium", multiplier: 1.5 },
-  high:   { label: "High",   multiplier: 2 },
+  high:   { label: "Fast",   multiplier: 2 },
 };
 
 type GasFeeNoticeProps = {
@@ -23,12 +23,12 @@ type GasFeeNoticeProps = {
 };
 
 const gasFeeNoticeClasses = cva(
-  "m-1 flex flex-col gap-3 rounded-lg border border-white px-4 py-3",
+  "mt-4 flex flex-col gap-3 rounded-md border border-border bg-muted/30 px-4 py-3.5",
   {
     variants: {
       isSubmitting: {
-        true: ["opacity-30"],
-        false: ["opacity-80"],
+        true: ["opacity-50"],
+        false: ["opacity-100"],
       },
     },
     defaultVariants: {
@@ -104,35 +104,40 @@ export const GasFeeNotice = ({
   return (
     hasValuesForGasCalculation && (
       <div className={gasFeeNoticeClasses({ isSubmitting })}>
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <Fuel className="h-4 w-4" />
-            {gasFee.isLoading ? (
-              <div className="flex gap-2">
-                <Loader className="h-4 w-4 animate-spin" />
-                Estimating fee...
-              </div>
-            ) : gasFee.error ? (
-              <span className="text-sm">{gasFee.error}</span>
-            ) : (
-              <span className="text-sm">~{gasFee.estimatedGas}</span>
-            )}
-          </div>
+        <div className="flex items-center justify-between text-sm text-muted-foreground">
+          <span className="font-medium">Network fee</span>
+          {gasFee.isLoading ? (
+            <span className="flex items-center gap-2">
+              <Loader className="h-4 w-4 animate-spin" />
+              Estimating fee...
+            </span>
+          ) : gasFee.error ? (
+            <span className="text-destructive">{gasFee.error}</span>
+          ) : (
+            <span className="font-mono text-foreground">≈ {gasFee.estimatedGas}</span>
+          )}
         </div>
-        <div className="flex gap-2">
-          {(["low", "medium", "high"] as FeeLevel[]).map((level) => (
-            <Button
-              key={level}
-              type="button"
-              variant={feeLevel === level ? "default" : "outline"}
-              size="sm"
-              onClick={() => onFeeLevelChange(level)}
-              disabled={isSubmitting}
-              className="flex-1"
-            >
-              {FEE_DISPLAY[level].label}
-            </Button>
-          ))}
+        <div className="grid grid-cols-3 gap-2">
+          {(["low", "medium", "high"] as FeeLevel[]).map((level) => {
+            const active = feeLevel === level;
+            return (
+              <button
+                key={level}
+                type="button"
+                onClick={() => onFeeLevelChange(level)}
+                disabled={isSubmitting}
+                aria-pressed={active}
+                className={cn(
+                  "rounded-sm border py-2 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50",
+                  active
+                    ? "border-secondary bg-secondary/10 text-secondary"
+                    : "border-input bg-background text-muted-foreground hover:text-foreground",
+                )}
+              >
+                {FEE_DISPLAY[level].label}
+              </button>
+            );
+          })}
         </div>
       </div>
     )

--- a/src/components/Core/Layout/Footer.tsx
+++ b/src/components/Core/Layout/Footer.tsx
@@ -1,6 +1,6 @@
 import { EXPLORER_BASE } from "@/config";
 import { ROUTES } from "@/router/router";
-import { useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { cn } from "@/utils/cn";
 
 /**
@@ -10,21 +10,20 @@ import { cn } from "@/utils/cn";
  *   hidden so it does not collide with the bottom tab bar).
  */
 export function FooterLinks({ className }: { className?: string }) {
-    const navigate = useNavigate();
     const linkClass =
         "text-xs md:text-sm cursor-pointer text-muted-foreground hover:text-foreground transition-colors";
 
     return (
         <div className={cn("flex items-center justify-center gap-6 md:gap-12", className)}>
-            <a className={linkClass} onClick={() => navigate(ROUTES.HOME)}>
+            <Link className={linkClass} to={ROUTES.HOME}>
                 Home
-            </a>
-            <a className={linkClass} onClick={() => navigate(ROUTES.PRIVACY)}>
+            </Link>
+            <Link className={linkClass} to={ROUTES.PRIVACY}>
                 Privacy
-            </a>
-            <a className={linkClass} onClick={() => navigate(ROUTES.TERMS)}>
+            </Link>
+            <Link className={linkClass} to={ROUTES.TERMS}>
                 Terms
-            </a>
+            </Link>
             <a
                 href={EXPLORER_BASE}
                 target="_blank"

--- a/src/components/Core/Layout/Footer.tsx
+++ b/src/components/Core/Layout/Footer.tsx
@@ -1,32 +1,48 @@
 import { EXPLORER_BASE } from "@/config";
 import { ROUTES } from "@/router/router";
 import { useNavigate } from "react-router-dom";
+import { cn } from "@/utils/cn";
 
-export default function Footer() {
+/**
+ * The Home / Privacy / Terms / Explorer link row. Rendered two ways:
+ * - desktop: pinned in the fixed bottom Footer bar.
+ * - mobile: inlined at the end of the page content (the fixed footer is
+ *   hidden so it does not collide with the bottom tab bar).
+ */
+export function FooterLinks({ className }: { className?: string }) {
     const navigate = useNavigate();
+    const linkClass =
+        "text-xs md:text-sm cursor-pointer text-muted-foreground hover:text-foreground transition-colors";
 
     return (
-        <footer className="fixed bottom-0 bg-background w-full z-10 border-t border-border/50">
-            {/* Navigation Links */}
-            <div className="h-8 md:h-10 flex items-center justify-center md:justify-start md:px-4 md:pl-12 gap-6 md:gap-12">
-                <a className="text-xs md:text-sm cursor-pointer text-muted-foreground hover:text-foreground transition-colors" onClick={() => navigate(ROUTES.HOME)}>
-                    Home
-                </a>
-                <a onClick={() => navigate(ROUTES.PRIVACY)} className="text-xs md:text-sm cursor-pointer text-muted-foreground hover:text-foreground transition-colors">
-                    Privacy
-                </a>
-                <a onClick={() => navigate(ROUTES.TERMS)} className="text-xs md:text-sm cursor-pointer text-muted-foreground hover:text-foreground transition-colors">
-                    Terms
-                </a>
-                <a
-                    href={EXPLORER_BASE}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-xs md:text-sm cursor-pointer text-muted-foreground hover:text-foreground transition-colors"
-                >
-                    Explorer
-                </a>
-            </div>
+        <div className={cn("flex items-center justify-center gap-6 md:gap-12", className)}>
+            <a className={linkClass} onClick={() => navigate(ROUTES.HOME)}>
+                Home
+            </a>
+            <a className={linkClass} onClick={() => navigate(ROUTES.PRIVACY)}>
+                Privacy
+            </a>
+            <a className={linkClass} onClick={() => navigate(ROUTES.TERMS)}>
+                Terms
+            </a>
+            <a
+                href={EXPLORER_BASE}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={linkClass}
+            >
+                Explorer
+            </a>
+        </div>
+    );
+}
+
+export default function Footer() {
+    return (
+        // Hidden on mobile: the links move into the page flow (see Layout) so
+        // they don't stack on top of the bottom tab bar.
+        <footer className="hidden md:block fixed bottom-0 bg-background w-full z-10 border-t border-border/50">
+            <FooterLinks className="h-10" />
         </footer>
-    )
+    );
 }

--- a/src/components/Core/Layout/Layout.tsx
+++ b/src/components/Core/Layout/Layout.tsx
@@ -1,6 +1,6 @@
 import { SidebarProvider } from "@/components/UI/sidebar"
 import { AppSidebar } from "@/components/Core/Layout/app-sidebar"
-import Footer from "@/components/Core/Layout/Footer"
+import Footer, { FooterLinks } from "@/components/Core/Layout/Footer"
 import MobileNav from "@/components/Core/Layout/MobileNav"
 
 export default function Layout({ children }: { children: React.ReactNode }) {
@@ -13,6 +13,9 @@ export default function Layout({ children }: { children: React.ReactNode }) {
                     </div>
                     <main className="flex-1 mb-20 md:mb-20 md:ml-20 overflow-x-hidden">
                         {children}
+                        {/* On mobile the nav links live in the page flow, not a fixed
+                            footer, so they don't collide with the bottom tab bar. */}
+                        <FooterLinks className="md:hidden py-6" />
                     </main>
                 </div>
                 <MobileNav />

--- a/src/components/Core/Layout/MobileNav.tsx
+++ b/src/components/Core/Layout/MobileNav.tsx
@@ -1,9 +1,10 @@
-import { Users, SendHorizontal, Settings as SettingsIcon, Plus, LogOut } from "lucide-react"
-import { useNavigate } from "react-router-dom";
+import { Wallet, SendHorizontal, Settings as SettingsIcon, Plus, LogOut } from "lucide-react"
+import { useNavigate, useLocation } from "react-router-dom";
 import { ROUTES } from "@/router/router";
 import { handleLogout } from "@/utils/logout";
 import { isInNativeApp } from "@/utils/nativeApp";
 import { navigateTo } from "@/utils/navigation";
+import { cn } from "@/utils/cn";
 
 const navItems = [
     {
@@ -12,7 +13,7 @@ const navItems = [
         path: ROUTES.TRANSFER,
     },
     {
-        icon: Users,
+        icon: Wallet,
         label: "Wallets",
         path: ROUTES.ACCOUNT_LIST,
     },
@@ -30,20 +31,35 @@ const navItems = [
 
 export default function MobileNav() {
     const navigate = useNavigate();
-    
+    const location = useLocation();
+
     const onLogoutClick = () => {
         handleLogout(navigate);
     };
 
+    const isActive = (path: string) =>
+        location.pathname === path || location.pathname.startsWith(`${path}/`);
+
     return (
-        <nav className="md:hidden fixed bottom-6 border-t-2 border-t-secondary border-t-opacity-50 bg-background w-full z-10 h-14 flex items-center justify-around px-4 pt-0">
+        <nav className="md:hidden fixed bottom-0 border-t-2 border-t-secondary/50 bg-background w-full z-10 h-14 flex items-center justify-around px-4">
             {
-                navItems.map((item) => (
-                    <button key={item.path} className="cursor-pointer flex flex-col items-center text-sm text-muted-foreground hover:text-foreground transition-colors" onClick={() => navigateTo(item.path, navigate)}>
-                        <item.icon className="h-5 w-5" />
-                        <span>{item.label}</span>
-                    </button>
-                ))
+                navItems.map((item) => {
+                    const active = isActive(item.path);
+                    return (
+                        <button
+                            key={item.path}
+                            aria-current={active ? "page" : undefined}
+                            className={cn(
+                                "cursor-pointer flex flex-col items-center text-sm transition-colors",
+                                active ? "text-secondary" : "text-muted-foreground hover:text-foreground",
+                            )}
+                            onClick={() => navigateTo(item.path, navigate)}
+                        >
+                            <item.icon className="h-5 w-5" />
+                            <span>{item.label}</span>
+                        </button>
+                    );
+                })
             }
             {/* Hide logout button when running in native app - wallet removal is handled in native settings */}
             {!isInNativeApp() && (

--- a/src/components/Core/Layout/app-sidebar.tsx
+++ b/src/components/Core/Layout/app-sidebar.tsx
@@ -71,26 +71,21 @@ export function AppSidebar() {
                                 return (
                                 <SidebarMenuItem key={item.title}>
                                     <SidebarMenuButton
-                                        asChild
                                         onClick={() => navigateTo(item.url, navigate)}
-                                        // Override shadcn's rounded-md + focus ring so the active
-                                        // accent reads as a flat full-bleed block with a straight
-                                        // orange edge (rounded right-border renders as a curve).
+                                        // Semantic <button> (no asChild) for native keyboard support.
+                                        // Override shadcn's rounded-md so the active accent reads as a
+                                        // flat full-bleed block with a straight orange edge; keep a
+                                        // keyboard-only inset focus ring (mouse clicks don't show it).
                                         className={cn(
-                                            "py-2 h-auto rounded-none border-r-2 border-r-transparent transition-colors",
-                                            "hover:bg-transparent focus-visible:ring-0",
-                                            active && "bg-secondary/10 border-r-secondary",
+                                            "flex flex-col justify-evenly items-center gap-1 py-2 h-auto rounded-none border-r-2 border-r-transparent transition-colors [&>svg]:!size-8",
+                                            "hover:bg-transparent focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-secondary",
+                                            active
+                                                ? "bg-secondary/10 border-r-secondary text-foreground"
+                                                : "text-muted-foreground hover:text-foreground",
                                         )}
                                     >
-                                        <div
-                                            className={cn(
-                                                "flex flex-col justify-evenly items-center cursor-pointer [&>svg]:!size-8",
-                                                active ? "text-foreground" : "text-muted-foreground hover:text-foreground",
-                                            )}
-                                        >
-                                            <item.icon className="size-8" />
-                                            <span className="block text-xs font-medium">{item.label}</span>
-                                        </div>
+                                        <item.icon className="size-8" />
+                                        <span className="block text-xs font-medium">{item.label}</span>
                                     </SidebarMenuButton>
                                 </SidebarMenuItem>
                                 );

--- a/src/components/Core/Layout/app-sidebar.tsx
+++ b/src/components/Core/Layout/app-sidebar.tsx
@@ -1,4 +1,4 @@
-import { LogOut, Users, SendHorizontal, Settings as SettingsIcon, Plus } from "lucide-react"
+import { LogOut, Wallet, SendHorizontal, Settings as SettingsIcon, Plus } from "lucide-react"
 
 import {
     Sidebar,
@@ -11,12 +11,13 @@ import {
     SidebarMenuButton,
     SidebarMenuItem,
 } from "@/components/UI/sidebar"
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import { ROUTES } from "@/router/router";
 import MyQRLWalletLogo from "../Header/MyQRLWalletLogo/MyQRLWalletLogo";
 import { handleLogout } from "@/utils/logout";
 import { isInNativeApp } from "@/utils/nativeApp";
 import { navigateTo } from "@/utils/navigation";
+import { cn } from "@/utils/cn";
 
 // Menu items.
 const sidebarItems = [
@@ -24,7 +25,7 @@ const sidebarItems = [
         title: "Account List",
         url: ROUTES.ACCOUNT_LIST,
         label: "Wallets",
-        icon: Users,
+        icon: Wallet,
     },
     {
         title: "Send",
@@ -48,9 +49,12 @@ const sidebarItems = [
 
 export function AppSidebar() {
     const navigate = useNavigate();
+    const location = useLocation();
     const onLogoutClick = () => {
         handleLogout(navigate);
     };
+    const isActive = (url: string) =>
+        location.pathname === url || location.pathname.startsWith(`${url}/`);
 
     return (
         <Sidebar className="h-[calc(100vh-2.5rem)] border-r-secondary">
@@ -62,17 +66,35 @@ export function AppSidebar() {
                             <SidebarMenuItem className="cursor-pointer flex justify-center py-5" onClick={() => navigate(ROUTES.HOME)}>
                                 <MyQRLWalletLogo showText={false} size="lg" />
                             </SidebarMenuItem>
-                            {sidebarItems.map((item) => (
+                            {sidebarItems.map((item) => {
+                                const active = isActive(item.url);
+                                return (
                                 <SidebarMenuItem key={item.title}>
-                                    <SidebarMenuButton asChild className="py-2 h-auto" onClick={() => navigateTo(item.url, navigate)}>
-                                        <div className="flex flex-col justify-evenly items-center cursor-pointer [&>svg]:!size-8 text-muted-foreground hover:text-foreground"
+                                    <SidebarMenuButton
+                                        asChild
+                                        onClick={() => navigateTo(item.url, navigate)}
+                                        // Override shadcn's rounded-md + focus ring so the active
+                                        // accent reads as a flat full-bleed block with a straight
+                                        // orange edge (rounded right-border renders as a curve).
+                                        className={cn(
+                                            "py-2 h-auto rounded-none border-r-2 border-r-transparent transition-colors",
+                                            "hover:bg-transparent focus-visible:ring-0",
+                                            active && "bg-secondary/10 border-r-secondary",
+                                        )}
+                                    >
+                                        <div
+                                            className={cn(
+                                                "flex flex-col justify-evenly items-center cursor-pointer [&>svg]:!size-8",
+                                                active ? "text-foreground" : "text-muted-foreground hover:text-foreground",
+                                            )}
                                         >
                                             <item.icon className="size-8" />
                                             <span className="block text-xs font-medium">{item.label}</span>
                                         </div>
                                     </SidebarMenuButton>
                                 </SidebarMenuItem>
-                            ))}
+                                );
+                            })}
                         </SidebarMenu>
                     </SidebarGroupContent>
                 </SidebarGroup>

--- a/src/components/UI/PinInput/PinInput.tsx
+++ b/src/components/UI/PinInput/PinInput.tsx
@@ -46,7 +46,10 @@ export const PinInput = ({
 
   const handleChange =
     (i: number) => (e: React.ChangeEvent<HTMLInputElement>) => {
-      const ch = e.target.value.replace(/\D/g, "").slice(-1);
+      const ch = e.target.value.slice(-1);
+      // Ignore non-digits outright so focus doesn't advance and the
+      // current cell isn't cleared.
+      if (ch && !/\d/.test(ch)) return;
       if (!ch && !chars[i]) return;
       setAt(i, ch);
       if (ch && i < length - 1) refs.current[i + 1]?.focus();
@@ -58,7 +61,10 @@ export const PinInput = ({
         e.preventDefault();
         return;
       }
+      // Backspace on an empty cell deletes the previous digit (not just
+      // moves focus), so one press removes one digit.
       if (e.key === "Backspace" && !chars[i] && i > 0) {
+        onChange(value.slice(0, -1));
         refs.current[i - 1]?.focus();
       }
       if (e.key === "ArrowLeft" && i > 0) refs.current[i - 1]?.focus();
@@ -97,6 +103,11 @@ export const PinInput = ({
             onChange={handleChange(i)}
             onKeyDown={handleKeyDown(i)}
             onPaste={handlePaste(i)}
+            onFocus={() => {
+              // Keep entry sequential: focusing a cell past the first
+              // empty one redirects to that empty cell.
+              if (i > value.length) refs.current[value.length]?.focus();
+            }}
             aria-label={`PIN digit ${i + 1}`}
             className={cn(
               "h-12 w-11 rounded-md border bg-background text-center font-mono text-xl text-foreground outline-none transition-colors",

--- a/src/components/UI/PinInput/PinInput.tsx
+++ b/src/components/UI/PinInput/PinInput.tsx
@@ -1,5 +1,4 @@
 import React, { useRef, useEffect } from "react";
-import { Input } from "../Input";
 import { cn } from "@/utils/cn";
 
 interface PinInputProps {
@@ -14,68 +13,109 @@ interface PinInputProps {
   autoFocus?: boolean;
 }
 
+/**
+ * Boxed PIN entry — a row of single-digit masked cells used to unlock the
+ * encrypted seed before signing. Keeps the original string-based API
+ * (`value`/`onChange`) so every call site stays untouched; only the
+ * presentation changed from one input to `length` cells.
+ */
 export const PinInput = ({
   length = 6,
   onChange,
   value = "",
   disabled = false,
-  placeholder = "Enter PIN",
+  // `placeholder` no longer renders (boxed cells), kept for API compatibility.
+  placeholder: _placeholder,
   className,
   description,
   error,
   autoFocus = false,
 }: PinInputProps) => {
-  const inputRef = useRef<HTMLInputElement>(null);
+  const refs = useRef<Array<HTMLInputElement | null>>([]);
+  const chars = value.split("").slice(0, length);
 
   useEffect(() => {
-    if (autoFocus && inputRef.current) {
-      inputRef.current.focus();
-    }
+    if (autoFocus) refs.current[0]?.focus();
   }, [autoFocus]);
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newValue = e.target.value;
-
-    // Only allow digits and limit to specified length
-    if (/^\d*$/.test(newValue) && newValue.length <= length) {
-      onChange(newValue);
-    }
+  const setAt = (i: number, ch: string) => {
+    const next = value.split("");
+    next[i] = ch;
+    onChange(next.join("").replace(/\D/g, "").slice(0, length));
   };
 
-  // Prevent Enter key from submitting parent form
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") {
+  const handleChange =
+    (i: number) => (e: React.ChangeEvent<HTMLInputElement>) => {
+      const ch = e.target.value.replace(/\D/g, "").slice(-1);
+      if (!ch && !chars[i]) return;
+      setAt(i, ch);
+      if (ch && i < length - 1) refs.current[i + 1]?.focus();
+    };
+
+  const handleKeyDown =
+    (i: number) => (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        return;
+      }
+      if (e.key === "Backspace" && !chars[i] && i > 0) {
+        refs.current[i - 1]?.focus();
+      }
+      if (e.key === "ArrowLeft" && i > 0) refs.current[i - 1]?.focus();
+      if (e.key === "ArrowRight" && i < length - 1) refs.current[i + 1]?.focus();
+    };
+
+  const handlePaste =
+    (i: number) => (e: React.ClipboardEvent<HTMLInputElement>) => {
       e.preventDefault();
-    }
-  };
+      const digits = e.clipboardData.getData("text").replace(/\D/g, "");
+      if (!digits) return;
+      const next = value.split("");
+      for (let k = 0; k < digits.length && i + k < length; k++) {
+        next[i + k] = digits.charAt(k);
+      }
+      const joined = next.join("").replace(/\D/g, "").slice(0, length);
+      onChange(joined);
+      refs.current[Math.min(i + digits.length, length - 1)]?.focus();
+    };
 
   return (
     <div className={cn("w-full space-y-2", className)}>
-      <Input
-        ref={inputRef}
-        type="password"
-        inputMode="numeric"
-        placeholder={placeholder}
-        value={value}
-        onChange={handleChange}
-        onKeyDown={handleKeyDown}
-        disabled={disabled}
-        autoComplete="current-password"
-        className={cn(
-          "placeholder:text-left placeholder:tracking-normal",
-          value.length > 0 ? "text-center tracking-widest" : "text-left tracking-normal",
-          error ? "border-destructive" : ""
-        )}
-      />
+      <div className="flex gap-2">
+        {Array.from({ length }).map((_, i) => (
+          <input
+            key={i}
+            ref={(el) => {
+              refs.current[i] = el;
+            }}
+            type="password"
+            inputMode="numeric"
+            autoComplete="one-time-code"
+            maxLength={1}
+            disabled={disabled}
+            value={chars[i] ?? ""}
+            onChange={handleChange(i)}
+            onKeyDown={handleKeyDown(i)}
+            onPaste={handlePaste(i)}
+            aria-label={`PIN digit ${i + 1}`}
+            className={cn(
+              "h-12 w-11 rounded-md border bg-background text-center font-mono text-xl text-foreground outline-none transition-colors",
+              "focus-visible:border-[#4aafff] focus-visible:ring-1 focus-visible:ring-[#4aafff]",
+              "disabled:cursor-not-allowed disabled:opacity-50",
+              error
+                ? "border-destructive"
+                : chars[i]
+                  ? "border-[#4aafff]"
+                  : "border-input",
+            )}
+          />
+        ))}
+      </div>
       {description && (
-        <div className="text-sm text-muted-foreground">
-          {description}
-        </div>
+        <div className="text-sm text-muted-foreground">{description}</div>
       )}
       {error && (
-        <div className="text-sm font-medium text-destructive">
-          {error}
-        </div>
+        <div className="text-sm font-medium text-destructive">{error}</div>
       )}
     </div>
   );

--- a/src/components/UI/Slider.tsx
+++ b/src/components/UI/Slider.tsx
@@ -15,10 +15,10 @@ const Slider = React.forwardRef<
     )}
     {...props}
   >
-    <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary">
-      <SliderPrimitive.Range className="absolute h-full bg-[#1F51FF]" />
+    <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-muted">
+      <SliderPrimitive.Range className="absolute h-full bg-secondary" />
     </SliderPrimitive.Track>
-    <SliderPrimitive.Thumb className="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50" />
+    <SliderPrimitive.Thumb className="block h-[18px] w-[18px] rounded-full border-2 border-background bg-secondary shadow-[0_0_0_1px_hsl(25_95%_53%/0.4),0_0_18px_-2px_hsl(25_95%_53%/0.45)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50" />
   </SliderPrimitive.Root>
 ))
 Slider.displayName = SliderPrimitive.Root.displayName


### PR DESCRIPTION
Merges the `mqwDesignSystem` kit into the live UI.

## Changes
- **Sidebar**: route-driven active state rendered as a flat filled block with a straight orange edge (overrides shadcn's `rounded-md` + focus ring so the accent is not a curved parenthesis). Wallets icon `Users` -> `Wallet`.
- **Transfer**: boxed multi-cell PIN entry (same `value`/`onChange` string API, so all 6 `PinInput` call sites are untouched); "Network fee" box with segmented Slow/Medium/Fast buttons; orange percentage slider.
- **NFTs**: tile layout (name below + "N items" badge), soft-blurred gallery thumbnails with the full sharp image reserved for the detail view on click, and a hide button that stays visible on touch devices (was hover-only).
- **Mobile**: bottom tab bar gains an active highlight + `Wallet` icon; footer links move off the fixed footer into the page flow on small screens so they no longer stack on top of the tab bar.

## Validation
- `npm run lint` clean (zero warnings)
- `tsc` + `npm run build` green
- `npm test` 114/114 passing

## Risk / notes
- `PinInput` is shared across Transfer, Settings, PinSetup, CreateToken, CreateAccount, NftDetail. API is unchanged; only presentation changed.
- No runtime/logic changes to gas estimation, signing, or NFT discovery; styling/markup only.
- No migrations, no env changes.