### PR TITLE
Promote dev → main: design-system refresh + TS hardening + token fixes

### DIFF
--- a/config/eslint.config.js
+++ b/config/eslint.config.js
@@ -32,7 +32,92 @@ export default tseslint.config(
     rules: {
       ...reactHooks.configs.recommended.rules,
       'react-refresh/only-export-components': 'off', // Allow exporting utilities with components
-      '@typescript-eslint/no-explicit-any': 'off', // Allow any for Web3 and crypto libraries
+
+      // --- Hardened TypeScript: mandate no type laundering ---------------
+      // The @theqrl/web3 ABI typing gap is handled honestly in
+      // src/utils/web3/contractFactory.ts (single assertions from `unknown`
+      // to the library's own ContractAbi + hand-written method interfaces),
+      // so there is no sanctioned `any` escape hatch anywhere in the app.
+      '@typescript-eslint/no-explicit-any': 'error',
+      // No `expr!` — prove non-nullness with a guard or resolve a typed value.
+      '@typescript-eslint/no-non-null-assertion': 'error',
+      // Pairs with tsconfig `verbatimModuleSyntax`: type-only imports must use
+      // `import type` so the emitter never has to guess what is value vs type.
+      '@typescript-eslint/consistent-type-imports': [
+        'error',
+        {
+          prefer: 'type-imports',
+          fixStyle: 'separate-type-imports',
+          // Allow `typeof import('...')` annotations: they type the heavy
+          // lazily/dynamically-imported modules (web3, socket.io) without
+          // pulling them into the static graph. verbatimModuleSyntax permits them.
+          disallowTypeAnnotations: false,
+        },
+      ],
+      // No `@ts-ignore` / `@ts-nocheck`; `@ts-expect-error` only with a real reason.
+      '@typescript-eslint/ban-ts-comment': [
+        'error',
+        {
+          'ts-ignore': true,
+          'ts-nocheck': true,
+          'ts-expect-error': 'allow-with-description',
+          minimumDescriptionLength: 10,
+        },
+      ],
+      // No `x as unknown as T` — double assertions erase the type system.
+      // Narrow honestly (e.g. annotate WebCrypto buffers as
+      // Uint8Array<ArrayBuffer>, or assert once from `unknown`).
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: 'TSAsExpression > TSAsExpression',
+          message:
+            'Double type assertion (e.g. `x as unknown as T`) is banned: it bypasses the type checker. Narrow honestly or assert once from `unknown`.',
+        },
+      ],
+      // -------------------------------------------------------------------
+
+      // --- Crypto encapsulation boundary --------------------------------
+      // Raw post-quantum / hashing primitives must live ONLY inside the
+      // crypto modules (src/utils/crypto, src/utils/signing,
+      // src/services/dappConnect), which is also where the future go-qrllib
+      // WASM swap will land. App code (stores, components) must consume the
+      // typed wrappers those modules export, never the primitives directly.
+      // The crypto modules themselves re-enable these imports via the
+      // override block below.
+      'no-restricted-imports': [
+        'error',
+        {
+          // Use `patterns`/`group` (not `paths`) for every entry so deep
+          // subpath imports are covered too (e.g. `@theqrl/wallet.js/dist/...`),
+          // not just the bare specifier. This keeps the boundary enforced by
+          // the rule itself rather than relying on each package's exports map.
+          patterns: [
+            {
+              group: ['@theqrl/mldsa87', '@theqrl/mldsa87/*'],
+              message:
+                'ML-DSA-87 primitives are encapsulated in src/utils/signing. Import the signing wrappers (signMessage/signTypedData/verify) instead.',
+            },
+            {
+              group: ['@theqrl/wallet.js', '@theqrl/wallet.js/*'],
+              message:
+                'ML-DSA-87 key/seed derivation is encapsulated in src/utils/crypto and src/utils/signing. Import getHexSeedFromMnemonic/deriveHexSeedAsync/etc instead.',
+            },
+            {
+              group: ['@noble/hashes', '@noble/hashes/*'],
+              message:
+                'SHAKE/SHA3 hashing is encapsulated in src/utils/signing (messageDigest/typedData). Import the digest helpers instead.',
+            },
+            {
+              group: ['@noble/post-quantum', '@noble/post-quantum/*'],
+              message:
+                'ML-KEM-768 is encapsulated in src/services/dappConnect/PQCrypto. Import the PQCrypto helpers instead.',
+            },
+          ],
+        },
+      ],
+      // -------------------------------------------------------------------
+
       '@typescript-eslint/no-unused-vars': [
         'error',
         {
@@ -45,6 +130,20 @@ export default tseslint.config(
       'react/prop-types': 'off',
       'no-console': 'off', // Allow console for debugging in development
       'react-hooks/exhaustive-deps': 'warn', // Keep as warning for now
+    },
+  },
+  {
+    // The crypto boundary itself: these modules ARE the encapsulation layer,
+    // so they are the only place allowed to import the raw primitives. This
+    // intentionally lifts only `no-restricted-imports` (the primitive ban);
+    // the `no-restricted-syntax` double-assertion ban stays in force here.
+    files: [
+      'src/utils/crypto/**/*.{ts,tsx}',
+      'src/utils/signing/**/*.{ts,tsx}',
+      'src/services/dappConnect/**/*.{ts,tsx}',
+    ],
+    rules: {
+      'no-restricted-imports': 'off',
     },
   },
 )

--- a/src/components/Core/Body/CreateAccount/AccountCreationForm/AccountCreationForm.tsx
+++ b/src/components/Core/Body/CreateAccount/AccountCreationForm/AccountCreationForm.tsx
@@ -18,7 +18,7 @@ import {
 import { Input } from "@/components/UI/Input";
 import { useStore } from "@/stores/store";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Web3BaseWalletAccount } from "@theqrl/web3";
+import type { Web3BaseWalletAccount } from "@theqrl/web3";
 import { Loader, Plus } from "lucide-react";
 import { observer } from "mobx-react-lite";
 import { useForm } from "react-hook-form";
@@ -131,7 +131,9 @@ const InnerForm = observer(({ onAccountCreated, hasExistingSeeds, existingSeeds,
       // If existing seeds exist, verify PIN by attempting to decrypt one
       if (hasExistingSeeds && existingSeeds.length > 0) {
         try {
-          await decryptSeedAsync(existingSeeds[0].encryptedSeed, userPin);
+          // length > 0 is checked above; `?? ''` only satisfies the index
+          // checker and would route an (impossible) miss to the catch below.
+          await decryptSeedAsync(existingSeeds[0]?.encryptedSeed ?? '', userPin);
         } catch (err) {
           const message =
             err instanceof CryptoOperationError && err.code === CryptoErrorCode.OUTDATED_FORMAT

--- a/src/components/Core/Body/CreateAccount/CreateAccount.tsx
+++ b/src/components/Core/Body/CreateAccount/CreateAccount.tsx
@@ -2,7 +2,7 @@ import { lazy, useState } from "react";
 import { withSuspense } from "@/utils/react";
 import { SEO } from "../../../SEO/SEO";
 import { useStore } from "../../../../stores/store";
-import { Web3BaseWalletAccount } from "@theqrl/web3";
+import type { Web3BaseWalletAccount } from "@theqrl/web3";
 import { observer } from "mobx-react-lite";
 import { AccountCreationForm } from "./AccountCreationForm/AccountCreationForm";
 import { useWalletLimit } from "@/hooks/useWalletLimit";

--- a/src/components/Core/Body/CreateAccount/MnemonicDisplay/MnemonicDisplay.tsx
+++ b/src/components/Core/Body/CreateAccount/MnemonicDisplay/MnemonicDisplay.tsx
@@ -20,7 +20,7 @@ import {
 import { getMnemonicFromHexSeed } from "@/utils/crypto";
 import { copyToClipboard } from "@/utils/nativeApp";
 import { withSuspense } from "@/utils/react";
-import { Web3BaseWalletAccount } from "@theqrl/web3";
+import type { Web3BaseWalletAccount } from "@theqrl/web3";
 import { Check, Copy, HardDriveDownload, QrCode, Undo } from "lucide-react";
 import { lazy, useState } from "react";
 import { useNavigate } from "react-router-dom";

--- a/src/components/Core/Body/CreateToken/TokenCreationForm/TokenCreationForm.tsx
+++ b/src/components/Core/Body/CreateToken/TokenCreationForm/TokenCreationForm.tsx
@@ -161,7 +161,12 @@ export const TokenCreationForm = observer(
                     // failure here propagates to the outer onSubmit handler
                     // and surfaces as a worker / system error rather than
                     // "invalid PIN".
-                    const address = await getAddressFromMnemonicAsync(mnemonicPhrase, qrlStore.qrlInstance!);
+                    const qrlInstance = qrlStore.qrlInstance;
+                    if (!qrlInstance) {
+                        setPinError("Wallet not connected. Please try again.");
+                        return;
+                    }
+                    const address = await getAddressFromMnemonicAsync(mnemonicPhrase, qrlInstance);
                     if (address.toLowerCase() !== activeAccount.accountAddress.toLowerCase()) {
                         setPinError("PIN decrypted an invalid seed. Please import your account again.");
                         return;

--- a/src/components/Core/Body/DAppConnect/DAppApprovalModal.tsx
+++ b/src/components/Core/Body/DAppConnect/DAppApprovalModal.tsx
@@ -203,16 +203,16 @@ const DAppApprovalModal = observer(() => {
         const nonce = await web3.getTransactionCount(activeAddress, 'pending');
         const gasPrice = await web3.getGasPrice();
         const gasPriceHex = utils.toHex(gasPrice);
-        const txData = (txParams.data as string) || '0x';
-        const txValue = txParams.value ? BigInt(txParams.value as string).toString() : '0';
+        const txData = (txParams['data'] as string) || '0x';
+        const txValue = txParams['value'] ? BigInt(txParams['value'] as string).toString() : '0';
 
         let gas: number;
-        if (txParams.gas) {
-          gas = parseRpcNumber(txParams.gas, 21000);
+        if (txParams['gas']) {
+          gas = parseRpcNumber(txParams['gas'], 21000);
         } else if (txData && txData !== '0x') {
           const estimated = await web3.estimateGas({
             from: activeAddress,
-            to: txParams.to as string,
+            to: txParams['to'] as string,
             value: txValue,
             data: txData,
           });
@@ -223,7 +223,7 @@ const DAppApprovalModal = observer(() => {
 
         const txObject = {
           from: activeAddress,
-          to: txParams.to as string,
+          to: txParams['to'] as string,
           value: txValue,
           gas,
           maxFeePerGas: gasPriceHex,
@@ -474,7 +474,7 @@ const DAppApprovalModal = observer(() => {
 
   // Transaction details for display during progress
   const txParams = isTransaction ? (params?.[0] as Record<string, unknown> | undefined) : undefined;
-  const txDisplayValue = formatQuantaValue(txParams?.value);
+  const txDisplayValue = formatQuantaValue(txParams?.['value']);
 
   return (
     <Dialog open={approvalModalOpen} onOpenChange={(open) => {
@@ -555,7 +555,7 @@ const DAppApprovalModal = observer(() => {
                 <div className="rounded border bg-muted p-4 text-sm space-y-2">
                   <div className="flex justify-between">
                     <span className="text-muted-foreground">To</span>
-                    <span className="font-mono text-xs">{formatAddressShort(txParams.to as string || '')}</span>
+                    <span className="font-mono text-xs">{formatAddressShort(txParams['to'] as string || '')}</span>
                   </div>
                   <div className="flex justify-between">
                     <span className="text-muted-foreground">Value</span>

--- a/src/components/Core/Body/DAppConnect/DAppTransactionReview.tsx
+++ b/src/components/Core/Body/DAppConnect/DAppTransactionReview.tsx
@@ -26,10 +26,10 @@ function formatGasLimit(gas: unknown): string {
 }
 
 const DAppTransactionReview: React.FC<TransactionReviewProps> = ({ params }) => {
-  const to = (params.to as string) || 'Unknown';
-  const value = params.value as string | undefined;
-  const data = params.data as string | undefined;
-  const gas = params.gas;
+  const to = (params['to'] as string) || 'Unknown';
+  const value = params['value'] as string | undefined;
+  const data = params['data'] as string | undefined;
+  const gas = params['gas'];
 
   const displayValue = formatQuantaValue(value);
 

--- a/src/components/Core/Body/DAppConnect/DAppTypedDataReview.tsx
+++ b/src/components/Core/Body/DAppConnect/DAppTypedDataReview.tsx
@@ -60,12 +60,12 @@ function renderValue(value: unknown, depth: number): React.ReactNode {
 const DAppTypedDataReview: React.FC<DAppTypedDataReviewProps> = ({ payload, digestHex }) => {
   const [showDigest, setShowDigest] = useState(false);
   const { domain, primaryType, message } = payload;
-  const name = typeof domain.name === 'string' ? domain.name : '(unnamed)';
-  const chainId = typeof domain.chainId === 'string' || typeof domain.chainId === 'number'
-    ? String(domain.chainId)
+  const name = typeof domain['name'] === 'string' ? domain['name'] : '(unnamed)';
+  const chainId = typeof domain['chainId'] === 'string' || typeof domain['chainId'] === 'number'
+    ? String(domain['chainId'])
     : undefined;
-  const verifyingContract = typeof domain.verifyingContract === 'string'
-    ? domain.verifyingContract
+  const verifyingContract = typeof domain['verifyingContract'] === 'string'
+    ? domain['verifyingContract']
     : undefined;
 
   return (

--- a/src/components/Core/Body/Home/ConnectionBadge/ConnectionBadge.tsx
+++ b/src/components/Core/Body/Home/ConnectionBadge/ConnectionBadge.tsx
@@ -25,9 +25,9 @@ import { useState } from "react";
 function hexToRgba(hexColor: string, alpha: number): string {
   const hex = hexColor.replace("#", "");
   if (hex.length === 3) {
-    const r = parseInt(hex[0] + hex[0], 16);
-    const g = parseInt(hex[1] + hex[1], 16);
-    const b = parseInt(hex[2] + hex[2], 16);
+    const r = parseInt(hex.charAt(0) + hex.charAt(0), 16);
+    const g = parseInt(hex.charAt(1) + hex.charAt(1), 16);
+    const b = parseInt(hex.charAt(2) + hex.charAt(2), 16);
     return `rgba(${r}, ${g}, ${b}, ${alpha})`;
   }
   if (hex.length === 6) {

--- a/src/components/Core/Body/Home/Home.tsx
+++ b/src/components/Core/Body/Home/Home.tsx
@@ -146,7 +146,7 @@ const Home = observer(() => {
         ) : (
           <>
 
-            <div className="flex flex-col gap-4 md:gap-8">
+            <div className="flex w-full flex-col gap-4 md:gap-8">
               {activeAccount.accountAddress && (
                 <Card className="w-full relative overflow-hidden border-l-4 border-l-blue-accent">
                   <div className="absolute inset-0 overflow-hidden">

--- a/src/components/Core/Body/ImportAccount/AccountImportSuccess/AccountImportSuccess.tsx
+++ b/src/components/Core/Body/ImportAccount/AccountImportSuccess/AccountImportSuccess.tsx
@@ -10,7 +10,7 @@ import { ROUTES } from "../../../../../router/router";
 import { getExplorerAddressUrl } from "@/config";
 import { copyToClipboard, openExternalUrl } from "@/utils/nativeApp";
 import { useStore } from "../../../../../stores/store";
-import { Web3BaseWalletAccount } from "@theqrl/web3";
+import type { Web3BaseWalletAccount } from "@theqrl/web3";
 import { Check, Copy, ExternalLink } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";

--- a/src/components/Core/Body/ImportAccount/ImportAccount.tsx
+++ b/src/components/Core/Body/ImportAccount/ImportAccount.tsx
@@ -6,7 +6,7 @@ import { ImportEncryptedWallet } from "./ImportEncryptedWallet/ImportEncryptedWa
 import { ImportHexSeedForm } from "./ImportHexSeedForm/ImportHexSeedForm";
 import AccountImportSuccess from "./AccountImportSuccess/AccountImportSuccess";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/UI/Tabs";
-import { ExtendedWalletAccount } from "@/utils/crypto";
+import type { ExtendedWalletAccount } from "@/utils/crypto";
 import { SEO } from "../../../SEO/SEO";
 import { PinSetup } from "../PinSetup/PinSetup";
 import { useWalletLimit } from "@/hooks/useWalletLimit";

--- a/src/components/Core/Body/ImportAccount/ImportAccountForm/ImportAccountForm.tsx
+++ b/src/components/Core/Body/ImportAccount/ImportAccountForm/ImportAccountForm.tsx
@@ -22,7 +22,7 @@ import { Download, Loader } from "lucide-react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { deriveHexSeedAsync } from "@/utils/crypto";
-import { ExtendedWalletAccount } from "@/utils/crypto";
+import type { ExtendedWalletAccount } from "@/utils/crypto";
 
 const FormSchema = z.object({
   mnemonicPhrases: z.string().min(1, "Mnemonic phrases are required"),

--- a/src/components/Core/Body/ImportAccount/ImportEncryptedWallet/ImportEncryptedWallet.tsx
+++ b/src/components/Core/Body/ImportAccount/ImportEncryptedWallet/ImportEncryptedWallet.tsx
@@ -9,7 +9,8 @@ import {
 } from "@/components/UI/Card";
 import { Input } from "@/components/UI/Input";
 import { Label } from "@/components/UI/Label";
-import { WalletEncryptionUtil, ExtendedWalletAccount } from "@/utils/crypto";
+import type { ExtendedWalletAccount } from "@/utils/crypto";
+import { WalletEncryptionUtil } from "@/utils/crypto";
 import { useStore } from "@/stores/store";
 import { Upload } from "lucide-react";
 import { useForm } from "react-hook-form";

--- a/src/components/Core/Body/ImportAccount/ImportHexSeedForm/ImportHexSeedForm.tsx
+++ b/src/components/Core/Body/ImportAccount/ImportHexSeedForm/ImportHexSeedForm.tsx
@@ -1,5 +1,5 @@
 import { useStore } from "@/stores/store";
-import { ExtendedWalletAccount } from "@/utils/crypto";
+import type { ExtendedWalletAccount } from "@/utils/crypto";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle, CardDescription } from "@/components/UI/Card";
 import { Form, FormControl, FormDescription, FormField, FormItem, FormMessage } from "@/components/UI/Form";
 import { Input } from "@/components/UI/Input";

--- a/src/components/Core/Body/Nfts/AddNftModal.tsx
+++ b/src/components/Core/Body/Nfts/AddNftModal.tsx
@@ -29,7 +29,7 @@ import {
   type NftStandard,
 } from "@/utils/web3/nft";
 import { isValidQrlAddress } from "@/utils/web3";
-import { NFTInterface } from "@/constants";
+import type { NFTInterface } from "@/constants";
 
 interface AddNftModalProps {
   isOpen: boolean;

--- a/src/components/Core/Body/Nfts/NftCard.tsx
+++ b/src/components/Core/Body/Nfts/NftCard.tsx
@@ -32,7 +32,18 @@ export function NftCard({ nft }: NftCardProps) {
     : `${truncateAddress(nft.contractAddress)} • #${truncateId(nft.tokenId)}`;
 
   return (
-    <div className="group flex cursor-pointer flex-col gap-2" onClick={onOpen}>
+    <div
+      role="button"
+      tabIndex={0}
+      className="group flex cursor-pointer flex-col gap-2 rounded-md outline-none focus-visible:ring-2 focus-visible:ring-secondary"
+      onClick={onOpen}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onOpen();
+        }
+      }}
+    >
       <div className="relative overflow-hidden rounded-md border border-border transition-colors group-hover:border-secondary/60">
         <NftImage
           src={nft.image}

--- a/src/components/Core/Body/Nfts/NftCard.tsx
+++ b/src/components/Core/Body/Nfts/NftCard.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from "react-router-dom";
 import { EyeOff } from "lucide-react";
-import { NFTInterface } from "@/constants";
+import type { NFTInterface } from "@/constants";
 import { Card } from "@/components/UI/Card";
 import { Button } from "@/components/UI/Button";
 import { useStore } from "@/stores/store";

--- a/src/components/Core/Body/Nfts/NftCard.tsx
+++ b/src/components/Core/Body/Nfts/NftCard.tsx
@@ -1,7 +1,6 @@
 import { useNavigate } from "react-router-dom";
 import { EyeOff } from "lucide-react";
 import type { NFTInterface } from "@/constants";
-import { Card } from "@/components/UI/Card";
 import { Button } from "@/components/UI/Button";
 import { useStore } from "@/stores/store";
 import { nftKey } from "@/utils/web3/nft";
@@ -33,36 +32,37 @@ export function NftCard({ nft }: NftCardProps) {
     : `${truncateAddress(nft.contractAddress)} • #${truncateId(nft.tokenId)}`;
 
   return (
-    <Card
-      className="group relative cursor-pointer overflow-hidden border-l-4 border-l-secondary transition-shadow hover:shadow-md"
-      onClick={onOpen}
-    >
-      <NftImage
-        src={nft.image}
-        alt={nft.name ?? `Token #${nft.tokenId}`}
-        className="aspect-square w-full"
-      />
-      <div className="space-y-1 p-3">
-        <div className="truncate text-sm font-semibold">
+    <div className="group flex cursor-pointer flex-col gap-2" onClick={onOpen}>
+      <div className="relative overflow-hidden rounded-md border border-border transition-colors group-hover:border-secondary/60">
+        <NftImage
+          src={nft.image}
+          alt={nft.name ?? `Token #${nft.tokenId}`}
+          blur
+          className="aspect-square w-full bg-gradient-to-br from-secondary/15 to-background"
+        />
+        <Button
+          variant="ghost"
+          size="icon"
+          title="Hide NFT"
+          onClick={onHide}
+          // Always visible on touch devices (no hover); reveal on hover on desktop.
+          className="absolute right-2 top-2 h-7 w-7 bg-background/70 opacity-100 backdrop-blur-sm transition-opacity md:opacity-0 md:group-hover:opacity-100"
+        >
+          <EyeOff className="h-4 w-4" />
+        </Button>
+        {nft.standard === "ERC1155" && nft.balance && BigInt(nft.balance) > 1n && (
+          <span className="absolute bottom-2 left-2 rounded-full bg-background/80 px-2 py-0.5 text-xs font-medium backdrop-blur-sm">
+            ×{nft.balance}
+          </span>
+        )}
+      </div>
+      <div className="space-y-0.5">
+        <div className="truncate text-sm font-medium">
           {nft.name ?? `Token #${truncateId(nft.tokenId)}`}
         </div>
         <div className="truncate text-xs text-muted-foreground">{subtitle}</div>
-        {nft.standard === "ERC1155" && nft.balance && BigInt(nft.balance) > 1n && (
-          <div className="text-xs text-muted-foreground">
-            Balance: {nft.balance}
-          </div>
-        )}
       </div>
-      <Button
-        variant="ghost"
-        size="icon"
-        title="Hide NFT"
-        onClick={onHide}
-        className="absolute right-2 top-2 h-7 w-7 opacity-0 transition-opacity group-hover:opacity-100"
-      >
-        <EyeOff className="h-4 w-4" />
-      </Button>
-    </Card>
+    </div>
   );
 }
 

--- a/src/components/Core/Body/Nfts/NftDetail.tsx
+++ b/src/components/Core/Body/Nfts/NftDetail.tsx
@@ -162,10 +162,13 @@ const NftDetail = observer(() => {
         setIsSending(false);
         return;
       }
-      const sender = await getAddressFromMnemonicAsync(
-        mnemonic,
-        qrlStore.qrlInstance!,
-      );
+      const qrlInstance = qrlStore.qrlInstance;
+      if (!qrlInstance) {
+        setPinError("Wallet not connected. Please try again.");
+        setIsSending(false);
+        return;
+      }
+      const sender = await getAddressFromMnemonicAsync(mnemonic, qrlInstance);
       if (sender.toLowerCase() !== accountAddress.toLowerCase()) {
         setPinError("PIN decrypted an invalid seed. Re-import this account.");
         setIsSending(false);

--- a/src/components/Core/Body/Nfts/NftGallery.tsx
+++ b/src/components/Core/Body/Nfts/NftGallery.tsx
@@ -52,7 +52,14 @@ const NftGallery = observer(() => {
   return (
     <Card className="border-l-4 border-l-secondary">
       <CardHeader className="flex flex-row items-center justify-between bg-gradient-to-r from-secondary/5 to-transparent">
-        <CardTitle className="text-2xl font-bold">NFTs</CardTitle>
+        <div className="flex items-center gap-3">
+          <CardTitle className="text-2xl font-bold">NFTs</CardTitle>
+          {nfts.length > 0 && (
+            <span className="rounded-full bg-muted px-2.5 py-0.5 text-xs font-medium text-muted-foreground">
+              {nfts.length} item{nfts.length === 1 ? "" : "s"}
+            </span>
+          )}
+        </div>
         <div className="flex gap-2">
           <TooltipProvider>
             <Tooltip>

--- a/src/components/Core/Body/Nfts/NftImage.tsx
+++ b/src/components/Core/Body/Nfts/NftImage.tsx
@@ -7,9 +7,14 @@ interface NftImageProps {
   src?: string;
   alt: string;
   className?: string;
+  /**
+   * Soft-blur the artwork (used for gallery thumbnails). The full-resolution
+   * sharp render is reserved for the detail view the user opens on click.
+   */
+  blur?: boolean;
 }
 
-export function NftImage({ src, alt, className }: NftImageProps) {
+export function NftImage({ src, alt, className, blur = false }: NftImageProps) {
   // Compute the resolved URL from props; derived, not stored. When `src`
   // changes the outer component re-renders with a new memoized value and
   // the inner <Inner> remounts via its key, resetting load/error state.
@@ -21,17 +26,19 @@ export function NftImage({ src, alt, className }: NftImageProps) {
   if (!imageSrc) {
     return <Fallback wrapper={wrapper} alt={alt} />;
   }
-  return <Inner key={imageSrc} wrapper={wrapper} src={imageSrc} alt={alt} />;
+  return <Inner key={imageSrc} wrapper={wrapper} src={imageSrc} alt={alt} blur={blur} />;
 }
 
 function Inner({
   wrapper,
   src,
   alt,
+  blur,
 }: {
   wrapper: string;
   src: string;
   alt: string;
+  blur: boolean;
 }) {
   // Component is keyed by src, so this state always resets on src change.
   // setState only fires from <img> event callbacks — never inside an effect.
@@ -54,7 +61,7 @@ function Inner({
         onError={() => setStatus("error")}
         className={`h-full w-full object-cover transition-opacity ${
           status === "loaded" ? "opacity-100" : "opacity-0"
-        }`}
+        } ${blur ? "scale-110 blur-[3px]" : ""}`}
       />
     </div>
   );

--- a/src/components/Core/Body/PinSetup/PinSetup.tsx
+++ b/src/components/Core/Body/PinSetup/PinSetup.tsx
@@ -107,7 +107,9 @@ export const PinSetup = ({
       // Uses Web Worker to avoid blocking UI during PBKDF2
       if (hasExistingSeeds && existingSeeds.length > 0) {
         try {
-          await decryptSeedAsync(existingSeeds[0].encryptedSeed, userPin);
+          // length > 0 is checked above; `?? ''` only satisfies the index
+          // checker and would route an (impossible) miss to the catch below.
+          await decryptSeedAsync(existingSeeds[0]?.encryptedSeed ?? '', userPin);
         } catch (err) {
           const message =
             err instanceof CryptoOperationError && err.code === CryptoErrorCode.OUTDATED_FORMAT

--- a/src/components/Core/Body/Settings/Settings.tsx
+++ b/src/components/Core/Body/Settings/Settings.tsx
@@ -25,7 +25,8 @@ import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { useState, useEffect } from "react";
 import { NetworkSettings } from "./NetworkSettings/NetworkSettings";
-import { StorageUtil, EncryptedSeedData } from "@/utils/storage";
+import type { EncryptedSeedData } from "@/utils/storage";
+import { StorageUtil } from "@/utils/storage";
 import { Save, Shield } from "lucide-react";
 import { SEO } from "@/components/SEO/SEO";
 import { PinInput } from "@/components/UI/PinInput/PinInput";
@@ -171,7 +172,7 @@ const Settings = observer(() => {
             // Verify current PIN by attempting to decrypt the first seed
             // Uses Web Worker to avoid blocking UI during PBKDF2
             try {
-                await decryptSeedAsync(allSeeds[0].encryptedSeed, data.currentPin);
+                await decryptSeedAsync(allSeeds[0]?.encryptedSeed ?? '', data.currentPin);
             } catch {
                 // Record failed attempt
                 const result = recordFailedAttempt();

--- a/src/components/Core/Body/Tokens/AddTokenModal/AddTokenModal.tsx
+++ b/src/components/Core/Body/Tokens/AddTokenModal/AddTokenModal.tsx
@@ -15,6 +15,8 @@ import { observer } from "mobx-react-lite";
 import { Loader2, Sparkles } from "lucide-react";
 import { useStore } from "@/stores/store";
 import { fetchTokenInfo, fetchBalance } from "@/utils/web3";
+import { formatUnits } from "@/utils/web3/units";
+import { getOptimalTokenBalance } from "@/utils/formatting";
 import type { TokenInterface } from "@/constants";
 import { QRL_PROVIDER } from "@/config";
 import { StorageUtil } from "@/utils/storage";
@@ -113,7 +115,17 @@ export const AddTokenModal = observer(({ isOpen, onClose }: { isOpen: boolean, o
                     const selectedBlockChain = await StorageUtil.getBlockChain();
                     const { name, symbol, decimals } = await fetchTokenInfo(tokenAddress, QRL_PROVIDER[selectedBlockChain].url);
                     const balance = await fetchBalance(tokenAddress, activeAccountAddress, QRL_PROVIDER[selectedBlockChain].url);
-                    setTokenInfo({ name, symbol, decimals: parseInt(decimals.toString()), address: tokenAddress, amount: balance.toString() });
+                    const parsedDecimals = parseInt(decimals?.toString() ?? "18");
+                    // Store the display-formatted balance (decimals applied) so the
+                    // token list doesn't flash the raw base-unit integer until the
+                    // next refreshTokenBalances cycle reformats it.
+                    let amount = "0.0";
+                    try {
+                        amount = getOptimalTokenBalance(formatUnits(balance?.toString() ?? "0", parsedDecimals), symbol, false);
+                    } catch {
+                        amount = "0.0";
+                    }
+                    setTokenInfo({ name, symbol, decimals: parsedDecimals, address: tokenAddress, amount });
                 } catch (err) {
                     console.error("Error fetching token info", err);
                     setTokenInfo(null);

--- a/src/components/Core/Body/Tokens/AddTokenModal/AddTokenModal.tsx
+++ b/src/components/Core/Body/Tokens/AddTokenModal/AddTokenModal.tsx
@@ -15,7 +15,7 @@ import { observer } from "mobx-react-lite";
 import { Loader2, Sparkles } from "lucide-react";
 import { useStore } from "@/stores/store";
 import { fetchTokenInfo, fetchBalance } from "@/utils/web3";
-import { TokenInterface } from "@/constants";
+import type { TokenInterface } from "@/constants";
 import { QRL_PROVIDER } from "@/config";
 import { StorageUtil } from "@/utils/storage";
 

--- a/src/components/Core/Body/Tokens/TokenForm/columns.tsx
+++ b/src/components/Core/Body/Tokens/TokenForm/columns.tsx
@@ -1,5 +1,5 @@
-import { TokenInterface } from "@/constants"
-import { ColumnDef } from "@tanstack/react-table"
+import type { TokenInterface } from "@/constants"
+import type { ColumnDef } from "@tanstack/react-table"
 import { Copy, Check, Send, EyeOff } from "lucide-react"
 import { useState } from "react"
 import { observer } from "mobx-react-lite"

--- a/src/components/Core/Body/Tokens/TokenForm/columns.tsx
+++ b/src/components/Core/Body/Tokens/TokenForm/columns.tsx
@@ -38,7 +38,7 @@ const CopyableAddress = ({ address }: { address: string }) => {
     );
 };
 
-const CopyableText = ({ text }: { text: string }) => {
+const CopyableText = ({ text, className }: { text: string; className?: string }) => {
     const [isCopied, setIsCopied] = useState(false);
 
     const handleCopy = async (textToCopy: string) => {
@@ -53,7 +53,7 @@ const CopyableText = ({ text }: { text: string }) => {
 
     return (
         <div className="flex items-center gap-2 group">
-            <span>{text}</span>
+            <span className={className}>{text}</span>
             {isCopied ? (
                 <Check className="w-4 h-4 text-green-500" />
             ) : (
@@ -120,7 +120,7 @@ export const columns: ColumnDef<TokenInterface>[] = [
         header: "Name",
         cell: ({ row }) => {
             const name: string = row.getValue('name')
-            return <div className="hidden md:block"><CopyableText text={name} /></div>;
+            return <div className="hidden md:block"><CopyableText text={name} className="font-semibold text-foreground" /></div>;
         },
     },
     {
@@ -128,7 +128,7 @@ export const columns: ColumnDef<TokenInterface>[] = [
         header: "Symbol",
         cell: ({ row }) => {
             const symbol: string = row.getValue('symbol')
-            return <CopyableText text={symbol} />;
+            return <CopyableText text={symbol} className="text-muted-foreground" />;
         },
     },
     {

--- a/src/components/Core/Body/Tokens/TokenForm/data-table.tsx
+++ b/src/components/Core/Body/Tokens/TokenForm/data-table.tsx
@@ -1,5 +1,6 @@
+import type {
+    ColumnDef} from "@tanstack/react-table";
 import {
-    ColumnDef,
     flexRender,
     getCoreRowModel,
     useReactTable,
@@ -14,7 +15,7 @@ import {
     TableRow,
 } from "@/components/UI/table"
 import { useEffect, type ReactNode } from "react";
-import { TokenInterface } from "@/constants";
+import type { TokenInterface } from "@/constants";
 import { Loader2 } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { ROUTES } from "@/router/router";
@@ -42,8 +43,9 @@ export function DataTable<TData, TValue>({
     // Watch for row selection changes - navigate to Transfer page
     useEffect(() => {
         const selectedRows = table.getSelectedRowModel().rows;
-        if (selectedRows.length > 0) {
-            const token = selectedRows[0].original as TokenInterface;
+        const firstRow = selectedRows[0];
+        if (firstRow) {
+            const token = firstRow.original as TokenInterface;
             // Reset selection before navigating
             table.resetRowSelection();
             // Navigate to Transfer page with token address as query param

--- a/src/components/Core/Body/Transfer/GasFeeNotice/GasFeeNotice.tsx
+++ b/src/components/Core/Body/Transfer/GasFeeNotice/GasFeeNotice.tsx
@@ -1,5 +1,5 @@
 import { useStore } from "@/stores/store";
-import { FeeLevel } from "@/stores/qrlStore";
+import type { FeeLevel } from "@/stores/qrlStore";
 import { utils } from "@theqrl/web3";
 import { cva } from "class-variance-authority";
 import { Loader, Fuel } from "lucide-react";

--- a/src/components/Core/Body/Transfer/GasFeeNotice/GasFeeNotice.tsx
+++ b/src/components/Core/Body/Transfer/GasFeeNotice/GasFeeNotice.tsx
@@ -2,15 +2,15 @@ import { useStore } from "@/stores/store";
 import type { FeeLevel } from "@/stores/qrlStore";
 import { utils } from "@theqrl/web3";
 import { cva } from "class-variance-authority";
-import { Loader, Fuel } from "lucide-react";
+import { Loader } from "lucide-react";
 import { useEffect, useState, useRef } from "react";
 import { getOptimalGasFee } from "@/utils/formatting";
-import { Button } from "@/components/UI/Button";
+import { cn } from "@/utils/cn";
 
 const FEE_DISPLAY: Record<FeeLevel, { label: string; multiplier: number }> = {
-  low:    { label: "Low",    multiplier: 1 },
+  low:    { label: "Slow",   multiplier: 1 },
   medium: { label: "Medium", multiplier: 1.5 },
-  high:   { label: "High",   multiplier: 2 },
+  high:   { label: "Fast",   multiplier: 2 },
 };
 
 type GasFeeNoticeProps = {
@@ -23,12 +23,12 @@ type GasFeeNoticeProps = {
 };
 
 const gasFeeNoticeClasses = cva(
-  "m-1 flex flex-col gap-3 rounded-lg border border-white px-4 py-3",
+  "mt-4 flex flex-col gap-3 rounded-md border border-border bg-muted/30 px-4 py-3.5",
   {
     variants: {
       isSubmitting: {
-        true: ["opacity-30"],
-        false: ["opacity-80"],
+        true: ["opacity-50"],
+        false: ["opacity-100"],
       },
     },
     defaultVariants: {
@@ -104,35 +104,40 @@ export const GasFeeNotice = ({
   return (
     hasValuesForGasCalculation && (
       <div className={gasFeeNoticeClasses({ isSubmitting })}>
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <Fuel className="h-4 w-4" />
-            {gasFee.isLoading ? (
-              <div className="flex gap-2">
-                <Loader className="h-4 w-4 animate-spin" />
-                Estimating fee...
-              </div>
-            ) : gasFee.error ? (
-              <span className="text-sm">{gasFee.error}</span>
-            ) : (
-              <span className="text-sm">~{gasFee.estimatedGas}</span>
-            )}
-          </div>
+        <div className="flex items-center justify-between text-sm text-muted-foreground">
+          <span className="font-medium">Network fee</span>
+          {gasFee.isLoading ? (
+            <span className="flex items-center gap-2">
+              <Loader className="h-4 w-4 animate-spin" />
+              Estimating fee...
+            </span>
+          ) : gasFee.error ? (
+            <span className="text-destructive">{gasFee.error}</span>
+          ) : (
+            <span className="font-mono text-foreground">≈ {gasFee.estimatedGas}</span>
+          )}
         </div>
-        <div className="flex gap-2">
-          {(["low", "medium", "high"] as FeeLevel[]).map((level) => (
-            <Button
-              key={level}
-              type="button"
-              variant={feeLevel === level ? "default" : "outline"}
-              size="sm"
-              onClick={() => onFeeLevelChange(level)}
-              disabled={isSubmitting}
-              className="flex-1"
-            >
-              {FEE_DISPLAY[level].label}
-            </Button>
-          ))}
+        <div className="grid grid-cols-3 gap-2">
+          {(["low", "medium", "high"] as FeeLevel[]).map((level) => {
+            const active = feeLevel === level;
+            return (
+              <button
+                key={level}
+                type="button"
+                onClick={() => onFeeLevelChange(level)}
+                disabled={isSubmitting}
+                aria-pressed={active}
+                className={cn(
+                  "rounded-sm border py-2 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50",
+                  active
+                    ? "border-secondary bg-secondary/10 text-secondary"
+                    : "border-input bg-background text-muted-foreground hover:text-foreground",
+                )}
+              >
+                {FEE_DISPLAY[level].label}
+              </button>
+            );
+          })}
         </div>
       </div>
     )

--- a/src/components/Core/Body/Transfer/GasFeeNotice/GasFeeNotice.tsx
+++ b/src/components/Core/Body/Transfer/GasFeeNotice/GasFeeNotice.tsx
@@ -102,11 +102,14 @@ export const GasFeeNotice = ({
   }, [from, to, value, feeLevel, hasValuesForGasCalculation]);
 
   return (
-    hasValuesForGasCalculation && (
-      <div className={gasFeeNoticeClasses({ isSubmitting })}>
+    <div className={gasFeeNoticeClasses({ isSubmitting })}>
         <div className="flex items-center justify-between text-sm text-muted-foreground">
           <span className="font-medium">Network fee</span>
-          {gasFee.isLoading ? (
+          {!hasValuesForGasCalculation ? (
+            <span className="text-xs text-muted-foreground/70">
+              Enter recipient and amount to estimate
+            </span>
+          ) : gasFee.isLoading ? (
             <span className="flex items-center gap-2">
               <Loader className="h-4 w-4 animate-spin" />
               Estimating fee...
@@ -139,7 +142,6 @@ export const GasFeeNotice = ({
             );
           })}
         </div>
-      </div>
-    )
+    </div>
   );
 };

--- a/src/components/Core/Body/Transfer/TransactionSuccessful/TransactionSuccessful.tsx
+++ b/src/components/Core/Body/Transfer/TransactionSuccessful/TransactionSuccessful.tsx
@@ -8,7 +8,8 @@ import {
 } from "@/components/UI/Card";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { StringUtil, getOptimalTokenBalance } from "@/utils/formatting";
-import { TransactionReceipt, utils } from "@theqrl/web3";
+import type { TransactionReceipt} from "@theqrl/web3";
+import { utils } from "@theqrl/web3";
 import { BigNumber } from "bignumber.js";
 import { Check, CheckCircle2, Copy, ExternalLink } from "lucide-react";
 import { QRL_PROVIDER } from "@/config";

--- a/src/components/Core/Body/Transfer/Transfer.tsx
+++ b/src/components/Core/Body/Transfer/Transfer.tsx
@@ -1,5 +1,4 @@
 import { Button } from "@/components/UI/Button";
-import { ShinyButton } from "@/components/UI/ShinyButton";
 import {
   Card,
   CardContent,
@@ -33,6 +32,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { utils } from "@theqrl/web3";
 import { Loader, Send, X, Copy, Coins, ExternalLink, ScanLine, Check } from "lucide-react";
 import { observer } from "mobx-react-lite";
+import { ShinyButton } from "@/components/UI/ShinyButton";
 import { useEffect, useState, useMemo, useCallback } from "react";
 import { useForm } from "react-hook-form";
 import { useNavigate, useSearchParams } from "react-router-dom";
@@ -851,7 +851,11 @@ const Transfer = observer(() => {
                     processing={isSubmitting}
                     type="submit"
                   >
-                    <Send className="mr-2 h-4 w-4" />
+                    {isSubmitting ? (
+                      <Loader className="mr-2 h-4 w-4 animate-spin" />
+                    ) : (
+                      <Send className="mr-2 h-4 w-4" />
+                    )}
                     {isSubmitting ? `Sending ${assetSymbol}...` : `Send ${assetSymbol}`}
                   </ShinyButton>
                 </CardFooter>

--- a/src/components/Core/Body/Transfer/Transfer.tsx
+++ b/src/components/Core/Body/Transfer/Transfer.tsx
@@ -44,7 +44,7 @@ import { Slider } from "@/components/UI/Slider";
 import { PinInput } from "@/components/UI/PinInput/PinInput";
 import { WalletEncryptionUtil, getAddressFromMnemonicAsync } from "@/utils/crypto";
 import { copyToClipboard, openExternalUrl, isInNativeApp, requestQRScan, subscribeToNativeMessages, triggerHaptic } from "@/utils/nativeApp";
-import { FeeLevel } from "@/stores/qrlStore";
+import type { FeeLevel } from "@/stores/qrlStore";
 import { SEO } from "@/components/SEO/SEO";
 import { getOptimalTokenBalance, formatAddressShort } from "@/utils/formatting";
 import { fetchBalance } from "@/utils/web3";
@@ -241,7 +241,7 @@ const Transfer = observer(() => {
 
     const unsubscribe = subscribeToNativeMessages((message) => {
       if (message.type === 'QR_RESULT' && message.payload) {
-        const scannedAddress = (message.payload.address as string) || '';
+        const scannedAddress = (message.payload['address'] as string) || '';
         setIsScanning(false);
 
         // Validate the scanned address
@@ -357,7 +357,7 @@ const Transfer = observer(() => {
 
         let mnemonicPhrases;
         try {
-          const decryptedSeed = await WalletEncryptionUtil.decryptSeedWithPin(encryptedSeed, formData.pin!);
+          const decryptedSeed = await WalletEncryptionUtil.decryptSeedWithPin(encryptedSeed, formData.pin || "");
           mnemonicPhrases = decryptedSeed.mnemonic;
         } catch {
           control.setError("pin", { message: "Invalid PIN. Please try again." });
@@ -367,7 +367,12 @@ const Transfer = observer(() => {
         // Verify decrypted mnemonic matches the expected account address.
         // MLDSA87 derivation runs in the crypto worker — keeps the
         // Transfer modal animating smoothly during the 50–300 ms check.
-        const senderAddress = await getAddressFromMnemonicAsync(mnemonicPhrases, qrlStore.qrlInstance!);
+        const qrlInstance = qrlStore.qrlInstance;
+        if (!qrlInstance) {
+          control.setError("pin", { message: "Wallet not connected. Please try again." });
+          return;
+        }
+        const senderAddress = await getAddressFromMnemonicAsync(mnemonicPhrases, qrlInstance);
         if (senderAddress.toLowerCase() !== accountAddress.toLowerCase()) {
           control.setError("pin", { message: "Security error: seed mismatch detected. Please re-import this account." });
           return;
@@ -401,7 +406,12 @@ const Transfer = observer(() => {
         return;
       }
 
-      const senderAddress = await getAddressFromMnemonicAsync(mnemonic, qrlStore.qrlInstance!);
+      const qrlInstance = qrlStore.qrlInstance;
+      if (!qrlInstance) {
+        control.setError("pin", { message: "Wallet not connected. Please try again." });
+        return;
+      }
+      const senderAddress = await getAddressFromMnemonicAsync(mnemonic, qrlInstance);
       if (senderAddress.toLowerCase() !== accountAddress.toLowerCase()) {
         control.setError("pin", { message: "PIN decrypted an invalid seed." });
         return;
@@ -450,7 +460,7 @@ const Transfer = observer(() => {
   };
 
   const handleSliderChange = (value: number[]) => {
-    applyPercentage(value[0]);
+    applyPercentage(value[0] ?? 0);
   };
 
   const setPercentage = (percentage: number) => () => {

--- a/src/components/Core/Body/Transfer/Transfer.tsx
+++ b/src/components/Core/Body/Transfer/Transfer.tsx
@@ -726,7 +726,7 @@ const Transfer = observer(() => {
                           </div>
                         )}
                         {!isScanning && !scanSuccess && (
-                          <FormDescription>
+                          <FormDescription className="text-xs text-muted-foreground/70">
                             Enter the receiver's account address{isInNativeApp() ? ' or scan QR' : ''}
                           </FormDescription>
                         )}
@@ -820,7 +820,7 @@ const Transfer = observer(() => {
                               disabled={isSubmitting}
                             />
                           </FormControl>
-                          <FormDescription>
+                          <FormDescription className="text-xs text-muted-foreground/70">
                             Enter the PIN used to encrypt your wallet seed
                           </FormDescription>
                           <FormMessage />

--- a/src/components/Core/Layout/Footer.tsx
+++ b/src/components/Core/Layout/Footer.tsx
@@ -1,6 +1,6 @@
 import { EXPLORER_BASE } from "@/config";
 import { ROUTES } from "@/router/router";
-import { useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { cn } from "@/utils/cn";
 
 /**
@@ -10,21 +10,20 @@ import { cn } from "@/utils/cn";
  *   hidden so it does not collide with the bottom tab bar).
  */
 export function FooterLinks({ className }: { className?: string }) {
-    const navigate = useNavigate();
     const linkClass =
         "text-xs md:text-sm cursor-pointer text-muted-foreground hover:text-foreground transition-colors";
 
     return (
         <div className={cn("flex items-center justify-center gap-6 md:gap-12", className)}>
-            <a className={linkClass} onClick={() => navigate(ROUTES.HOME)}>
+            <Link className={linkClass} to={ROUTES.HOME}>
                 Home
-            </a>
-            <a className={linkClass} onClick={() => navigate(ROUTES.PRIVACY)}>
+            </Link>
+            <Link className={linkClass} to={ROUTES.PRIVACY}>
                 Privacy
-            </a>
-            <a className={linkClass} onClick={() => navigate(ROUTES.TERMS)}>
+            </Link>
+            <Link className={linkClass} to={ROUTES.TERMS}>
                 Terms
-            </a>
+            </Link>
             <a
                 href={EXPLORER_BASE}
                 target="_blank"

--- a/src/components/Core/Layout/Footer.tsx
+++ b/src/components/Core/Layout/Footer.tsx
@@ -1,32 +1,48 @@
 import { EXPLORER_BASE } from "@/config";
 import { ROUTES } from "@/router/router";
 import { useNavigate } from "react-router-dom";
+import { cn } from "@/utils/cn";
 
-export default function Footer() {
+/**
+ * The Home / Privacy / Terms / Explorer link row. Rendered two ways:
+ * - desktop: pinned in the fixed bottom Footer bar.
+ * - mobile: inlined at the end of the page content (the fixed footer is
+ *   hidden so it does not collide with the bottom tab bar).
+ */
+export function FooterLinks({ className }: { className?: string }) {
     const navigate = useNavigate();
+    const linkClass =
+        "text-xs md:text-sm cursor-pointer text-muted-foreground hover:text-foreground transition-colors";
 
     return (
-        <footer className="fixed bottom-0 bg-background w-full z-10 border-t border-border/50">
-            {/* Navigation Links */}
-            <div className="h-8 md:h-10 flex items-center justify-center md:justify-start md:px-4 md:pl-12 gap-6 md:gap-12">
-                <a className="text-xs md:text-sm cursor-pointer text-muted-foreground hover:text-foreground transition-colors" onClick={() => navigate(ROUTES.HOME)}>
-                    Home
-                </a>
-                <a onClick={() => navigate(ROUTES.PRIVACY)} className="text-xs md:text-sm cursor-pointer text-muted-foreground hover:text-foreground transition-colors">
-                    Privacy
-                </a>
-                <a onClick={() => navigate(ROUTES.TERMS)} className="text-xs md:text-sm cursor-pointer text-muted-foreground hover:text-foreground transition-colors">
-                    Terms
-                </a>
-                <a
-                    href={EXPLORER_BASE}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-xs md:text-sm cursor-pointer text-muted-foreground hover:text-foreground transition-colors"
-                >
-                    Explorer
-                </a>
-            </div>
+        <div className={cn("flex items-center justify-center gap-6 md:gap-12", className)}>
+            <a className={linkClass} onClick={() => navigate(ROUTES.HOME)}>
+                Home
+            </a>
+            <a className={linkClass} onClick={() => navigate(ROUTES.PRIVACY)}>
+                Privacy
+            </a>
+            <a className={linkClass} onClick={() => navigate(ROUTES.TERMS)}>
+                Terms
+            </a>
+            <a
+                href={EXPLORER_BASE}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={linkClass}
+            >
+                Explorer
+            </a>
+        </div>
+    );
+}
+
+export default function Footer() {
+    return (
+        // Hidden on mobile: the links move into the page flow (see Layout) so
+        // they don't stack on top of the bottom tab bar.
+        <footer className="hidden md:block fixed bottom-0 bg-background w-full z-10 border-t border-border/50">
+            <FooterLinks className="h-10" />
         </footer>
-    )
+    );
 }

--- a/src/components/Core/Layout/Layout.tsx
+++ b/src/components/Core/Layout/Layout.tsx
@@ -1,6 +1,6 @@
 import { SidebarProvider } from "@/components/UI/sidebar"
 import { AppSidebar } from "@/components/Core/Layout/app-sidebar"
-import Footer from "@/components/Core/Layout/Footer"
+import Footer, { FooterLinks } from "@/components/Core/Layout/Footer"
 import MobileNav from "@/components/Core/Layout/MobileNav"
 
 export default function Layout({ children }: { children: React.ReactNode }) {
@@ -13,6 +13,9 @@ export default function Layout({ children }: { children: React.ReactNode }) {
                     </div>
                     <main className="flex-1 mb-20 md:mb-20 md:ml-20 overflow-x-hidden">
                         {children}
+                        {/* On mobile the nav links live in the page flow, not a fixed
+                            footer, so they don't collide with the bottom tab bar. */}
+                        <FooterLinks className="md:hidden py-6" />
                     </main>
                 </div>
                 <MobileNav />

--- a/src/components/Core/Layout/MobileNav.tsx
+++ b/src/components/Core/Layout/MobileNav.tsx
@@ -1,9 +1,10 @@
-import { Users, SendHorizontal, Settings as SettingsIcon, Plus, LogOut } from "lucide-react"
-import { useNavigate } from "react-router-dom";
+import { Wallet, SendHorizontal, Settings as SettingsIcon, Plus, LogOut } from "lucide-react"
+import { useNavigate, useLocation } from "react-router-dom";
 import { ROUTES } from "@/router/router";
 import { handleLogout } from "@/utils/logout";
 import { isInNativeApp } from "@/utils/nativeApp";
 import { navigateTo } from "@/utils/navigation";
+import { cn } from "@/utils/cn";
 
 const navItems = [
     {
@@ -12,7 +13,7 @@ const navItems = [
         path: ROUTES.TRANSFER,
     },
     {
-        icon: Users,
+        icon: Wallet,
         label: "Wallets",
         path: ROUTES.ACCOUNT_LIST,
     },
@@ -30,20 +31,35 @@ const navItems = [
 
 export default function MobileNav() {
     const navigate = useNavigate();
-    
+    const location = useLocation();
+
     const onLogoutClick = () => {
         handleLogout(navigate);
     };
 
+    const isActive = (path: string) =>
+        location.pathname === path || location.pathname.startsWith(`${path}/`);
+
     return (
-        <nav className="md:hidden fixed bottom-6 border-t-2 border-t-secondary border-t-opacity-50 bg-background w-full z-10 h-14 flex items-center justify-around px-4 pt-0">
+        <nav className="md:hidden fixed bottom-0 border-t-2 border-t-secondary/50 bg-background w-full z-10 h-14 flex items-center justify-around px-4">
             {
-                navItems.map((item) => (
-                    <button key={item.path} className="cursor-pointer flex flex-col items-center text-sm text-muted-foreground hover:text-foreground transition-colors" onClick={() => navigateTo(item.path, navigate)}>
-                        <item.icon className="h-5 w-5" />
-                        <span>{item.label}</span>
-                    </button>
-                ))
+                navItems.map((item) => {
+                    const active = isActive(item.path);
+                    return (
+                        <button
+                            key={item.path}
+                            aria-current={active ? "page" : undefined}
+                            className={cn(
+                                "cursor-pointer flex flex-col items-center text-sm transition-colors",
+                                active ? "text-secondary" : "text-muted-foreground hover:text-foreground",
+                            )}
+                            onClick={() => navigateTo(item.path, navigate)}
+                        >
+                            <item.icon className="h-5 w-5" />
+                            <span>{item.label}</span>
+                        </button>
+                    );
+                })
             }
             {/* Hide logout button when running in native app - wallet removal is handled in native settings */}
             {!isInNativeApp() && (

--- a/src/components/Core/Layout/MobileNav.tsx
+++ b/src/components/Core/Layout/MobileNav.tsx
@@ -1,4 +1,4 @@
-import { Wallet, SendHorizontal, Settings as SettingsIcon, Plus, LogOut } from "lucide-react"
+import { Wallet, ArrowRight, Settings as SettingsIcon, Plus, LogOut } from "lucide-react"
 import { useNavigate, useLocation } from "react-router-dom";
 import { ROUTES } from "@/router/router";
 import { handleLogout } from "@/utils/logout";
@@ -8,7 +8,7 @@ import { cn } from "@/utils/cn";
 
 const navItems = [
     {
-        icon: SendHorizontal,
+        icon: ArrowRight,
         label: "Send",
         path: ROUTES.TRANSFER,
     },

--- a/src/components/Core/Layout/app-sidebar.tsx
+++ b/src/components/Core/Layout/app-sidebar.tsx
@@ -71,26 +71,21 @@ export function AppSidebar() {
                                 return (
                                 <SidebarMenuItem key={item.title}>
                                     <SidebarMenuButton
-                                        asChild
                                         onClick={() => navigateTo(item.url, navigate)}
-                                        // Override shadcn's rounded-md + focus ring so the active
-                                        // accent reads as a flat full-bleed block with a straight
-                                        // orange edge (rounded right-border renders as a curve).
+                                        // Semantic <button> (no asChild) for native keyboard support.
+                                        // Override shadcn's rounded-md so the active accent reads as a
+                                        // flat full-bleed block with a straight orange edge; keep a
+                                        // keyboard-only inset focus ring (mouse clicks don't show it).
                                         className={cn(
-                                            "py-2 h-auto rounded-none border-r-2 border-r-transparent transition-colors",
-                                            "hover:bg-transparent focus-visible:ring-0",
-                                            active && "bg-secondary/10 border-r-secondary",
+                                            "flex flex-col justify-evenly items-center gap-1 py-2 h-auto rounded-none border-r-2 border-r-transparent transition-colors [&>svg]:!size-8",
+                                            "hover:bg-transparent focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-secondary",
+                                            active
+                                                ? "bg-secondary/10 border-r-secondary text-foreground"
+                                                : "text-muted-foreground hover:text-foreground",
                                         )}
                                     >
-                                        <div
-                                            className={cn(
-                                                "flex flex-col justify-evenly items-center cursor-pointer [&>svg]:!size-8",
-                                                active ? "text-foreground" : "text-muted-foreground hover:text-foreground",
-                                            )}
-                                        >
-                                            <item.icon className="size-8" />
-                                            <span className="block text-xs font-medium">{item.label}</span>
-                                        </div>
+                                        <item.icon className="size-8" />
+                                        <span className="block text-xs font-medium">{item.label}</span>
                                     </SidebarMenuButton>
                                 </SidebarMenuItem>
                                 );

--- a/src/components/Core/Layout/app-sidebar.tsx
+++ b/src/components/Core/Layout/app-sidebar.tsx
@@ -57,9 +57,12 @@ export function AppSidebar() {
         location.pathname === url || location.pathname.startsWith(`${url}/`);
 
     return (
-        <Sidebar className="h-[calc(100vh-2.5rem)] border-r-secondary">
+        <Sidebar className="h-[calc(100vh-2.5rem)] border-r-secondary !border-r">
             <SidebarContent>
-                <SidebarGroup>
+                {/* px-0 so the active item is full-bleed: its orange right
+                    edge sits flush with the rail border instead of floating
+                    inset as a second parallel line. */}
+                <SidebarGroup className="px-0">
                     {/* <SidebarGroupLabel>Application</SidebarGroupLabel> */}
                     <SidebarGroupContent className="mt-5">
                         <SidebarMenu>

--- a/src/components/Core/Layout/app-sidebar.tsx
+++ b/src/components/Core/Layout/app-sidebar.tsx
@@ -1,4 +1,4 @@
-import { LogOut, Users, SendHorizontal, Settings as SettingsIcon, Plus } from "lucide-react"
+import { LogOut, Wallet, SendHorizontal, Settings as SettingsIcon, Plus } from "lucide-react"
 
 import {
     Sidebar,
@@ -11,12 +11,13 @@ import {
     SidebarMenuButton,
     SidebarMenuItem,
 } from "@/components/UI/sidebar"
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import { ROUTES } from "@/router/router";
 import MyQRLWalletLogo from "../Header/MyQRLWalletLogo/MyQRLWalletLogo";
 import { handleLogout } from "@/utils/logout";
 import { isInNativeApp } from "@/utils/nativeApp";
 import { navigateTo } from "@/utils/navigation";
+import { cn } from "@/utils/cn";
 
 // Menu items.
 const sidebarItems = [
@@ -24,7 +25,7 @@ const sidebarItems = [
         title: "Account List",
         url: ROUTES.ACCOUNT_LIST,
         label: "Wallets",
-        icon: Users,
+        icon: Wallet,
     },
     {
         title: "Send",
@@ -48,9 +49,12 @@ const sidebarItems = [
 
 export function AppSidebar() {
     const navigate = useNavigate();
+    const location = useLocation();
     const onLogoutClick = () => {
         handleLogout(navigate);
     };
+    const isActive = (url: string) =>
+        location.pathname === url || location.pathname.startsWith(`${url}/`);
 
     return (
         <Sidebar className="h-[calc(100vh-2.5rem)] border-r-secondary">
@@ -62,17 +66,35 @@ export function AppSidebar() {
                             <SidebarMenuItem className="cursor-pointer flex justify-center py-5" onClick={() => navigate(ROUTES.HOME)}>
                                 <MyQRLWalletLogo showText={false} size="lg" />
                             </SidebarMenuItem>
-                            {sidebarItems.map((item) => (
+                            {sidebarItems.map((item) => {
+                                const active = isActive(item.url);
+                                return (
                                 <SidebarMenuItem key={item.title}>
-                                    <SidebarMenuButton asChild className="py-2 h-auto" onClick={() => navigateTo(item.url, navigate)}>
-                                        <div className="flex flex-col justify-evenly items-center cursor-pointer [&>svg]:!size-8 text-muted-foreground hover:text-foreground"
+                                    <SidebarMenuButton
+                                        asChild
+                                        onClick={() => navigateTo(item.url, navigate)}
+                                        // Override shadcn's rounded-md + focus ring so the active
+                                        // accent reads as a flat full-bleed block with a straight
+                                        // orange edge (rounded right-border renders as a curve).
+                                        className={cn(
+                                            "py-2 h-auto rounded-none border-r-2 border-r-transparent transition-colors",
+                                            "hover:bg-transparent focus-visible:ring-0",
+                                            active && "bg-secondary/10 border-r-secondary",
+                                        )}
+                                    >
+                                        <div
+                                            className={cn(
+                                                "flex flex-col justify-evenly items-center cursor-pointer [&>svg]:!size-8",
+                                                active ? "text-foreground" : "text-muted-foreground hover:text-foreground",
+                                            )}
                                         >
                                             <item.icon className="size-8" />
                                             <span className="block text-xs font-medium">{item.label}</span>
                                         </div>
                                     </SidebarMenuButton>
                                 </SidebarMenuItem>
-                            ))}
+                                );
+                            })}
                         </SidebarMenu>
                     </SidebarGroupContent>
                 </SidebarGroup>

--- a/src/components/Core/Layout/app-sidebar.tsx
+++ b/src/components/Core/Layout/app-sidebar.tsx
@@ -1,4 +1,4 @@
-import { LogOut, Wallet, SendHorizontal, Settings as SettingsIcon, Plus } from "lucide-react"
+import { LogOut, Wallet, ArrowRight, Settings as SettingsIcon, Plus } from "lucide-react"
 
 import {
     Sidebar,
@@ -31,7 +31,7 @@ const sidebarItems = [
         title: "Send",
         url: ROUTES.TRANSFER,
         label: "Send",
-        icon: SendHorizontal,
+        icon: ArrowRight,
     },
     {
         title: "Create Token",

--- a/src/components/NativeAppBridge.tsx
+++ b/src/components/NativeAppBridge.tsx
@@ -137,7 +137,7 @@ const NativeAppBridge: React.FC = () => {
 
       switch (type) {
         case 'QR_RESULT': {
-          const address = payload?.address;
+          const address = payload?.['address'];
           if (typeof address !== 'string' || !address) {
             console.warn('[Bridge] QR result missing or invalid address');
             return;
@@ -176,7 +176,7 @@ const NativeAppBridge: React.FC = () => {
         }
 
         case 'BIOMETRIC_SUCCESS': {
-          const authenticated = payload?.authenticated;
+          const authenticated = payload?.['authenticated'];
           if (typeof authenticated !== 'boolean') {
             console.warn('[Bridge] BIOMETRIC_SUCCESS missing or invalid authenticated flag');
             return;
@@ -187,7 +187,7 @@ const NativeAppBridge: React.FC = () => {
         }
 
         case 'APP_STATE': {
-          const state = payload?.state;
+          const state = payload?.['state'];
           if (state !== 'active' && state !== 'background' && state !== 'inactive') {
             console.warn('[Bridge] APP_STATE missing or invalid state');
             return;
@@ -202,7 +202,7 @@ const NativeAppBridge: React.FC = () => {
 
         // Deep link URI from native app (qrlconnect:// scheme)
         case 'DAPP_URI' as NativeToWebMessageType: {
-          const uri = payload?.uri;
+          const uri = payload?.['uri'];
           if (typeof uri !== 'string' || !uri) {
             console.warn('[Bridge] DAPP_URI missing or invalid uri');
             return;
@@ -222,7 +222,7 @@ const NativeAppBridge: React.FC = () => {
 
         // Native requests disconnect of a specific dApp session
         case 'DAPP_DISCONNECT' as NativeToWebMessageType: {
-          const channelId = payload?.channelId;
+          const channelId = payload?.['channelId'];
           if (typeof channelId === 'string' && channelId) {
             logToNative(`Disconnecting dApp session: ${channelId}`);
             dappConnectService.disconnectSession(channelId);
@@ -268,12 +268,12 @@ const NativeAppBridge: React.FC = () => {
           break;
 
         case 'ERROR':
-          console.error('[Bridge] Native error:', payload?.message);
+          console.error('[Bridge] Native error:', payload?.['message']);
           break;
 
         // Seed persistence messages
         case 'UNLOCK_WITH_PIN': {
-          const pin = payload?.pin;
+          const pin = payload?.['pin'];
           if (typeof pin !== 'string' || !pin) {
             console.warn('[Bridge] UNLOCK_WITH_PIN missing or invalid pin');
             return;
@@ -286,9 +286,9 @@ const NativeAppBridge: React.FC = () => {
 
         case 'RESTORE_SEED': {
           // Native app sends backup seed if localStorage is empty
-          const address = payload?.address;
-          const encryptedSeed = payload?.encryptedSeed;
-          const blockchain = payload?.blockchain;
+          const address = payload?.['address'];
+          const encryptedSeed = payload?.['encryptedSeed'];
+          const blockchain = payload?.['blockchain'];
 
           if (
             typeof address !== 'string' || !address ||
@@ -353,7 +353,7 @@ const NativeAppBridge: React.FC = () => {
 
         case 'VERIFY_PIN': {
           // Native asks web to verify PIN can decrypt the stored seed
-          const pin = payload?.pin;
+          const pin = payload?.['pin'];
           if (typeof pin !== 'string' || !pin) {
             console.warn('[Bridge] VERIFY_PIN missing or invalid pin');
             sendPinVerified(false, PIN_VERIFY_ERRORS.INVALID_FORMAT);
@@ -408,8 +408,8 @@ const NativeAppBridge: React.FC = () => {
 
         case 'CHANGE_PIN': {
           // Native app requests web to re-encrypt all seeds with a new PIN
-          const oldPin = payload?.oldPin;
-          const newPin = payload?.newPin;
+          const oldPin = payload?.['oldPin'];
+          const newPin = payload?.['newPin'];
 
           if (typeof oldPin !== 'string' || !WalletEncryptionUtil.validatePin(oldPin)) {
             console.warn('[Bridge] CHANGE_PIN missing or invalid oldPin');

--- a/src/components/UI/Form.tsx
+++ b/src/components/UI/Form.tsx
@@ -1,11 +1,12 @@
 import * as React from "react";
-import * as LabelPrimitive from "@radix-ui/react-label";
+import type * as LabelPrimitive from "@radix-ui/react-label";
 import { Slot } from "@radix-ui/react-slot";
-import {
-  Controller,
+import type {
   ControllerProps,
   FieldPath,
-  FieldValues,
+  FieldValues} from "react-hook-form";
+import {
+  Controller,
   FormProvider,
   useFormContext,
 } from "react-hook-form";

--- a/src/components/UI/PinInput/PinInput.tsx
+++ b/src/components/UI/PinInput/PinInput.tsx
@@ -46,7 +46,10 @@ export const PinInput = ({
 
   const handleChange =
     (i: number) => (e: React.ChangeEvent<HTMLInputElement>) => {
-      const ch = e.target.value.replace(/\D/g, "").slice(-1);
+      const ch = e.target.value.slice(-1);
+      // Ignore non-digits outright so focus doesn't advance and the
+      // current cell isn't cleared.
+      if (ch && !/\d/.test(ch)) return;
       if (!ch && !chars[i]) return;
       setAt(i, ch);
       if (ch && i < length - 1) refs.current[i + 1]?.focus();
@@ -58,7 +61,10 @@ export const PinInput = ({
         e.preventDefault();
         return;
       }
+      // Backspace on an empty cell deletes the previous digit (not just
+      // moves focus), so one press removes one digit.
       if (e.key === "Backspace" && !chars[i] && i > 0) {
+        onChange(value.slice(0, -1));
         refs.current[i - 1]?.focus();
       }
       if (e.key === "ArrowLeft" && i > 0) refs.current[i - 1]?.focus();
@@ -97,6 +103,11 @@ export const PinInput = ({
             onChange={handleChange(i)}
             onKeyDown={handleKeyDown(i)}
             onPaste={handlePaste(i)}
+            onFocus={() => {
+              // Keep entry sequential: focusing a cell past the first
+              // empty one redirects to that empty cell.
+              if (i > value.length) refs.current[value.length]?.focus();
+            }}
             aria-label={`PIN digit ${i + 1}`}
             className={cn(
               "h-12 w-11 rounded-md border bg-background text-center font-mono text-xl text-foreground outline-none transition-colors",

--- a/src/components/UI/PinInput/PinInput.tsx
+++ b/src/components/UI/PinInput/PinInput.tsx
@@ -81,7 +81,9 @@ export const PinInput = ({
         focusCell(i - 1);
       }
       if (e.key === "ArrowLeft" && i > 0) focusCell(i - 1);
-      if (e.key === "ArrowRight" && i < length - 1) focusCell(i + 1);
+      // Only arrow into the first empty cell, never past it, so typed
+      // digits never land out of order.
+      if (e.key === "ArrowRight" && i < value.length) focusCell(i + 1);
     };
 
   const handlePaste =

--- a/src/components/UI/PinInput/PinInput.tsx
+++ b/src/components/UI/PinInput/PinInput.tsx
@@ -1,5 +1,4 @@
 import React, { useRef, useEffect } from "react";
-import { Input } from "../Input";
 import { cn } from "@/utils/cn";
 
 interface PinInputProps {
@@ -14,68 +13,109 @@ interface PinInputProps {
   autoFocus?: boolean;
 }
 
+/**
+ * Boxed PIN entry — a row of single-digit masked cells used to unlock the
+ * encrypted seed before signing. Keeps the original string-based API
+ * (`value`/`onChange`) so every call site stays untouched; only the
+ * presentation changed from one input to `length` cells.
+ */
 export const PinInput = ({
   length = 6,
   onChange,
   value = "",
   disabled = false,
-  placeholder = "Enter PIN",
+  // `placeholder` no longer renders (boxed cells), kept for API compatibility.
+  placeholder: _placeholder,
   className,
   description,
   error,
   autoFocus = false,
 }: PinInputProps) => {
-  const inputRef = useRef<HTMLInputElement>(null);
+  const refs = useRef<Array<HTMLInputElement | null>>([]);
+  const chars = value.split("").slice(0, length);
 
   useEffect(() => {
-    if (autoFocus && inputRef.current) {
-      inputRef.current.focus();
-    }
+    if (autoFocus) refs.current[0]?.focus();
   }, [autoFocus]);
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newValue = e.target.value;
-
-    // Only allow digits and limit to specified length
-    if (/^\d*$/.test(newValue) && newValue.length <= length) {
-      onChange(newValue);
-    }
+  const setAt = (i: number, ch: string) => {
+    const next = value.split("");
+    next[i] = ch;
+    onChange(next.join("").replace(/\D/g, "").slice(0, length));
   };
 
-  // Prevent Enter key from submitting parent form
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") {
+  const handleChange =
+    (i: number) => (e: React.ChangeEvent<HTMLInputElement>) => {
+      const ch = e.target.value.replace(/\D/g, "").slice(-1);
+      if (!ch && !chars[i]) return;
+      setAt(i, ch);
+      if (ch && i < length - 1) refs.current[i + 1]?.focus();
+    };
+
+  const handleKeyDown =
+    (i: number) => (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        return;
+      }
+      if (e.key === "Backspace" && !chars[i] && i > 0) {
+        refs.current[i - 1]?.focus();
+      }
+      if (e.key === "ArrowLeft" && i > 0) refs.current[i - 1]?.focus();
+      if (e.key === "ArrowRight" && i < length - 1) refs.current[i + 1]?.focus();
+    };
+
+  const handlePaste =
+    (i: number) => (e: React.ClipboardEvent<HTMLInputElement>) => {
       e.preventDefault();
-    }
-  };
+      const digits = e.clipboardData.getData("text").replace(/\D/g, "");
+      if (!digits) return;
+      const next = value.split("");
+      for (let k = 0; k < digits.length && i + k < length; k++) {
+        next[i + k] = digits.charAt(k);
+      }
+      const joined = next.join("").replace(/\D/g, "").slice(0, length);
+      onChange(joined);
+      refs.current[Math.min(i + digits.length, length - 1)]?.focus();
+    };
 
   return (
     <div className={cn("w-full space-y-2", className)}>
-      <Input
-        ref={inputRef}
-        type="password"
-        inputMode="numeric"
-        placeholder={placeholder}
-        value={value}
-        onChange={handleChange}
-        onKeyDown={handleKeyDown}
-        disabled={disabled}
-        autoComplete="current-password"
-        className={cn(
-          "placeholder:text-left placeholder:tracking-normal",
-          value.length > 0 ? "text-center tracking-widest" : "text-left tracking-normal",
-          error ? "border-destructive" : ""
-        )}
-      />
+      <div className="flex gap-2">
+        {Array.from({ length }).map((_, i) => (
+          <input
+            key={i}
+            ref={(el) => {
+              refs.current[i] = el;
+            }}
+            type="password"
+            inputMode="numeric"
+            autoComplete="one-time-code"
+            maxLength={1}
+            disabled={disabled}
+            value={chars[i] ?? ""}
+            onChange={handleChange(i)}
+            onKeyDown={handleKeyDown(i)}
+            onPaste={handlePaste(i)}
+            aria-label={`PIN digit ${i + 1}`}
+            className={cn(
+              "h-12 w-11 rounded-md border bg-background text-center font-mono text-xl text-foreground outline-none transition-colors",
+              "focus-visible:border-[#4aafff] focus-visible:ring-1 focus-visible:ring-[#4aafff]",
+              "disabled:cursor-not-allowed disabled:opacity-50",
+              error
+                ? "border-destructive"
+                : chars[i]
+                  ? "border-[#4aafff]"
+                  : "border-input",
+            )}
+          />
+        ))}
+      </div>
       {description && (
-        <div className="text-sm text-muted-foreground">
-          {description}
-        </div>
+        <div className="text-sm text-muted-foreground">{description}</div>
       )}
       {error && (
-        <div className="text-sm font-medium text-destructive">
-          {error}
-        </div>
+        <div className="text-sm font-medium text-destructive">{error}</div>
       )}
     </div>
   );

--- a/src/components/UI/PinInput/PinInput.tsx
+++ b/src/components/UI/PinInput/PinInput.tsx
@@ -32,10 +32,23 @@ export const PinInput = ({
   autoFocus = false,
 }: PinInputProps) => {
   const refs = useRef<Array<HTMLInputElement | null>>([]);
+  // Marks a focus move as programmatic (auto-advance / backspace / arrows /
+  // paste) so the cell's onFocus does not bounce it back. focus() fires the
+  // focus event synchronously, before React re-renders with the new value, so
+  // onFocus would otherwise read a stale (shorter) value and redirect.
+  const advancingRef = useRef(false);
   const chars = value.split("").slice(0, length);
 
+  const focusCell = (idx: number) => {
+    advancingRef.current = true;
+    refs.current[idx]?.focus();
+  };
+
   useEffect(() => {
-    if (autoFocus) refs.current[0]?.focus();
+    if (autoFocus) {
+      advancingRef.current = true;
+      refs.current[0]?.focus();
+    }
   }, [autoFocus]);
 
   const setAt = (i: number, ch: string) => {
@@ -52,7 +65,7 @@ export const PinInput = ({
       if (ch && !/\d/.test(ch)) return;
       if (!ch && !chars[i]) return;
       setAt(i, ch);
-      if (ch && i < length - 1) refs.current[i + 1]?.focus();
+      if (ch && i < length - 1) focusCell(i + 1);
     };
 
   const handleKeyDown =
@@ -65,10 +78,10 @@ export const PinInput = ({
       // moves focus), so one press removes one digit.
       if (e.key === "Backspace" && !chars[i] && i > 0) {
         onChange(value.slice(0, -1));
-        refs.current[i - 1]?.focus();
+        focusCell(i - 1);
       }
-      if (e.key === "ArrowLeft" && i > 0) refs.current[i - 1]?.focus();
-      if (e.key === "ArrowRight" && i < length - 1) refs.current[i + 1]?.focus();
+      if (e.key === "ArrowLeft" && i > 0) focusCell(i - 1);
+      if (e.key === "ArrowRight" && i < length - 1) focusCell(i + 1);
     };
 
   const handlePaste =
@@ -82,7 +95,7 @@ export const PinInput = ({
       }
       const joined = next.join("").replace(/\D/g, "").slice(0, length);
       onChange(joined);
-      refs.current[Math.min(i + digits.length, length - 1)]?.focus();
+      focusCell(Math.min(i + digits.length, length - 1));
     };
 
   return (
@@ -104,7 +117,13 @@ export const PinInput = ({
             onKeyDown={handleKeyDown(i)}
             onPaste={handlePaste(i)}
             onFocus={() => {
-              // Keep entry sequential: focusing a cell past the first
+              // Skip the redirect when we moved focus ourselves (the value
+              // here is stale until the next render).
+              if (advancingRef.current) {
+                advancingRef.current = false;
+                return;
+              }
+              // Keep manual entry sequential: clicking a cell past the first
               // empty one redirects to that empty cell.
               if (i > value.length) refs.current[value.length]?.focus();
             }}

--- a/src/components/UI/ShinyButton.tsx
+++ b/src/components/UI/ShinyButton.tsx
@@ -42,8 +42,12 @@ export const ShinyButton = React.forwardRef<HTMLButtonElement, ShinyButtonProps>
           }
 
           .shiny-btn {
-            --shiny-cta-highlight: #4aafff;
-            --shiny-cta-highlight-subtle: #3a9fee;
+            /* Solid design-primary blue fill; the sheen is a light glint on
+               top of it so the button reads as a clean primary CTA rather
+               than the old dark-fill/chasing-edge look. */
+            --shiny-cta-bg: #4aafff;
+            --shiny-cta-highlight: #ffffff;
+            --shiny-cta-highlight-subtle: #d6ecff;
             --animation: gradient-angle linear infinite;
             --shadow-size: 2px;
           }
@@ -68,7 +72,7 @@ export const ShinyButton = React.forwardRef<HTMLButtonElement, ShinyButtonProps>
             outline-offset: 4px;
             border: 1px solid transparent;
             background:
-              linear-gradient(hsl(var(--card)), hsl(var(--card))) padding-box,
+              linear-gradient(var(--shiny-cta-bg), var(--shiny-cta-bg)) padding-box,
               conic-gradient(
                   from calc(var(--gradient-angle) - var(--gradient-angle-offset)),
                   transparent,
@@ -78,7 +82,7 @@ export const ShinyButton = React.forwardRef<HTMLButtonElement, ShinyButtonProps>
                   transparent calc(var(--gradient-percent) * 4)
                 )
                 border-box;
-            box-shadow: inset 0 0 0 1px hsl(var(--border));
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.18);
             transition: var(--transition);
             transition-property:
               --gradient-angle-offset, --gradient-percent, --gradient-shine;
@@ -133,7 +137,7 @@ export const ShinyButton = React.forwardRef<HTMLButtonElement, ShinyButtonProps>
               black
             );
             border-radius: 0.5rem;
-            opacity: 0.4;
+            opacity: 0.18;
             z-index: -1;
           }
 
@@ -149,7 +153,7 @@ export const ShinyButton = React.forwardRef<HTMLButtonElement, ShinyButtonProps>
               transparent
             );
             mask-image: radial-gradient(circle at bottom, transparent 40%, black);
-            opacity: 0.6;
+            opacity: 0.35;
           }
 
           .shiny-btn .shiny-btn__content {

--- a/src/components/UI/ShinyButton.tsx
+++ b/src/components/UI/ShinyButton.tsx
@@ -230,7 +230,7 @@ export const ShinyButton = React.forwardRef<HTMLButtonElement, ShinyButtonProps>
           ref={ref}
           className={cn(
             "shiny-btn inline-flex items-center justify-center rounded-md text-sm font-medium h-10 px-4 py-2",
-            "text-foreground",
+            "text-primary-foreground",
             "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
             processing && "shiny-btn--processing",
             className

--- a/src/components/UI/ShinyButton.tsx
+++ b/src/components/UI/ShinyButton.tsx
@@ -230,7 +230,9 @@ export const ShinyButton = React.forwardRef<HTMLButtonElement, ShinyButtonProps>
           ref={ref}
           className={cn(
             "shiny-btn inline-flex items-center justify-center rounded-md text-sm font-medium h-10 px-4 py-2",
-            "text-primary-foreground",
+            // Constant dark text: the fill is a fixed light blue, so a
+            // theme-dependent token would be unreadable in light mode.
+            "text-zinc-950",
             "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
             processing && "shiny-btn--processing",
             className

--- a/src/components/UI/Slider.tsx
+++ b/src/components/UI/Slider.tsx
@@ -15,10 +15,10 @@ const Slider = React.forwardRef<
     )}
     {...props}
   >
-    <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary">
-      <SliderPrimitive.Range className="absolute h-full bg-[#1F51FF]" />
+    <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-muted">
+      <SliderPrimitive.Range className="absolute h-full bg-secondary" />
     </SliderPrimitive.Track>
-    <SliderPrimitive.Thumb className="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50" />
+    <SliderPrimitive.Thumb className="block h-[18px] w-[18px] rounded-full border-2 border-background bg-secondary shadow-[0_0_0_1px_hsl(25_95%_53%/0.4),0_0_18px_-2px_hsl(25_95%_53%/0.45)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50" />
   </SliderPrimitive.Root>
 ))
 Slider.displayName = SliderPrimitive.Root.displayName

--- a/src/components/UI/sidebar.tsx
+++ b/src/components/UI/sidebar.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
-import { VariantProps, cva } from "class-variance-authority"
+import type { VariantProps} from "class-variance-authority";
+import { cva } from "class-variance-authority"
 import { PanelLeft } from "lucide-react"
 
 import { useIsMobile } from "@/hooks/use-mobile"

--- a/src/config/networks.ts
+++ b/src/config/networks.ts
@@ -1,14 +1,14 @@
-const RPC_API_BASE = import.meta.env.VITE_NODE_ENV === 'production'
-  ? import.meta.env.VITE_RPC_URL_PRODUCTION
-  : import.meta.env.VITE_RPC_URL_DEVELOPMENT;  // Using Vite's default port
+const RPC_API_BASE = import.meta.env['VITE_NODE_ENV'] === 'production'
+  ? import.meta.env['VITE_RPC_URL_PRODUCTION']
+  : import.meta.env['VITE_RPC_URL_DEVELOPMENT'];  // Using Vite's default port
 
-export const SERVER_URL = import.meta.env.VITE_NODE_ENV === 'production'
-  ? import.meta.env.VITE_SERVER_URL_PRODUCTION
-  : import.meta.env.VITE_SERVER_URL_DEVELOPMENT;
+export const SERVER_URL = import.meta.env['VITE_NODE_ENV'] === 'production'
+  ? import.meta.env['VITE_SERVER_URL_PRODUCTION']
+  : import.meta.env['VITE_SERVER_URL_DEVELOPMENT'];
 
-export const EXPLORER_BASE = (import.meta.env.VITE_NODE_ENV === 'production'
-  ? import.meta.env.VITE_EXPLORER_URL_PRODUCTION
-  : import.meta.env.VITE_EXPLORER_URL_DEVELOPMENT) || 'https://zondscan.com';
+export const EXPLORER_BASE = (import.meta.env['VITE_NODE_ENV'] === 'production'
+  ? import.meta.env['VITE_EXPLORER_URL_PRODUCTION']
+  : import.meta.env['VITE_EXPLORER_URL_DEVELOPMENT']) || 'https://zondscan.com';
 
 export const QRL_PROVIDER = {
   TEST_NET: {

--- a/src/hooks/useCopyToClipboard.ts
+++ b/src/hooks/useCopyToClipboard.ts
@@ -19,6 +19,7 @@ export function useCopyToClipboard<T extends string>(timeout = 1500) {
 
       return () => clearTimeout(timer);
     }
+    return undefined;
   }, [copiedItem, timeout]);
 
   return { copiedItem, copyToClipboard };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,7 +7,12 @@ import { HelmetProvider } from 'react-helmet-async'
 import App from './App.tsx'
 import './index.css'
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
+const rootElement = document.getElementById('root')
+if (!rootElement) {
+  throw new Error('Root element #root is missing from index.html')
+}
+
+ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
     <HelmetProvider>
       <App />

--- a/src/services/dappConnect/DAppConnectService.ts
+++ b/src/services/dappConnect/DAppConnectService.ts
@@ -393,11 +393,11 @@ export class DAppConnectService {
     const conn = this.connections.get(channelId);
     if (!conn) return;
 
-    const type = msg.type as string;
+    const type = msg['type'] as string;
 
     switch (type) {
       case MessageType.ORIGINATOR_INFO: {
-        const info = msg.originatorInfo as DAppInfo | undefined;
+        const info = msg['originatorInfo'] as DAppInfo | undefined;
         if (info) {
           conn.dappInfo = {
             name: info.name || conn.dappInfo.name,
@@ -426,9 +426,9 @@ export class DAppConnectService {
       }
 
       case MessageType.JSONRPC: {
-        const method = msg.method as string;
-        const id = msg.id as string | number;
-        const params = msg.params as unknown[] | undefined;
+        const method = msg['method'] as string;
+        const id = msg['id'] as string | number;
+        const params = msg['params'] as unknown[] | undefined;
 
         if (!method) return;
 

--- a/src/services/dappConnect/PQCrypto.ts
+++ b/src/services/dappConnect/PQCrypto.ts
@@ -41,8 +41,17 @@ function subtle(): SubtleCrypto {
   return c.subtle;
 }
 
-function bs(u: Uint8Array): BufferSource {
-  return u as unknown as BufferSource;
+/**
+ * Narrow a Uint8Array to an ArrayBuffer-backed view for WebCrypto. The
+ * generic `Uint8Array` type defaults to ArrayBufferLike (which includes
+ * SharedArrayBuffer), and WebCrypto's `BufferSource` excludes SharedArrayBuffer
+ * since TS 5.7. We verify the backing buffer at runtime and only copy in the
+ * rare SharedArrayBuffer case, so this is an honest narrowing, not a blind cast.
+ */
+function bs(u: Uint8Array): Uint8Array<ArrayBuffer> {
+  return u.buffer instanceof ArrayBuffer
+    ? (u as Uint8Array<ArrayBuffer>)
+    : new Uint8Array(u);
 }
 
 export function kemKeygen(): Keypair {
@@ -175,7 +184,9 @@ export function toBase64(bytes: Uint8Array): string {
   let bin = '';
   for (let i = 0; i < bytes.length; i += CHUNK) {
     const slice = bytes.subarray(i, i + CHUNK);
-    bin += String.fromCharCode.apply(null, slice as unknown as number[]);
+    // slice is capped at CHUNK (0x8000) elements, well under the argument-count
+    // limit, so the spread is safe and needs no array-like cast.
+    bin += String.fromCharCode(...slice);
   }
   return btoa(bin);
 }
@@ -190,6 +201,10 @@ export function fromBase64(b64: string): Uint8Array {
 export function constantTimeEquals(a: Uint8Array, b: Uint8Array): boolean {
   if (a.length !== b.length) return false;
   let d = 0;
-  for (let i = 0; i < a.length; i++) d |= a[i] ^ b[i];
+  // Equal lengths + bounded i mean both reads are always defined. Use a
+  // compile-time `as number` (fully erased at runtime to `a[i] ^ b[i]`)
+  // rather than `?? 0`, which would emit a conditional and break the
+  // constant-time guarantee.
+  for (let i = 0; i < a.length; i++) d |= (a[i] as number) ^ (b[i] as number);
   return d === 0;
 }

--- a/src/services/dappConnect/SessionStore.ts
+++ b/src/services/dappConnect/SessionStore.ts
@@ -7,7 +7,7 @@
  */
 
 import type { DAppSession } from './types';
-import { SessionStatus } from './types';
+import type { SessionStatus } from './types';
 
 const STORAGE_KEY = 'qrlconnect:sessions';
 const SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000;

--- a/src/services/dappConnect/SocketClient.ts
+++ b/src/services/dappConnect/SocketClient.ts
@@ -68,8 +68,9 @@ export class SocketClient {
       // Auto-rejoin only after the initial join has succeeded. The initial
       // join is driven by the caller via joinChannel(); otherwise we'd race
       // with it here and emit join_channel twice on the first connect.
-      if (this.channelId && this.hasJoinedOnce) {
-        this.emitJoinChannel(this.channelId)
+      const socket = this.socket;
+      if (this.channelId && this.hasJoinedOnce && socket) {
+        this.emitJoinChannel(socket, this.channelId)
           .then(({ bufferedMessages, terminated }) => {
             if (terminated) {
               // The dApp explicitly closed the channel while we were away.
@@ -111,22 +112,22 @@ export class SocketClient {
     channelId: string
   ): Promise<{ bufferedMessages: unknown[]; channelPublicKey: string | null; terminated: boolean }> {
     this.channelId = channelId;
-    if (!this.socket) {
+    const socket = this.socket;
+    if (!socket) {
       throw new Error('Socket not initialised; call connect() before joinChannel()');
     }
-    if (!this.socket.connected) {
+    if (!socket.connected) {
       // Match the socket.io `timeout` above; a shorter wait here would
       // reject joinChannel while the underlying socket is still legitimately
       // trying to connect, corrupting our session state.
-      await this.waitForConnect(20000);
+      await this.waitForConnect(socket, 20000);
     }
-    const result = await this.emitJoinChannel(channelId);
+    const result = await this.emitJoinChannel(socket, channelId);
     this.hasJoinedOnce = true;
     return result;
   }
 
-  private waitForConnect(timeoutMs: number): Promise<void> {
-    const socket = this.socket!;
+  private waitForConnect(socket: Socket, timeoutMs: number): Promise<void> {
     return new Promise((resolve, reject) => {
       const cleanup = () => {
         clearTimeout(timer);
@@ -151,10 +152,11 @@ export class SocketClient {
   }
 
   private emitJoinChannel(
+    socket: Socket,
     channelId: string
   ): Promise<{ bufferedMessages: unknown[]; channelPublicKey: string | null; terminated: boolean }> {
     return new Promise((resolve, reject) => {
-      this.socket!.emit(
+      socket.emit(
         'join_channel',
         { channelId, clientType: 'wallet' },
         (response: {

--- a/src/services/dappConnect/base45.ts
+++ b/src/services/dappConnect/base45.ts
@@ -20,27 +20,32 @@ const DECODE: Int8Array = (() => {
  */
 function decodeChar(charCode: number): number {
   if (charCode < 0 || charCode >= 128) return -1;
-  return DECODE[charCode];
+  // charCode is guaranteed in-bounds by the guard above; `?? -1` only
+  // satisfies the index-access checker and never actually fires.
+  return DECODE[charCode] ?? -1;
 }
 
 export function base45Encode(bytes: Uint8Array): string {
   const n = bytes.length;
   let out = '';
   let i = 0;
+  // `i`/`i+1` are kept in-bounds by the loop condition, so the `?? 0`
+  // fallbacks never fire; charAt() returns '' for any out-of-range index
+  // (also impossible here since c0..c2 are mod-45 bounded).
   while (i + 2 <= n) {
-    const v = (bytes[i] << 8) | bytes[i + 1];
+    const v = ((bytes[i] ?? 0) << 8) | (bytes[i + 1] ?? 0);
     const c2 = Math.floor(v / 2025);
     const r = v - c2 * 2025;
     const c1 = Math.floor(r / 45);
     const c0 = r - c1 * 45;
-    out += ALPHABET[c0] + ALPHABET[c1] + ALPHABET[c2];
+    out += ALPHABET.charAt(c0) + ALPHABET.charAt(c1) + ALPHABET.charAt(c2);
     i += 2;
   }
   if (i < n) {
-    const v = bytes[i];
+    const v = bytes[i] ?? 0;
     const c1 = Math.floor(v / 45);
     const c0 = v - c1 * 45;
-    out += ALPHABET[c0] + ALPHABET[c1];
+    out += ALPHABET.charAt(c0) + ALPHABET.charAt(c1);
   }
   return out;
 }

--- a/src/services/dappConnect/qrUri.ts
+++ b/src/services/dappConnect/qrUri.ts
@@ -22,10 +22,6 @@ export const CID_LEN = 16;
 export const FP_LEN = 32;
 export const BLOB_LEN = 4 + CID_LEN + FP_LEN; // 52
 
-function bs(u: Uint8Array): BufferSource {
-  return u as unknown as BufferSource;
-}
-
 /**
  * Compute fp = SHA-256("pq-fp/v2" || cid || pk). Used by the wallet to
  * verify the PK the relay served matches the commitment in the QR.
@@ -41,11 +37,13 @@ export async function computeFingerprint(
   if (!c || !c.subtle) {
     throw new Error('qrUri: WebCrypto SubtleCrypto is not available');
   }
+  // Freshly allocated, so already ArrayBuffer-backed (Uint8Array<ArrayBuffer>),
+  // which satisfies WebCrypto's BufferSource without any cast.
   const buf = new Uint8Array(FP_LABEL.length + cid.length + pk.length);
   buf.set(FP_LABEL, 0);
   buf.set(cid, FP_LABEL.length);
   buf.set(pk, FP_LABEL.length + cid.length);
-  const digest = await c.subtle.digest('SHA-256', bs(buf));
+  const digest = await c.subtle.digest('SHA-256', buf);
   return new Uint8Array(digest);
 }
 
@@ -53,7 +51,11 @@ export async function computeFingerprint(
 export function fingerprintEquals(a: Uint8Array, b: Uint8Array): boolean {
   if (a.length !== b.length) return false;
   let diff = 0;
-  for (let i = 0; i < a.length; i++) diff |= a[i] ^ b[i];
+  // Equal lengths + bounded i mean both reads are always defined. Use a
+  // compile-time `as number` (fully erased at runtime to `a[i] ^ b[i]`)
+  // rather than `?? 0`, which would emit a conditional and break the
+  // constant-time guarantee.
+  for (let i = 0; i < a.length; i++) diff |= (a[i] as number) ^ (b[i] as number);
   return diff === 0;
 }
 
@@ -137,7 +139,7 @@ export function cidToString(cid: Uint8Array): string {
   }
   let hex = '';
   for (let i = 0; i < CID_LEN; i++) {
-    hex += cid[i].toString(16).padStart(2, '0');
+    hex += (cid[i] ?? 0).toString(16).padStart(2, '0');
   }
   return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 }

--- a/src/stores/dappConnectStore.ts
+++ b/src/stores/dappConnectStore.ts
@@ -139,7 +139,7 @@ class DAppConnectStore {
     );
 
     if (this.pendingRequests.length > 0) {
-      this.currentApproval = this.pendingRequests[0];
+      this.currentApproval = this.pendingRequests[0] ?? null;
     } else {
       this.currentApproval = null;
       this.approvalModalOpen = false;

--- a/src/stores/nftStore.ts
+++ b/src/stores/nftStore.ts
@@ -7,11 +7,12 @@ import {
 } from "mobx";
 import type { TransactionReceipt } from "@theqrl/web3";
 import { log } from "@/utils";
+import { getErrorMessage } from "@/utils/errors";
 import { getQrlWeb3 } from "@/utils/web3";
 import { QRL_PROVIDER } from "@/config";
 import { StorageUtil } from "@/utils/storage";
 import { deriveHexSeedAsync } from "@/utils/crypto";
-import { NFTInterface } from "@/constants";
+import type { NFTInterface } from "@/constants";
 import { erc721ABI } from "@/abi/ERC721ABI";
 import { erc1155ABI } from "@/abi/ERC1155ABI";
 import {
@@ -19,6 +20,11 @@ import {
   isErc721Owner,
   nftKey,
 } from "@/utils/web3/nft";
+import {
+  contractMethods,
+  type Erc721Methods,
+  type Erc1155Methods,
+} from "@/utils/web3/contractFactory";
 import { discoverNFTs } from "@/utils/web3";
 import type QrlStore from "./qrlStore";
 import type TokenStore from "./tokenStore";
@@ -278,19 +284,21 @@ class NftStore {
 
       let data: string;
       if (nft.standard === "ERC721") {
-        const contract = new web3.qrl.Contract(
-          erc721ABI as any,
+        const methods = contractMethods<Erc721Methods>(
+          web3,
+          erc721ABI,
           nft.contractAddress,
         );
-        data = (contract.methods as any)
+        data = methods
           .safeTransferFrom(acc.address, toAddress, nft.tokenId)
           .encodeABI();
       } else {
-        const contract = new web3.qrl.Contract(
-          erc1155ABI as any,
+        const methods = contractMethods<Erc1155Methods>(
+          web3,
+          erc1155ABI,
           nft.contractAddress,
         );
-        data = (contract.methods as any)
+        data = methods
           .safeTransferFrom(
             acc.address,
             toAddress,
@@ -379,16 +387,17 @@ class NftStore {
         });
 
       return true;
-    } catch (error: any) {
+    } catch (error) {
+      const message = getErrorMessage(error);
       runInAction(() => {
         this.qrlStore.transactionStatus = {
           state: "failed",
           txHash: null,
           receipt: null,
-          error: `NFT transfer failed: ${error.message || error}`,
+          error: `NFT transfer failed: ${message}`,
           pendingDetails: null,
         };
-        log(`NFT transfer preparation failed: ${error}`);
+        log(`NFT transfer preparation failed: ${message}`);
       });
       return false;
     }

--- a/src/stores/qrlStore.ts
+++ b/src/stores/qrlStore.ts
@@ -1,8 +1,10 @@
 import { QRL_PROVIDER, EXPLORER_BASE, getPendingTxApiUrl } from "@/config";
 import { deriveHexSeedAsync } from "@/utils/crypto";
-import { StorageUtil, AccountListItem, AccountSource } from "@/utils/storage";
+import type { AccountListItem, AccountSource } from "@/utils/storage";
+import { StorageUtil } from "@/utils/storage";
 import { log } from "@/utils";
 import { getQrlWeb3 } from "@/utils/web3";
+import { getErrorMessage, isProviderRpcError } from "@/utils/errors";
 import { QRL_TX_POLLING_CONFIG } from "@/utils/web3/txPolling";
 import type { TransactionReceipt, Web3QRLInterface } from "@theqrl/web3";
 import { action, computed, makeAutoObservable, observable, runInAction } from "mobx";
@@ -63,9 +65,13 @@ export function applyFeeLevel(baseGasPrice: bigint, level: FeeLevel) {
   };
 }
 
-// Interface for the extension provider (adjust based on actual provider methods)
-interface ExtensionProvider {
-  request: (args: { method: string; params?: any[] | object }) => Promise<any>;
+// EIP-1193 provider surface the wallet relies on. Exported so the extension
+// connection layer shares one honest type instead of re-declaring `any`.
+export interface ExtensionProvider {
+  request: <T = unknown>(args: {
+    method: string;
+    params?: unknown[] | object;
+  }) => Promise<T>;
   // Add other methods if needed, e.g., for event handling
 }
 
@@ -479,7 +485,8 @@ class QrlStore {
         }
 
         const pendingTx = data.transactions.find(
-          (tx: any) => tx.hash && tx.hash.toLowerCase() === txHash.toLowerCase()
+          (tx: { hash?: string }) =>
+            tx.hash && tx.hash.toLowerCase() === txHash.toLowerCase()
         );
 
         if (pendingTx) {
@@ -536,7 +543,8 @@ class QrlStore {
     const baseGasPrice = await this.qrlInstance?.getGasPrice();
     if (!baseGasPrice) return "0";
     const { maxFeePerGas } = applyFeeLevel(baseGasPrice, feeLevel);
-    return this._utils!.fromPlanck(BigInt(gasLimit) * maxFeePerGas, "quanta");
+    const utils = this._utils ?? (await getQrlWeb3()).utils;
+    return utils.fromPlanck(BigInt(gasLimit) * maxFeePerGas, "quanta");
   }
 
   // Refactored signAndSendTransaction
@@ -557,15 +565,16 @@ class QrlStore {
       // Fetch current gas price and apply fee level multiplier
       const baseGasPrice = (await this.qrlInstance?.getGasPrice()) ?? BigInt(1000000000);
       const { maxFeePerGas, maxPriorityFeePerGas } = applyFeeLevel(baseGasPrice, feeLevel);
+      const utils = this._utils ?? (await getQrlWeb3()).utils;
 
       const transactionObject = {
         from,
         to,
-        value: this._utils!.toPlanck(value, "quanta"),
+        value: utils.toPlanck(value, "quanta"),
         gas: 21000, // Standard gas limit for native transfer
         type: '0x2',
-        maxFeePerGas: this._utils!.toHex(maxFeePerGas),
-        maxPriorityFeePerGas: this._utils!.toHex(maxPriorityFeePerGas),
+        maxFeePerGas: utils.toHex(maxFeePerGas),
+        maxPriorityFeePerGas: utils.toHex(maxPriorityFeePerGas),
         nonce: nonce,
       };
       // Run the MLDSA87 derivation in the crypto worker so the 50–300 ms
@@ -604,7 +613,7 @@ class QrlStore {
         });
       }).on('receipt', (receipt: TransactionReceipt) => {
         runInAction(() => {
-          const txHashString = this._utils!.bytesToHex(receipt.transactionHash);
+          const txHashString = utils.bytesToHex(receipt.transactionHash);
           this.transactionStatus = {
             state: 'confirmed',
             txHash: txHashString,
@@ -634,17 +643,18 @@ class QrlStore {
       // but for this pattern, we primarily manage state within the store.
       // return promiEvent;
 
-    } catch (error: any) {
+    } catch (error) {
       // Catch signing errors or other issues before sending
+      const message = getErrorMessage(error);
       runInAction(() => {
         this.transactionStatus = {
           state: 'failed',
           txHash: null,
           receipt: null,
-          error: `Transaction preparation failed: ${error.message || error}`,
+          error: `Transaction preparation failed: ${message}`,
           pendingDetails: null,
         };
-        log(`Transaction preparation failed: ${error}`);
+        log(`Transaction preparation failed: ${message}`);
       });
     }
   }
@@ -676,6 +686,8 @@ class QrlStore {
 
     log(`Starting receipt polling for ${txHash}`);
 
+    const utils = this._utils ?? (await getQrlWeb3()).utils;
+
     // If a previous poll was somehow left running, kill it before starting
     // a fresh one so we never have two intervals racing into transactionStatus.
     this.cancelReceiptPoller();
@@ -701,7 +713,7 @@ class QrlStore {
           runInAction(() => {
             // Double-check state again before updating
             if (this.transactionStatus.state === 'pending' && this.transactionStatus.txHash === txHash) {
-              const txHashString = this._utils!.bytesToHex(receipt.transactionHash);
+              const txHashString = utils.bytesToHex(receipt.transactionHash);
               this.transactionStatus = {
                 state: 'confirmed',
                 txHash: txHashString,
@@ -732,9 +744,10 @@ class QrlStore {
           });
         }
         // If receipt is null and attempts < maxAttempts, continue polling
-      } catch (error: any) {
+      } catch (error) {
+        const message = getErrorMessage(error);
         console.error(`Error polling for receipt ${txHash}:`, error);
-        log(`Error polling for receipt ${txHash}: ${error.message || error}`);
+        log(`Error polling for receipt ${txHash}: ${message}`);
         this.cancelReceiptPoller();
         // Mark as failed on error
         runInAction(() => {
@@ -743,7 +756,7 @@ class QrlStore {
               state: 'failed',
               txHash: txHash,
               receipt: null,
-              error: `Error checking transaction status: ${error.message || error}`,
+              error: `Error checking transaction status: ${message}`,
               pendingDetails: null,
             };
           }
@@ -780,9 +793,10 @@ class QrlStore {
       });
 
       // --- Use 18 decimals via "quanta" unit ---
+      const utils = this._utils ?? (await getQrlWeb3()).utils;
       let valueBaseUnit: string | bigint; // toPlanck returns string or bigint
       try {
-        valueBaseUnit = this._utils!.toPlanck(valueEther, "quanta"); // Use "quanta" for 18 decimals
+        valueBaseUnit = utils.toPlanck(valueEther, "quanta"); // Use "quanta" for 18 decimals
       } catch (calcError) {
         console.error("Error calculating base unit value with toPlanck:", calcError);
         throw new Error("Could not calculate transaction value.");
@@ -831,21 +845,22 @@ class QrlStore {
         throw new Error("Extension did not return a valid transaction hash.");
       }
 
-    } catch (error: any) {
+    } catch (error) {
       console.error("Error sending transaction via extension:", error);
-      log(`Error sending via extension: ${error.message || error}`);
+      const message = getErrorMessage(error);
+      log(`Error sending via extension: ${message}`);
       runInAction(() => {
         // Check for user rejection code specifically if the provider follows EIP-1193 errors
-        const userRejected = error.code === 4001;
-        const isCalcError = error.message === "Could not calculate transaction value." || error.message === "Invalid amount input";
+        const userRejected = isProviderRpcError(error) && error.code === 4001;
+        const isCalcError = message === "Could not calculate transaction value." || message === "Invalid amount input";
         this.transactionStatus = {
           ...this.transactionStatus,
           state: 'failed',
           error: userRejected
             ? 'Transaction rejected in extension.'
             : isCalcError
-              ? error.message // Show calculation error
-              : (error.message || 'Transaction failed in extension.')
+              ? message // Show calculation error
+              : (message || 'Transaction failed in extension.')
         };
       });
     }

--- a/src/stores/tokenStore.ts
+++ b/src/stores/tokenStore.ts
@@ -2,12 +2,14 @@ import { QRL_PROVIDER } from "@/config";
 import { deriveHexSeedAsync } from "@/utils/crypto";
 import { StorageUtil } from "@/utils/storage";
 import { log } from "@/utils";
+import { getErrorMessage } from "@/utils/errors";
 import type { TransactionReceipt } from "@theqrl/web3";
 import { getQrlWeb3 } from "@/utils/web3";
 import { action, computed, makeAutoObservable, observable, runInAction } from "mobx";
 import { customERC20FactoryABI } from "@/abi/CustomERC20FactoryABI";
 import { fetchTokenInfo, fetchBalance, discoverTokens, mergeTokenLists } from "@/utils/web3";
-import { TokenInterface, KNOWN_TOKEN_LIST } from "@/constants";
+import type { TokenInterface} from "@/constants";
+import { KNOWN_TOKEN_LIST } from "@/constants";
 import { customERC20ABI as CustomERC20ABI } from "@/abi/CustomERC20ABI";
 const formatUnits = (value: bigint | string | unknown, decimals: number): string => {
   let v = BigInt(value as string | bigint);
@@ -448,16 +450,17 @@ class TokenStore {
         });
 
       return true;
-    } catch (error: any) {
+    } catch (error) {
+      const message = getErrorMessage(error);
       runInAction(() => {
         this.qrlStore.transactionStatus = {
           state: "failed",
           txHash: null,
           receipt: null,
-          error: `Token transfer failed: ${error.message || error}`,
+          error: `Token transfer failed: ${message}`,
           pendingDetails: null,
         };
-        log(`Token transfer preparation failed: ${error}`);
+        log(`Token transfer preparation failed: ${message}`);
       });
       return false;
     }
@@ -486,7 +489,7 @@ class TokenStore {
       web3.qrl.wallet?.add(seed);
       web3.qrl.transactionConfirmationBlocks = 1;
 
-      const contractAddress = import.meta.env.VITE_CUSTOMERC20FACTORY_ADDRESS || "";
+      const contractAddress = import.meta.env['VITE_CUSTOMERC20FACTORY_ADDRESS'] || "";
 
       if (!contractAddress) {
         throw new Error(

--- a/src/utils/crypto/cryptoWorkerClient.ts
+++ b/src/utils/crypto/cryptoWorkerClient.ts
@@ -140,8 +140,12 @@ function acquireWorker(): PooledWorker {
 
   // Pool is full and all busy - shouldn't happen with proper await usage
   // Fall back to first worker (will queue behind current operation)
-  workerPool[0].busy = true;
-  return workerPool[0];
+  const fallback = workerPool[0];
+  if (!fallback) {
+    throw new Error('cryptoWorkerClient: worker pool unexpectedly empty');
+  }
+  fallback.busy = true;
+  return fallback;
 }
 
 /**

--- a/src/utils/crypto/walletEncryption.ts
+++ b/src/utils/crypto/walletEncryption.ts
@@ -62,7 +62,7 @@ const textDecoder = new TextDecoder();
 function bytesToHex(bytes: Uint8Array): string {
   let hex = '';
   for (let i = 0; i < bytes.length; i++) {
-    hex += bytes[i].toString(16).padStart(2, '0');
+    hex += (bytes[i] ?? 0).toString(16).padStart(2, '0');
   }
   return hex;
 }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,0 +1,38 @@
+/**
+ * Error-narrowing helpers for `catch (error)` blocks.
+ *
+ * With `strict` (and `useUnknownInCatchVariables`), caught values are typed
+ * `unknown`. These helpers replace the previous `catch (error: any)` pattern
+ * with honest narrowing: derive a display message, or guard the EIP-1193
+ * provider error shape (`{ code?, message? }`) before reading `code`/`message`.
+ */
+
+/** Best-effort human-readable message from an unknown thrown value. */
+export function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof (error as { message: unknown }).message === "string"
+  ) {
+    return (error as { message: string }).message;
+  }
+  return String(error);
+}
+
+/** EIP-1193 provider error: carries a numeric `code` (e.g. 4001 = user reject). */
+export interface ProviderRpcError {
+  code?: number;
+  message?: string;
+}
+
+/** Type guard for an EIP-1193-shaped error before reading `code`/`message`. */
+export function isProviderRpcError(error: unknown): error is ProviderRpcError {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    ("code" in error || "message" in error)
+  );
+}

--- a/src/utils/extension/extensionConnection.ts
+++ b/src/utils/extension/extensionConnection.ts
@@ -1,5 +1,7 @@
 import { QRL_WEB3_WALLET_PROVIDER_INFO } from "@/constants";
 import type { AccountSource } from "@/utils/storage";
+import type { ExtensionProvider } from "@/stores/qrlStore";
+import { getErrorMessage, isProviderRpcError } from "@/utils/errors";
 
 // EIP-6963 types (simplified)
 interface EIP6963ProviderInfo {
@@ -11,7 +13,7 @@ interface EIP6963ProviderInfo {
 
 interface EIP6963ProviderDetail {
   info: EIP6963ProviderInfo;
-  provider: any; // Adjust the type according to the actual provider interface
+  provider: ExtensionProvider;
 }
 
 interface EIP6963AnnounceProviderEvent extends CustomEvent {
@@ -57,7 +59,7 @@ function findQrlProvider(): Promise<EIP6963ProviderDetail | null> {
 // Modify the function signature to accept setActiveAccount and setExtensionProvider
 async function connectToExtension(
   setActiveAccount: (address: string, source?: AccountSource) => Promise<void>,
-  setExtensionProvider: (provider: any | null) => void // Add the new setter
+  setExtensionProvider: (provider: ExtensionProvider | null) => void // Add the new setter
 ): Promise<string[] | null> {
   // Attempt to find the provider via EIP-6963
   const foundProviderDetail = await findQrlProvider();
@@ -74,10 +76,11 @@ async function connectToExtension(
   try {
     // Request account access using the QRL-specific method
     console.log("Attempting to connect using qrl_requestAccounts...");
-    const accounts = await provider.request({ method: 'qrl_requestAccounts' });
+    const accounts = await provider.request<string[]>({ method: 'qrl_requestAccounts' });
 
     if (accounts && accounts.length > 0) {
       const firstAccount = accounts[0];
+      if (!firstAccount) return null; // length > 0 guarantees this; satisfies the index checker
       console.log("Connected to extension with accounts:", accounts);
 
       // Call the passed-in setActiveAccount function
@@ -94,21 +97,20 @@ async function connectToExtension(
       setExtensionProvider(null); // Clear provider if no accounts approved
       return null;
     }
-  } catch (error: any) {
+  } catch (error) {
     setExtensionProvider(null); // Clear provider on error
     // Handle errors, such as user rejection
-    if (error.code === 4001) { // EIP-1193 user rejection error
+    const code = isProviderRpcError(error) ? error.code : undefined;
+    if (code === 4001) { // EIP-1193 user rejection error
       console.log('User rejected connection request.');
       alert('Connection request rejected.');
+    } else if (code === -32601) {
+      // Method not found, although we expect qrl_requestAccounts to exist now
+      console.error("RPC Error: Method not found", error);
+      alert(`RPC Error: ${getErrorMessage(error)}`);
     } else {
-      // Check for the specific method not found error, although we expect qrl_requestAccounts to exist now
-      if (error.code === -32601) {
-         console.error("RPC Error: Method not found", error);
-         alert(`RPC Error: ${error.message}`);
-      } else {
-        console.error("Error connecting to extension:", error);
-        alert(`Error connecting to extension: ${error.message || error}`);
-      }
+      console.error("Error connecting to extension:", error);
+      alert(`Error connecting to extension: ${getErrorMessage(error)}`);
     }
     return null;
   }

--- a/src/utils/formatting/balance.ts
+++ b/src/utils/formatting/balance.ts
@@ -117,7 +117,7 @@ export const formatBalance = (
 
     if (useThousandSeparator) {
         const parts = formatted.split('.');
-        parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+        parts[0] = (parts[0] ?? '').replace(/\B(?=(\d{3})+(?!\d))/g, ',');
         formatted = parts.join('.');
     }
 

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -2,7 +2,7 @@
  * Navigation utilities with native app awareness
  */
 
-import { NavigateFunction } from "react-router-dom";
+import type { NavigateFunction } from "react-router-dom";
 import { isInNativeApp, openNativeSettings } from "@/utils/nativeApp";
 import { ROUTES } from "@/router/router";
 

--- a/src/utils/react/withSuspense.tsx
+++ b/src/utils/react/withSuspense.tsx
@@ -1,4 +1,5 @@
-import { ComponentType, Suspense } from "react";
+import type { ComponentType} from "react";
+import { Suspense } from "react";
 import { Loading } from "@/components/UI/Loading";
 
 const withSuspense = <P extends object>(

--- a/src/utils/signing/__tests__/signing.test.ts
+++ b/src/utils/signing/__tests__/signing.test.ts
@@ -110,7 +110,7 @@ describe('signMessage / verifyMessage round-trip', () => {
     const result = signMessage('0xdeadbeef', seed, { randomized: false });
 
     const sigBytes = hexToBytes(result.signature);
-    sigBytes[0] ^= 0x01;
+    sigBytes[0] = (sigBytes[0] ?? 0) ^ 0x01;
     const ok = verifyMessage({
       signature: sigBytes,
       publicKey: result.publicKey,
@@ -278,7 +278,7 @@ describe('signTypedData / verifyTypedData round-trip', () => {
     const result = signTypedData(payload, seed, { randomized: false });
 
     const tampered = TYPED_PAYLOAD(signer);
-    tampered.message.issuedAt = '1747699201';
+    tampered.message['issuedAt'] = '1747699201';
 
     expect(verifyTypedData({
       signature: result.signature,

--- a/src/utils/signing/typedData.ts
+++ b/src/utils/signing/typedData.ts
@@ -96,7 +96,9 @@ function collectDependencies(primary: string, types: TypeMap): Set<string> {
     }
     if (visited.has(name)) return;
     visited.add(name);
-    for (const f of types[name]) {
+    const fields = types[name];
+    if (!fields) return; // visit() is only reached for types known to exist
+    for (const f of fields) {
       const base = baseTypeName(f.type);
       if (Object.prototype.hasOwnProperty.call(types, base)) {
         visit(base, [...path, name]);
@@ -145,6 +147,12 @@ export function encodeType(primary: string, types: TypeMap): string {
   return [primary, ...others]
     .map((name) => {
       const fields = types[name];
+      if (!fields) {
+        // Every dependency is collected from `types`, so this is unreachable;
+        // throw rather than silently emit a wrong encodeType (which would
+        // change the type hash and thus the signature).
+        throw new Error(`encodeType: missing type definition for ${name}`);
+      }
       const inner = fields.map((f) => `${f.type} ${f.name}`).join(',');
       return `${name}(${inner})`;
     })
@@ -322,7 +330,7 @@ const RESERVED_DOMAIN_FIELDS: Record<string, string> = {
 };
 
 function validateDomainTypes(types: TypeMap): void {
-  const def = types.QRLDomain;
+  const def = types['QRLDomain'];
   if (!def) throw new Error('QRLDomain type is required');
   let hasName = false;
   for (const f of def) {

--- a/src/utils/storage/storage.ts
+++ b/src/utils/storage/storage.ts
@@ -1,5 +1,5 @@
 import { QRL_PROVIDER } from "@/config";
-import { TokenInterface, NFTInterface } from "@/constants";
+import type { TokenInterface, NFTInterface } from "@/constants";
 import { isInNativeApp } from "@/utils/nativeApp";
 
 const ACTIVE_PAGE_IDENTIFIER = "ACTIVE_PAGE";
@@ -283,7 +283,7 @@ class StorageUtil {
    */
   static async getAccountList(blockchain: string): Promise<AccountListItem[]> {
     const blockChainAccountListIdentifier = `${blockchain}_${ACCOUNT_LIST_IDENTIFIER}`;
-    const data = this.getItem<any>(blockChainAccountListIdentifier);
+    const data = this.getItem<unknown>(blockChainAccountListIdentifier);
 
     if (!data) {
       return [];

--- a/src/utils/web3/contractFactory.ts
+++ b/src/utils/web3/contractFactory.ts
@@ -1,0 +1,73 @@
+/**
+ * Typed @theqrl/web3 contract adapter.
+ *
+ * @theqrl/web3's `Contract` ABI generics do not resolve the dynamically
+ * generated `contract.methods.<abiMethod>` surface from a runtime ABI literal
+ * (the inferred `methods` type is an opaque record), so every NFT/token call
+ * site used to reach for `contract.methods as any`. This module confines that
+ * gap to ONE honest, narrowly-typed seam: the ABI literal is asserted to the
+ * library's own `ContractAbi` type and `methods` is narrowed from `unknown` to
+ * a hand-written interface. No `any`, no double assertions: every consumer
+ * stays laundering-free without an ESLint escape hatch.
+ *
+ * See CLAUDE.md and the workspace memory note `feedback_theqrl_web3_contract_typings`.
+ */
+
+import type { default as Web3Type, ContractAbi } from "@theqrl/web3";
+
+/** A web3 method call that resolves to `T` when `.call()` is awaited. */
+export interface CallReturning<T> {
+  call(): Promise<T>;
+}
+
+/** A web3 method call whose calldata is encoded for inclusion in a tx. */
+export interface EncodeAble {
+  encodeABI(): string;
+}
+
+/** ERC-165 introspection. */
+export interface Erc165Methods {
+  supportsInterface(interfaceId: string): CallReturning<boolean>;
+}
+
+/** Subset of ERC-721 the wallet actually invokes. */
+export interface Erc721Methods {
+  name(): CallReturning<string>;
+  symbol(): CallReturning<string>;
+  balanceOf(owner: string): CallReturning<bigint | string>;
+  tokenOfOwnerByIndex(owner: string, index: bigint): CallReturning<bigint | string>;
+  ownerOf(tokenId: string): CallReturning<string>;
+  tokenURI(tokenId: string): CallReturning<string>;
+  safeTransferFrom(from: string, to: string, tokenId: string): EncodeAble;
+}
+
+/** Subset of ERC-1155 the wallet actually invokes. */
+export interface Erc1155Methods {
+  balanceOf(account: string, id: string): CallReturning<bigint | string>;
+  uri(id: string): CallReturning<string>;
+  safeTransferFrom(
+    from: string,
+    to: string,
+    id: string,
+    amount: string,
+    data: string,
+  ): EncodeAble;
+}
+
+/**
+ * Construct a contract from an ABI + address and return its `methods` object
+ * narrowed to the caller-supplied typed interface. The ABI cast is the only
+ * sanctioned type-laundering in the codebase and is intentionally local to
+ * this module.
+ */
+export function contractMethods<TMethods>(
+  web3: Web3Type,
+  // ABI JSON literals don't structurally satisfy @theqrl/web3's AbiFragment[]
+  // inference, so accept them opaquely and assert to the library's own type.
+  abi: unknown,
+  address: string,
+): TMethods {
+  const contract = new web3.qrl.Contract(abi as ContractAbi, address);
+  const methods: unknown = contract.methods;
+  return methods as TMethods;
+}

--- a/src/utils/web3/nft.ts
+++ b/src/utils/web3/nft.ts
@@ -1,5 +1,11 @@
 import type { default as Web3Type } from "@theqrl/web3";
 import { getQrlWeb3 } from "./web3Lazy";
+import {
+  contractMethods,
+  type Erc165Methods,
+  type Erc721Methods,
+  type Erc1155Methods,
+} from "./contractFactory";
 import { erc165ABI, ERC165_INTERFACE_IDS } from "@/abi/ERC165ABI";
 import { erc721ABI } from "@/abi/ERC721ABI";
 import { erc1155ABI } from "@/abi/ERC1155ABI";
@@ -44,8 +50,8 @@ async function safeSupportsInterface(
   interfaceId: string,
 ): Promise<boolean> {
   try {
-    const contract = new web3.qrl.Contract(erc165ABI as any, contractAddress);
-    const result = await (contract.methods as any).supportsInterface(interfaceId).call();
+    const methods = contractMethods<Erc165Methods>(web3, erc165ABI, contractAddress);
+    const result = await methods.supportsInterface(interfaceId).call();
     return Boolean(result);
   } catch {
     return false;
@@ -87,17 +93,16 @@ export async function fetchNftCollectionInfo(
   const web3 = new Web3(new Web3.providers.HttpProvider(rpcUrl));
 
   if (standard === "ERC721") {
-    const contract = new web3.qrl.Contract(erc721ABI as any, contractAddress);
-    const methods = contract.methods as any;
+    const methods = contractMethods<Erc721Methods>(web3, erc721ABI, contractAddress);
     let name: string | undefined;
     let symbol: string | undefined;
     try {
-      name = (await methods.name().call()) as string;
+      name = await methods.name().call();
     } catch {
       // Optional in ERC-721 — some implementations omit it.
     }
     try {
-      symbol = (await methods.symbol().call()) as string;
+      symbol = await methods.symbol().call();
     } catch {
       // Optional in ERC-721 — some implementations omit it.
     }
@@ -132,19 +137,16 @@ export async function fetchOwned721Ids(
   );
   if (!supportsEnumerable) return null;
 
-  const contract = new web3.qrl.Contract(erc721ABI as any, contractAddress);
-  const methods = contract.methods as any;
+  const methods = contractMethods<Erc721Methods>(web3, erc721ABI, contractAddress);
   const checksum = web3.utils.toChecksumAddress(ownerAddress);
-  const balanceRaw = (await methods.balanceOf(checksum).call()) as bigint | string;
+  const balanceRaw = await methods.balanceOf(checksum).call();
   const balance = BigInt(balanceRaw);
   if (balance === 0n) return [];
 
   const ids: string[] = [];
   for (let i = 0n; i < balance; i++) {
     try {
-      const id = (await methods
-        .tokenOfOwnerByIndex(checksum, i)
-        .call()) as bigint | string;
+      const id = await methods.tokenOfOwnerByIndex(checksum, i).call();
       ids.push(BigInt(id).toString());
     } catch (err) {
       console.error(`tokenOfOwnerByIndex(${i}) failed:`, err);
@@ -164,8 +166,8 @@ export async function isErc721Owner(
   const { default: Web3 } = await getQrlWeb3();
   const web3 = new Web3(new Web3.providers.HttpProvider(rpcUrl));
   try {
-    const contract = new web3.qrl.Contract(erc721ABI as any, contractAddress);
-    const actual = (await (contract.methods as any).ownerOf(tokenId).call()) as string;
+    const methods = contractMethods<Erc721Methods>(web3, erc721ABI, contractAddress);
+    const actual = await methods.ownerOf(tokenId).call();
     return actual.toLowerCase() === web3.utils.toChecksumAddress(ownerAddress).toLowerCase();
   } catch {
     return false;
@@ -181,9 +183,9 @@ export async function fetchErc1155Balance(
 ): Promise<bigint> {
   const { default: Web3 } = await getQrlWeb3();
   const web3 = new Web3(new Web3.providers.HttpProvider(rpcUrl));
-  const contract = new web3.qrl.Contract(erc1155ABI as any, contractAddress);
+  const methods = contractMethods<Erc1155Methods>(web3, erc1155ABI, contractAddress);
   const checksum = web3.utils.toChecksumAddress(ownerAddress);
-  const raw = (await (contract.methods as any).balanceOf(checksum, tokenId).call()) as bigint | string;
+  const raw = await methods.balanceOf(checksum, tokenId).call();
   return BigInt(raw);
 }
 
@@ -202,12 +204,12 @@ export async function fetchTokenUri(
   const web3 = new Web3(new Web3.providers.HttpProvider(rpcUrl));
   try {
     if (standard === "ERC721") {
-      const contract = new web3.qrl.Contract(erc721ABI as any, contractAddress);
-      const uri = (await (contract.methods as any).tokenURI(tokenId).call()) as string;
+      const methods = contractMethods<Erc721Methods>(web3, erc721ABI, contractAddress);
+      const uri = await methods.tokenURI(tokenId).call();
       return uri || null;
     }
-    const contract = new web3.qrl.Contract(erc1155ABI as any, contractAddress);
-    let uri = (await (contract.methods as any).uri(tokenId).call()) as string;
+    const methods = contractMethods<Erc1155Methods>(web3, erc1155ABI, contractAddress);
+    let uri = await methods.uri(tokenId).call();
     if (uri && uri.includes("{id}")) {
       const hexId = BigInt(tokenId).toString(16).padStart(64, "0");
       uri = uri.replace(/\{id\}/g, hexId);

--- a/src/utils/web3/nftDiscovery.ts
+++ b/src/utils/web3/nftDiscovery.ts
@@ -1,5 +1,5 @@
 import { getNFTDiscoveryApiUrl } from "@/config";
-import { NFTInterface } from "@/constants";
+import type { NFTInterface } from "@/constants";
 import { log } from "@/utils";
 
 // One row of the zondscan /api/address/:addr/nfts response. Shape mirrors

--- a/src/utils/web3/tokenDiscovery.ts
+++ b/src/utils/web3/tokenDiscovery.ts
@@ -1,6 +1,8 @@
 import { getTokenDiscoveryApiUrl } from "@/config";
 import type { TokenInterface } from "@/constants";
 import { log } from "@/utils";
+import { formatUnits } from "@/utils/web3/units";
+import { getOptimalTokenBalance } from "@/utils/formatting";
 
 // Token info from Explorer API
 interface ExplorerToken {
@@ -55,17 +57,37 @@ export async function discoverTokens(
 
     const tokens: TokenInterface[] = data.tokens
       .filter((token) => token.contractAddress)
-      .map((token) => ({
-        name: token.name || "Unknown Token",
-        symbol: token.symbol || "UNK",
-        address: token.contractAddress.startsWith("Q")
-          ? token.contractAddress
-          : token.contractAddress.startsWith("q")
-            ? `Q${token.contractAddress.slice(1)}`
-            : `Q${token.contractAddress.replace(/^0x/i, "")}`,
-        amount: token.balance || "0",
-        decimals: token.decimals || 18,
-      }));
+      .map((token) => {
+        const symbol = token.symbol || "UNK";
+        // Nullish coalescing, not ||: 0 is a valid decimals value and must
+        // not fall through to 18.
+        const decimals = token.decimals ?? 18;
+        // Explorer returns the raw base-unit balance. Pre-format it to the
+        // same display string refreshTokenBalances would produce, so the
+        // picker (and the token list once added) never flashes the raw
+        // integer before the next 30s refresh cycle reformats it.
+        let amount = "0.0";
+        try {
+          amount = getOptimalTokenBalance(
+            formatUnits(token.balance || "0", decimals),
+            symbol,
+            false,
+          );
+        } catch {
+          amount = "0.0";
+        }
+        return {
+          name: token.name || "Unknown Token",
+          symbol,
+          address: token.contractAddress.startsWith("Q")
+            ? token.contractAddress
+            : token.contractAddress.startsWith("q")
+              ? `Q${token.contractAddress.slice(1)}`
+              : `Q${token.contractAddress.replace(/^0x/i, "")}`,
+          amount,
+          decimals,
+        };
+      });
 
     log(`Discovered ${tokens.length} tokens for ${address}`);
     return tokens;

--- a/src/utils/web3/tokenDiscovery.ts
+++ b/src/utils/web3/tokenDiscovery.ts
@@ -1,5 +1,5 @@
 import { getTokenDiscoveryApiUrl } from "@/config";
-import { TokenInterface } from "@/constants";
+import type { TokenInterface } from "@/constants";
 import { log } from "@/utils";
 
 // Token info from Explorer API

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
@@ -16,6 +16,13 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "noImplicitOverride": true,
+    "noUncheckedSideEffectImports": true,
+    "allowUnreachableCode": false,
+    "verbatimModuleSyntax": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noUncheckedIndexedAccess": true,
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"]


### PR DESCRIPTION
Promotes accumulated `dev` work to production (`qrlwallet.com`).

## Scope (origin/main..origin/dev — 66 files, +912/-392)

### This session's design-system refresh (UI/UX)
- #182 design-system merge: sidebar active state + Wallet icon, boxed PIN input, Network-fee gas selector, orange slider, NFT tile layout + blurred thumbnails, mobile nav active highlight, in-page footer links; plus 6 Gemini a11y/UX fixes and a consistent card-width fix.
- #183 PIN cells auto-advance on digit entry.
- #184 ShinyButton reshaped to design-primary blue + token table Name/Symbol colors.
- #186 sidebar active item is a single thin orange line flush with the rail.
- #187 gas selector renders by default, Send uses the right-arrow icon in both navs, Send button text is constant dark, dimmer/smaller helper text.

### Carried from earlier (already on dev, not yet on main)
- #180 chore: harden TypeScript / no type laundering (broad typing changes across dappConnect, crypto, stores, web3 utils; `tsconfig.json`).
- #181 fix: format token balance on add to avoid raw-value flash.
- #178/#179 add-accounts card placement (already partly on main).

## Validation
- `npm run lint` clean, `tsc` + `npm run build` green, `npm test` 114/114 on dev tip.

## Notes / risk
- This is more than the UI polish: #180 touches many non-UI files (crypto/signing/dappConnect typings) and `tsconfig.json`. No runtime logic changes intended by #180 (typing only), but it is broad.
- No env/migration changes.