### PR TITLE
fix(pin): bound ArrowRight to the first empty cell

### DIFF
--- a/src/components/UI/PinInput/PinInput.tsx
+++ b/src/components/UI/PinInput/PinInput.tsx
@@ -81,7 +81,9 @@ export const PinInput = ({
         focusCell(i - 1);
       }
       if (e.key === "ArrowLeft" && i > 0) focusCell(i - 1);
-      if (e.key === "ArrowRight" && i < length - 1) focusCell(i + 1);
+      // Only arrow into the first empty cell, never past it, so typed
+      // digits never land out of order.
+      if (e.key === "ArrowRight" && i < value.length) focusCell(i + 1);
     };
 
   const handlePaste =


### PR DESCRIPTION
Addresses the Gemini review on #188: arrowing right past the first empty cell let typed digits land out of order. Restrict ArrowRight to `i < value.length`.

Gates: lint clean, tsc + build green, 114/114 tests.