### PR TITLE
fix(dapp-connect): await async socketClient.connect() before joinChannel

### DIFF
--- a/src/services/dappConnect/DAppConnectService.ts
+++ b/src/services/dappConnect/DAppConnectService.ts
@@ -214,7 +214,10 @@ export class DAppConnectService {
     let channelPublicKey: string | null;
     try {
       dlog(`Connecting to relay ${relayUrl} as wallet participant`);
-      socketClient.connect();
+      // connect() is async since the lazy socket.io-client import (perf
+      // #153): it assigns this.socket only after the import resolves, so it
+      // MUST be awaited or joinChannel races it and throws on a null socket.
+      await socketClient.connect();
       const joinResult = await socketClient.joinChannel(channelId);
       channelPublicKey = joinResult.channelPublicKey;
       dlog(
@@ -735,7 +738,10 @@ export class DAppConnectService {
           originatedViaDeepLink: false,
         });
 
-        socketClient.connect();
+        // Same as the fresh-scan path: connect() resolves only after the
+        // lazy socket.io-client import assigns this.socket; await it before
+        // joinChannel.
+        await socketClient.connect();
         const { bufferedMessages, terminated } = await socketClient.joinChannel(session.id);
 
         if (terminated) {


### PR DESCRIPTION
Fixes the wallet-side pairing failure reproduced on-device via the zondscan dapp-example QR scan:

```
[DAppConnect] Connection failed: Socket not initialised; call connect() before joinChannel()
```

**Root cause:** `SocketClient.connect()` became async in the LCP perf pass (#153, `e75fc71`, June 1): it assigns `this.socket` only after the lazy `socket.io-client` import resolves. Both call sites (`DAppConnectService.ts:217` fresh QR scan, `:738` stored-session reconnect) called it without `await`, so `joinChannel()` ran synchronously on a still-null socket and threw. Every fresh wallet-side pairing has been broken on dev AND prod (`origin/main` carries the same code) since that commit.

**Why nobody noticed:** the e2e transport test simulates the wallet side with the npm SDK, whose `connect()` is synchronous; the resilience release's device QR-scan test was still pending.

**Fix:** `await` both call sites. `joinChannel` already tolerates a connecting-but-not-yet-connected socket via `waitForConnect`, so the await is all that was missing.

Gates: eslint --max-warnings 0 clean, jest 114/114, vite build green.

After merge to dev this auto-deploys to dev.qrlwallet.com for the in-progress device test; needs a dev -> main promotion afterwards since prod is equally affected.