### PR TITLE
fix(sidebar): single thin orange line for active item

### DIFF
--- a/src/components/Core/Layout/app-sidebar.tsx
+++ b/src/components/Core/Layout/app-sidebar.tsx
@@ -57,9 +57,12 @@ export function AppSidebar() {
         location.pathname === url || location.pathname.startsWith(`${url}/`);
 
     return (
-        <Sidebar className="h-[calc(100vh-2.5rem)] border-r-secondary">
+        <Sidebar className="h-[calc(100vh-2.5rem)] border-r-secondary !border-r">
             <SidebarContent>
-                <SidebarGroup>
+                {/* px-0 so the active item is full-bleed: its orange right
+                    edge sits flush with the rail border instead of floating
+                    inset as a second parallel line. */}
+                <SidebarGroup className="px-0">
                     {/* <SidebarGroupLabel>Application</SidebarGroupLabel> */}
                     <SidebarGroupContent className="mt-5">
                         <SidebarMenu>


### PR DESCRIPTION
Follow-up polish to the sidebar active state (#182).

**Issue:** the active item's orange right border was inset 8px from the rail edge (`SidebarGroup p-2`), so it floated as a second parallel orange line left of the rail border — a doubled, too-thick look.

**Fix:**
- `px-0` on the group so the active block is full-bleed and its accent sits flush with the rail border (no second line).
- Rail border thinned to 1px.
- Active accent kept at 2px so it reads as one thin line, emphasized at the active row, matching the design.

Gates: lint clean, tsc + build green.