### PR TITLE
feat(ui): reshape ShinyButton to design-primary + token Name/Symbol colors

### DIFF
--- a/src/components/Core/Body/Tokens/TokenForm/columns.tsx
+++ b/src/components/Core/Body/Tokens/TokenForm/columns.tsx
@@ -38,7 +38,7 @@ const CopyableAddress = ({ address }: { address: string }) => {
     );
 };
 
-const CopyableText = ({ text }: { text: string }) => {
+const CopyableText = ({ text, className }: { text: string; className?: string }) => {
     const [isCopied, setIsCopied] = useState(false);
 
     const handleCopy = async (textToCopy: string) => {
@@ -53,7 +53,7 @@ const CopyableText = ({ text }: { text: string }) => {
 
     return (
         <div className="flex items-center gap-2 group">
-            <span>{text}</span>
+            <span className={className}>{text}</span>
             {isCopied ? (
                 <Check className="w-4 h-4 text-green-500" />
             ) : (
@@ -120,7 +120,7 @@ export const columns: ColumnDef<TokenInterface>[] = [
         header: "Name",
         cell: ({ row }) => {
             const name: string = row.getValue('name')
-            return <div className="hidden md:block"><CopyableText text={name} /></div>;
+            return <div className="hidden md:block"><CopyableText text={name} className="font-semibold text-foreground" /></div>;
         },
     },
     {
@@ -128,7 +128,7 @@ export const columns: ColumnDef<TokenInterface>[] = [
         header: "Symbol",
         cell: ({ row }) => {
             const symbol: string = row.getValue('symbol')
-            return <CopyableText text={symbol} />;
+            return <CopyableText text={symbol} className="text-muted-foreground" />;
         },
     },
     {

--- a/src/components/Core/Body/Transfer/Transfer.tsx
+++ b/src/components/Core/Body/Transfer/Transfer.tsx
@@ -1,5 +1,4 @@
 import { Button } from "@/components/UI/Button";
-import { ShinyButton } from "@/components/UI/ShinyButton";
 import {
   Card,
   CardContent,
@@ -33,6 +32,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { utils } from "@theqrl/web3";
 import { Loader, Send, X, Copy, Coins, ExternalLink, ScanLine, Check } from "lucide-react";
 import { observer } from "mobx-react-lite";
+import { ShinyButton } from "@/components/UI/ShinyButton";
 import { useEffect, useState, useMemo, useCallback } from "react";
 import { useForm } from "react-hook-form";
 import { useNavigate, useSearchParams } from "react-router-dom";
@@ -851,7 +851,11 @@ const Transfer = observer(() => {
                     processing={isSubmitting}
                     type="submit"
                   >
-                    <Send className="mr-2 h-4 w-4" />
+                    {isSubmitting ? (
+                      <Loader className="mr-2 h-4 w-4 animate-spin" />
+                    ) : (
+                      <Send className="mr-2 h-4 w-4" />
+                    )}
                     {isSubmitting ? `Sending ${assetSymbol}...` : `Send ${assetSymbol}`}
                   </ShinyButton>
                 </CardFooter>

--- a/src/components/UI/ShinyButton.tsx
+++ b/src/components/UI/ShinyButton.tsx
@@ -42,8 +42,12 @@ export const ShinyButton = React.forwardRef<HTMLButtonElement, ShinyButtonProps>
           }
 
           .shiny-btn {
-            --shiny-cta-highlight: #4aafff;
-            --shiny-cta-highlight-subtle: #3a9fee;
+            /* Solid design-primary blue fill; the sheen is a light glint on
+               top of it so the button reads as a clean primary CTA rather
+               than the old dark-fill/chasing-edge look. */
+            --shiny-cta-bg: #4aafff;
+            --shiny-cta-highlight: #ffffff;
+            --shiny-cta-highlight-subtle: #d6ecff;
             --animation: gradient-angle linear infinite;
             --shadow-size: 2px;
           }
@@ -68,7 +72,7 @@ export const ShinyButton = React.forwardRef<HTMLButtonElement, ShinyButtonProps>
             outline-offset: 4px;
             border: 1px solid transparent;
             background:
-              linear-gradient(hsl(var(--card)), hsl(var(--card))) padding-box,
+              linear-gradient(var(--shiny-cta-bg), var(--shiny-cta-bg)) padding-box,
               conic-gradient(
                   from calc(var(--gradient-angle) - var(--gradient-angle-offset)),
                   transparent,
@@ -78,7 +82,7 @@ export const ShinyButton = React.forwardRef<HTMLButtonElement, ShinyButtonProps>
                   transparent calc(var(--gradient-percent) * 4)
                 )
                 border-box;
-            box-shadow: inset 0 0 0 1px hsl(var(--border));
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.18);
             transition: var(--transition);
             transition-property:
               --gradient-angle-offset, --gradient-percent, --gradient-shine;
@@ -133,7 +137,7 @@ export const ShinyButton = React.forwardRef<HTMLButtonElement, ShinyButtonProps>
               black
             );
             border-radius: 0.5rem;
-            opacity: 0.4;
+            opacity: 0.18;
             z-index: -1;
           }
 
@@ -149,7 +153,7 @@ export const ShinyButton = React.forwardRef<HTMLButtonElement, ShinyButtonProps>
               transparent
             );
             mask-image: radial-gradient(circle at bottom, transparent 40%, black);
-            opacity: 0.6;
+            opacity: 0.35;
           }
 
           .shiny-btn .shiny-btn__content {


### PR DESCRIPTION
Follow-up to the design-system refresh (#182).

- **ShinyButton** reshaped to conform to the new design: solid design-primary blue fill (`#4aafff`) with a *toned-down* white sheen instead of the old dark-fill / chasing-edge look (dot pattern `0.4 -> 0.18`, inner shimmer `0.6 -> 0.35`, soft white inset ring). Keeps the shimmer signature but reads as a clean primary CTA. This unifies every primary CTA that uses it (Transfer, Create Token, Create Account, PIN Setup).
- **Transfer Send**: stays on ShinyButton; added a spinner while submitting.
- **Token table**: Name is `font-semibold text-foreground`, Symbol is `text-muted-foreground`, matching the kit's `TokenTable` color hierarchy.

Gates: lint clean, tsc + build green, 114/114 tests.

Note: the sheen values are tuned conservatively and easy to dial; will eyeball on dev after deploy.