### PR TITLE
fix(dapp-connect): address Gemini review findings from #192/#194/#195

### DIFF
--- a/src/services/dappConnect/DAppConnectService.ts
+++ b/src/services/dappConnect/DAppConnectService.ts
@@ -188,7 +188,8 @@ export class DAppConnectService {
       onReconnected: () => {
         dlog(`Socket reconnected for channel ${channelId}`);
         const conn = this.connections.get(channelId);
-        if (conn?.keyExchange.areKeysExchanged()) {
+        if (!conn) return;
+        if (conn.keyExchange.areKeysExchanged()) {
           SessionStore.updateStatus(channelId, SessionStatus.CONNECTED);
           this.handlers?.onSessionsChanged();
         } else {
@@ -840,16 +841,22 @@ export class DAppConnectService {
       (data.clientType === 'dapp' || !data.clientType)
     ) {
       const conn = this.connections.get(channelId);
-      if (conn && !conn.keyExchange.areKeysExchanged()) {
-        // The dApp left before the handshake ever completed. There is no
-        // established session to grace-hold: a later relay-buffered ACK
-        // would otherwise complete the handshake into a ghost CONNECTED
-        // session whose peer is long gone, and an encrypted TERMINATE from
-        // the dApp is undecryptable pre-handshake. Fail closed now.
+      if (!conn) return;
+      if (!conn.keyExchange.areKeysExchanged() && data.event === 'leave') {
+        // The dApp DELIBERATELY left (leave_channel) before the handshake
+        // completed. There is no established session to grace-hold, and an
+        // encrypted TERMINATE from the dApp is undecryptable pre-handshake,
+        // so this is the only disconnect signal we will ever get. Fail
+        // closed now; it also stops a later relay-buffered ACK completing
+        // the handshake into a ghost CONNECTED session.
         dlog(`dApp left before handshake completed; tearing down ${channelId}`);
         void this.disconnectSession(channelId, false);
         return;
       }
+      // Transient pre-handshake socket drop ('disconnect') gets the normal
+      // grace: the dApp's auto-reconnect re-joins, we retransmit the cached
+      // SYNACK, and the handshake converges. The grace timer still bounds a
+      // late-buffered-ACK ghost if the dApp never returns.
       this.scheduleDappLeaveTimeout(channelId);
     }
   }

--- a/src/services/dappConnect/SocketClient.ts
+++ b/src/services/dappConnect/SocketClient.ts
@@ -35,20 +35,24 @@ export class SocketClient {
     this.handlers = handlers;
   }
 
-  private _connecting = false;
+  // In-flight connect, memoized so concurrent callers all await the SAME
+  // attempt instead of returning early while this.socket is still null
+  // (a boolean guard let a second caller race past and hit joinChannel on
+  // an uninitialized socket).
+  private connectPromise: Promise<void> | null = null;
 
-  async connect(): Promise<void> {
-    if (this.socket?.connected || this._connecting) return;
-    this._connecting = true;
-    let ioFn: typeof import('socket.io-client')['io'];
-    try {
-      ioFn = (await import('socket.io-client')).io;
-    } catch (e) {
-      this._connecting = false;
-      throw e;
-    }
-    // Another call may have raced past the guard while we awaited the import
-    if (this.socket?.connected) { this._connecting = false; return; }
+  connect(): Promise<void> {
+    if (this.socket?.connected) return Promise.resolve();
+    this.connectPromise ??= this.doConnect().finally(() => {
+      this.connectPromise = null;
+    });
+    return this.connectPromise;
+  }
+
+  private async doConnect(): Promise<void> {
+    const ioFn = (await import('socket.io-client')).io;
+    // A prior attempt may have finished while we awaited the import
+    if (this.socket?.connected) return;
     this.socket = ioFn(this.relayUrl, {
       path: RELAY_PATH,
       // Websocket-first, matching the dApp SDK. Long-poll XHRs are killed
@@ -66,8 +70,6 @@ export class SocketClient {
       reconnectionAttempts: Infinity,
       timeout: 20000,
     });
-
-    this._connecting = false;
 
     this.socket.on('connect', () => {
       this.connectedAt = Date.now();
@@ -104,6 +106,7 @@ export class SocketClient {
       // died, how long it lived, what the engine said, and whether the
       // WebView was visible at that instant.
       const aliveMs = this.connectedAt ? Date.now() - this.connectedAt : -1;
+      this.connectedAt = null;
       let detail = '';
       if (description instanceof Error) {
         detail = description.message;


### PR DESCRIPTION
Post-merge review follow-ups: connect-promise memoization (HIGH: concurrent connect() callers raced a null socket past the boolean guard), leave-vs-disconnect distinction for pre-handshake teardown (transient dApp flaps now recover via SYNACK retransmit instead of forcing a re-scan), missing conn guards, connectedAt reset. Deferred: reconnectAll concurrency (replied on #195). Gates: lint clean, jest 114/114, build green.