### PR TITLE
fix(dapp-connect): SYNACK retransmit on rejoin + pre-handshake teardown on dApp leave

### DIFF
--- a/src/services/dappConnect/DAppConnectService.ts
+++ b/src/services/dappConnect/DAppConnectService.ts
@@ -8,6 +8,7 @@
 
 import {
   KeyExchange,
+  type SynAckMessage,
   type AckMessage,
 } from './KeyExchange';
 import { parseConnectionURI, cidToString, computeFingerprint, fingerprintEquals } from './qrUri';
@@ -67,6 +68,13 @@ interface ActiveConnection {
   // return-to-dApp peer redirect: bouncing to the dApp URL only makes sense
   // on the same device. A QR scan means the dApp is on another device.
   originatedViaDeepLink: boolean;
+  // The SYNACK wire message for a handshake that has not completed yet.
+  // Kept so a socket flap between our SYNACK and the dApp's ACK does not
+  // strand the pairing: on rejoin we re-send the identical SYNACK (the
+  // AEAD nonce is deterministic, so the bytes are stable) and the dApp
+  // either consumes it or re-sends its cached ACK. Cleared once keys are
+  // exchanged.
+  pendingSynAck?: SynAckMessage;
 }
 
 type ServiceEventHandler = {
@@ -183,6 +191,11 @@ export class DAppConnectService {
         if (conn?.keyExchange.areKeysExchanged()) {
           SessionStore.updateStatus(channelId, SessionStatus.CONNECTED);
           this.handlers?.onSessionsChanged();
+        } else {
+          // Mid-handshake flap: our SYNACK may have died with the old
+          // transport, or the dApp's ACK may have been delivered to the
+          // dead socket. Re-send the cached SYNACK so both sides converge.
+          this.resendPendingSynAck(channelId);
         }
       },
       onParticipantsChanged: (data) => {
@@ -247,6 +260,7 @@ export class DAppConnectService {
       connection.dappPublicKey = pk;
 
       const synack = await keyExchange.receiveQR(parsed.cid, pk);
+      connection.pendingSynAck = synack;
 
       // Send SYNACK — this kicks off the visible portion of the handshake.
       await socketClient.sendMessage({
@@ -290,6 +304,7 @@ export class DAppConnectService {
 
     const conn = this.connections.get(channelId);
     if (!conn) return;
+    conn.pendingSynAck = undefined;
 
     SessionStore.updateStatus(channelId, SessionStatus.CONNECTED);
     await this.persistSession(channelId);
@@ -814,6 +829,9 @@ export class DAppConnectService {
 
     if (data.event === 'join' && data.clientType === 'dapp') {
       this.clearDappLeaveTimeout(channelId);
+      // If the handshake is still open, the (re)joining dApp may have
+      // missed our SYNACK; re-send it (idempotent on the dApp side).
+      this.resendPendingSynAck(channelId);
       return;
     }
 
@@ -821,8 +839,40 @@ export class DAppConnectService {
       (data.event === 'disconnect' || data.event === 'leave') &&
       (data.clientType === 'dapp' || !data.clientType)
     ) {
+      const conn = this.connections.get(channelId);
+      if (conn && !conn.keyExchange.areKeysExchanged()) {
+        // The dApp left before the handshake ever completed. There is no
+        // established session to grace-hold: a later relay-buffered ACK
+        // would otherwise complete the handshake into a ghost CONNECTED
+        // session whose peer is long gone, and an encrypted TERMINATE from
+        // the dApp is undecryptable pre-handshake. Fail closed now.
+        dlog(`dApp left before handshake completed; tearing down ${channelId}`);
+        void this.disconnectSession(channelId, false);
+        return;
+      }
       this.scheduleDappLeaveTimeout(channelId);
     }
+  }
+
+  /**
+   * Re-send the cached SYNACK for a handshake that has not completed.
+   * Safe to call repeatedly: the bytes are deterministic, the dApp ignores
+   * duplicates after completing (or answers with its cached ACK), and we
+   * stop once keys are exchanged.
+   */
+  private resendPendingSynAck(channelId: string): void {
+    const conn = this.connections.get(channelId);
+    if (!conn || conn.keyExchange.areKeysExchanged() || !conn.pendingSynAck) return;
+    dlog(`Re-sending SYNACK for incomplete handshake on ${channelId}`);
+    void conn.socketClient
+      .sendMessage({
+        id: channelId,
+        clientType: 'wallet',
+        message: conn.pendingSynAck,
+      })
+      .catch((err: unknown) => {
+        dlog(`SYNACK re-send failed: ${err instanceof Error ? err.message : String(err)}`);
+      });
   }
 
   private scheduleDappLeaveTimeout(channelId: string): void {


### PR DESCRIPTION
Fixes the two failure modes from today's device test of the dapp-example pairing (after #191 unblocked the scan path):

**1. Stalled half-open handshake.** Wallet sent SYNACK, its socket dropped with `transport error`, and the dApp's ACK was delivered to the dead socket / relay-buffered. The wallet waited forever ("no Keys exchanged" after rejoin) while the dApp showed connected. Now the SYNACK is cached on the connection and re-sent on socket rejoin and on dApp (re)join while the handshake is incomplete. Bytes are deterministic (counter nonce, seq 0) so the re-send is idempotent; paired SDK change (myqrlwallet-connect PR #15) makes the dApp answer a duplicate SYNACK with its cached ACK.

**2. Ghost CONNECTED session.** The relay buffers messages for 5 minutes, so the stranded ACK completed the handshake on a later rejoin, minutes after the dApp had disconnected: wallet flipped to CONNECTED with no live peer ("it thinks it reconnected"). And because an encrypted TERMINATE is undecryptable pre-handshake, the dApp-side disconnect left the app stuck on RECONNECTING. Now a dApp leave before handshake completion tears the session down immediately (nothing exists to grace-hold) instead of arming the 90s stale timeout.

Both changes are wallet-local and wire-compatible; old dApps simply ignore re-sent SYNACKs (status quo behavior, no recovery but no breakage).

Gates: eslint --max-warnings 0 clean, jest 114/114, vite build green.