### PR TITLE
Promote dev -> main: dApp-connect pairing fixes (device-test validated)

### DIFF
--- a/src/services/dappConnect/DAppConnectService.ts
+++ b/src/services/dappConnect/DAppConnectService.ts
@@ -8,6 +8,7 @@
 
 import {
   KeyExchange,
+  type SynAckMessage,
   type AckMessage,
 } from './KeyExchange';
 import { parseConnectionURI, cidToString, computeFingerprint, fingerprintEquals } from './qrUri';
@@ -67,6 +68,13 @@ interface ActiveConnection {
   // return-to-dApp peer redirect: bouncing to the dApp URL only makes sense
   // on the same device. A QR scan means the dApp is on another device.
   originatedViaDeepLink: boolean;
+  // The SYNACK wire message for a handshake that has not completed yet.
+  // Kept so a socket flap between our SYNACK and the dApp's ACK does not
+  // strand the pairing: on rejoin we re-send the identical SYNACK (the
+  // AEAD nonce is deterministic, so the bytes are stable) and the dApp
+  // either consumes it or re-sends its cached ACK. Cleared once keys are
+  // exchanged.
+  pendingSynAck?: SynAckMessage;
 }
 
 type ServiceEventHandler = {
@@ -183,6 +191,11 @@ export class DAppConnectService {
         if (conn?.keyExchange.areKeysExchanged()) {
           SessionStore.updateStatus(channelId, SessionStatus.CONNECTED);
           this.handlers?.onSessionsChanged();
+        } else {
+          // Mid-handshake flap: our SYNACK may have died with the old
+          // transport, or the dApp's ACK may have been delivered to the
+          // dead socket. Re-send the cached SYNACK so both sides converge.
+          this.resendPendingSynAck(channelId);
         }
       },
       onParticipantsChanged: (data) => {
@@ -247,6 +260,7 @@ export class DAppConnectService {
       connection.dappPublicKey = pk;
 
       const synack = await keyExchange.receiveQR(parsed.cid, pk);
+      connection.pendingSynAck = synack;
 
       // Send SYNACK — this kicks off the visible portion of the handshake.
       await socketClient.sendMessage({
@@ -290,6 +304,7 @@ export class DAppConnectService {
 
     const conn = this.connections.get(channelId);
     if (!conn) return;
+    conn.pendingSynAck = undefined;
 
     SessionStore.updateStatus(channelId, SessionStatus.CONNECTED);
     await this.persistSession(channelId);
@@ -814,6 +829,9 @@ export class DAppConnectService {
 
     if (data.event === 'join' && data.clientType === 'dapp') {
       this.clearDappLeaveTimeout(channelId);
+      // If the handshake is still open, the (re)joining dApp may have
+      // missed our SYNACK; re-send it (idempotent on the dApp side).
+      this.resendPendingSynAck(channelId);
       return;
     }
 
@@ -821,8 +839,40 @@ export class DAppConnectService {
       (data.event === 'disconnect' || data.event === 'leave') &&
       (data.clientType === 'dapp' || !data.clientType)
     ) {
+      const conn = this.connections.get(channelId);
+      if (conn && !conn.keyExchange.areKeysExchanged()) {
+        // The dApp left before the handshake ever completed. There is no
+        // established session to grace-hold: a later relay-buffered ACK
+        // would otherwise complete the handshake into a ghost CONNECTED
+        // session whose peer is long gone, and an encrypted TERMINATE from
+        // the dApp is undecryptable pre-handshake. Fail closed now.
+        dlog(`dApp left before handshake completed; tearing down ${channelId}`);
+        void this.disconnectSession(channelId, false);
+        return;
+      }
       this.scheduleDappLeaveTimeout(channelId);
     }
+  }
+
+  /**
+   * Re-send the cached SYNACK for a handshake that has not completed.
+   * Safe to call repeatedly: the bytes are deterministic, the dApp ignores
+   * duplicates after completing (or answers with its cached ACK), and we
+   * stop once keys are exchanged.
+   */
+  private resendPendingSynAck(channelId: string): void {
+    const conn = this.connections.get(channelId);
+    if (!conn || conn.keyExchange.areKeysExchanged() || !conn.pendingSynAck) return;
+    dlog(`Re-sending SYNACK for incomplete handshake on ${channelId}`);
+    void conn.socketClient
+      .sendMessage({
+        id: channelId,
+        clientType: 'wallet',
+        message: conn.pendingSynAck,
+      })
+      .catch((err: unknown) => {
+        dlog(`SYNACK re-send failed: ${err instanceof Error ? err.message : String(err)}`);
+      });
   }
 
   private scheduleDappLeaveTimeout(channelId: string): void {

--- a/src/services/dappConnect/DAppConnectService.ts
+++ b/src/services/dappConnect/DAppConnectService.ts
@@ -214,7 +214,10 @@ export class DAppConnectService {
     let channelPublicKey: string | null;
     try {
       dlog(`Connecting to relay ${relayUrl} as wallet participant`);
-      socketClient.connect();
+      // connect() is async since the lazy socket.io-client import (perf
+      // #153): it assigns this.socket only after the import resolves, so it
+      // MUST be awaited or joinChannel races it and throws on a null socket.
+      await socketClient.connect();
       const joinResult = await socketClient.joinChannel(channelId);
       channelPublicKey = joinResult.channelPublicKey;
       dlog(
@@ -735,7 +738,10 @@ export class DAppConnectService {
           originatedViaDeepLink: false,
         });
 
-        socketClient.connect();
+        // Same as the fresh-scan path: connect() resolves only after the
+        // lazy socket.io-client import assigns this.socket; await it before
+        // joinChannel.
+        await socketClient.connect();
         const { bufferedMessages, terminated } = await socketClient.joinChannel(session.id);
 
         if (terminated) {

--- a/src/services/dappConnect/SocketClient.ts
+++ b/src/services/dappConnect/SocketClient.ts
@@ -24,6 +24,7 @@ type SocketEventHandler = {
 
 export class SocketClient {
   private socket: Socket | null = null;
+  private connectedAt: number | null = null;
   private relayUrl: string;
   private channelId: string | null = null;
   private handlers: SocketEventHandler;
@@ -69,6 +70,8 @@ export class SocketClient {
     this._connecting = false;
 
     this.socket.on('connect', () => {
+      this.connectedAt = Date.now();
+      logToNative(`[SocketClient] connected via ${this.transportName()}`);
       this.handlers.onConnected();
 
       // Auto-rejoin only after the initial join has succeeded. The initial
@@ -96,7 +99,27 @@ export class SocketClient {
       }
     });
 
-    this.socket.on('disconnect', (reason) => {
+    this.socket.on('disconnect', (reason, description) => {
+      // Diagnostic context for on-device transport flaps: which transport
+      // died, how long it lived, what the engine said, and whether the
+      // WebView was visible at that instant.
+      const aliveMs = this.connectedAt ? Date.now() - this.connectedAt : -1;
+      let detail = '';
+      if (description instanceof Error) {
+        detail = description.message;
+      } else if (description && typeof description === 'object') {
+        const rec: Record<string, unknown> = { ...description };
+        if (typeof rec['description'] === 'string') detail = rec['description'];
+        else if (typeof rec['type'] === 'string') detail = rec['type'];
+      }
+      const visible =
+        typeof document !== 'undefined' ? document.visibilityState : 'n/a';
+      const online = typeof navigator !== 'undefined' ? String(navigator.onLine) : 'n/a';
+      logToNative(
+        `[SocketClient] disconnect: ${reason}; detail=${detail || 'none'}; ` +
+          `transport=${this.transportName()}; aliveMs=${aliveMs}; ` +
+          `visible=${visible}; online=${online}`
+      );
       this.handlers.onDisconnected(reason);
     });
 
@@ -256,6 +279,10 @@ export class SocketClient {
       this.socket.disconnect();
       this.socket = null;
     }
+  }
+
+  private transportName(): string {
+    return this.socket?.io.engine?.transport?.name ?? 'unknown';
   }
 
   isConnected(): boolean {

--- a/src/services/dappConnect/SocketClient.ts
+++ b/src/services/dappConnect/SocketClient.ts
@@ -50,9 +50,15 @@ export class SocketClient {
     if (this.socket?.connected) { this._connecting = false; return; }
     this.socket = ioFn(this.relayUrl, {
       path: RELAY_PATH,
-      // Polling-first so Cloudflare can negotiate any challenge/cookie
-      // handshake at the HTTP layer before auto-upgrading to WS.
-      transports: ['polling', 'websocket'],
+      // Websocket-first, matching the dApp SDK. Long-poll XHRs are killed
+      // when native UI transitions interrupt the WebView (tab switch on
+      // DAPP_SHOW_WEBVIEW, haptics, backgrounding), surfacing as periodic
+      // "transport error" flaps on device; a single WS survives those
+      // pauses. Cloudflare clearance is already established by the page
+      // load itself, so the old polling-first challenge rationale no
+      // longer applies; socket.io still falls back to polling if WSS is
+      // blocked.
+      transports: ['websocket', 'polling'],
       reconnection: true,
       reconnectionDelay: 1000,
       reconnectionDelayMax: 30000,

--- a/src/services/dappConnect/base45.ts
+++ b/src/services/dappConnect/base45.ts
@@ -13,15 +13,14 @@ const DECODE: Int8Array = (() => {
 })();
 
 /**
- * Char codes ≥128 are always invalid — looking them up on the 128-slot
- * Int8Array returns `undefined`, and `undefined < 0` is false, which
- * would let hostile input silently decode to zero bytes and bypass the
- * "invalid character" throw below.
+ * Decode a single character to its Base45 alphabet value, or -1 if invalid.
+ * Char codes <0 or >=128 are rejected up front by the explicit guard, so the
+ * 128-slot table is only ever indexed in-bounds; the `?? -1` below merely
+ * satisfies the index-access checker and never actually fires. Invalid
+ * characters still surface as the "invalid character" throw in the caller.
  */
 function decodeChar(charCode: number): number {
   if (charCode < 0 || charCode >= 128) return -1;
-  // charCode is guaranteed in-bounds by the guard above; `?? -1` only
-  // satisfies the index-access checker and never actually fires.
   return DECODE[charCode] ?? -1;
 }
 


### PR DESCRIPTION
Promotes today's device-test-validated dApp-connect fixes to prod. 10 commits (5 PRs + docs), no migrations, no env changes.

- #191 await async socketClient.connect(): fresh wallet-side pairings have been broken on prod since June 1 (perf #153 made connect() async; joinChannel raced a null socket). This is the critical fix.
- #192 SYNACK retransmit on rejoin + immediate teardown when the dApp leaves pre-handshake (fixes stalled half-open pairings and ghost CONNECTED sessions from relay-buffered ACKs).
- #193 websocket-first relay transport (long-poll XHRs die when native UI transitions interrupt the WebView).
- #194 engine-level disconnect diagnostics (transport, lifetime, visibility, online).
- #190 base45 doc tidy.

Validation: full on-device acceptance pass today (pair, approve, sign, wallet-side disconnect, dApp-side disconnect, re-pair) against dev.qrlwallet.com; lint --max-warnings 0, jest 114/114, vite build green on the promoted HEAD.

Risks: transport-order change is fallback-safe (polling remains); retransmit is wire-compatible (old dApps ignore duplicates); diagnostics are log-only. Known open issue (not blocked by this): periodic on-device reconnect loop under investigation with the new diagnostics; this promotion strictly improves prod, which currently cannot pair at all.