### PR TITLE
feat(desktop): route key operations through the Electron signer bridge

### DIFF
--- a/config/vite.config.ts
+++ b/config/vite.config.ts
@@ -8,6 +8,10 @@ import tailwindcss from '@tailwindcss/postcss'
 const require = createRequire(import.meta.url)
 
 export default defineConfig(({ mode }) => ({
+  // Desktop (Electron) loads the bundle from disk via loadFile (file://), so
+  // assets must be referenced relatively. Set VITE_DESKTOP=1 for that build
+  // (see myqrlwallet-desktop/scripts/build-renderer.sh). Web builds keep '/'.
+  base: process.env.VITE_DESKTOP === '1' ? './' : '/',
   plugins: [
     react(),
     // Remove vendor-qrl-crypto from <link rel="modulepreload"> — it's a

--- a/src/components/Core/Body/CreateAccount/AccountCreationForm/AccountCreationForm.tsx
+++ b/src/components/Core/Body/CreateAccount/AccountCreationForm/AccountCreationForm.tsx
@@ -28,6 +28,7 @@ import { StorageUtil } from "@/utils/storage";
 import { isInNativeApp, notifySeedStored } from "@/utils/nativeApp";
 import { PinInput } from "@/components/UI/PinInput/PinInput";
 import { Separator } from "@/components/UI/Separator";
+import { isDesktop, desktopSigner } from "@/desktop/bridge";
 
 // Password must match WalletEncryptionUtil.validatePassword() requirements
 const passwordValidation = z.string()
@@ -75,17 +76,35 @@ const ExistingUserSchema = z.object({
   path: ["reEnteredPassword"],
 });
 
+// Desktop schema - PIN is not used (the signer does Argon2id over a password);
+// only the password and its confirmation are validated. The PIN fields stay
+// present in the form values so the shared form typing is unchanged.
+const DesktopSchema = z.object({
+  password: passwordValidation,
+  reEnteredPassword: z.string().min(1, "Please re-enter your password"),
+  pin: z.string(),
+  reEnteredPin: z.string(),
+}).refine((data) => data.password === data.reEnteredPassword, {
+  message: "Passwords don't match",
+  path: ["reEnteredPassword"],
+});
+
 type AccountCreationFormProps = {
+  // On desktop, `account` is undefined and the signer-returned mnemonic +
+  // address are supplied so the backup screen can render without any seed
+  // material in the renderer.
   onAccountCreated: (
-    account: Web3BaseWalletAccount,
+    account: Web3BaseWalletAccount | undefined,
     password: string,
+    desktopBackup?: { address: string; mnemonic: string },
   ) => void;
 };
 
 type InnerFormProps = {
   onAccountCreated: (
-    account: Web3BaseWalletAccount,
+    account: Web3BaseWalletAccount | undefined,
     password: string,
+    desktopBackup?: { address: string; mnemonic: string },
   ) => void;
   hasExistingSeeds: boolean;
   existingSeeds: { address: string; encryptedSeed: string }[];
@@ -101,8 +120,13 @@ const InnerForm = observer(({ onAccountCreated, hasExistingSeeds, existingSeeds,
   const { qrlInstance } = qrlStore;
   const [isEncrypting, setIsEncrypting] = useState(false);
 
-  // Select schema based on whether user has existing seeds
-  const schema = hasExistingSeeds ? ExistingUserSchema : NewUserSchema;
+  // Select schema based on whether user has existing seeds. On desktop the
+  // password is the only secret (no PIN) so a dedicated schema is used.
+  const schema = isDesktop
+    ? DesktopSchema
+    : hasExistingSeeds
+    ? ExistingUserSchema
+    : NewUserSchema;
 
   const form = useForm<FormValues>({
     resolver: zodResolver(schema),
@@ -127,6 +151,28 @@ const InnerForm = observer(({ onAccountCreated, hasExistingSeeds, existingSeeds,
     try {
       const userPassword = formData.password;
       const userPin = formData.pin;
+
+      // Desktop: the signer generates the seed and returns the mnemonic ONCE
+      // for backup. No seed material is materialised, encrypted, or stored in
+      // the renderer (no accounts.create / getMnemonicFromHexSeed /
+      // encryptSeedAsync / storeEncryptedSeed).
+      if (isDesktop) {
+        setIsEncrypting(true);
+        try {
+          const { status, mnemonic } = await desktopSigner.createWallet(userPassword);
+          setIsEncrypting(false);
+          onAccountCreated(undefined, userPassword, {
+            address: status.address,
+            mnemonic,
+          });
+        } catch (err) {
+          setIsEncrypting(false);
+          setError("root", {
+            message: `${err instanceof Error ? err.message : String(err)} There was an error while creating the account`,
+          });
+        }
+        return;
+      }
 
       // If existing seeds exist, verify PIN by attempting to decrypt one
       if (hasExistingSeeds && existingSeeds.length > 0) {
@@ -245,6 +291,10 @@ const InnerForm = observer(({ onAccountCreated, hasExistingSeeds, existingSeeds,
               </div>
             </div>
 
+            {/* PIN section is web/native only. On desktop the signer uses the
+                password (Argon2id) and there is no per-transaction PIN. */}
+            {!isDesktop && (
+            <>
             <Separator />
 
             <div>
@@ -293,6 +343,8 @@ const InnerForm = observer(({ onAccountCreated, hasExistingSeeds, existingSeeds,
                 )}
               </div>
             </div>
+            </>
+            )}
           </CardContent>
           <CardFooter className="flex-col gap-4">
             {errors.root && (

--- a/src/components/Core/Body/CreateAccount/CreateAccount.tsx
+++ b/src/components/Core/Body/CreateAccount/CreateAccount.tsx
@@ -22,19 +22,27 @@ const CreateAccount = observer(() => {
   const [account, setAccount] = useState<Web3BaseWalletAccount>();
   const [hasAccountCreated, setHasAccountCreated] = useState(false);
   const [userPassword, setUserPassword] = useState<string>("");
+  // Desktop only: the signer-returned address + mnemonic for the backup screen.
+  // The hex seed is never returned to the renderer.
+  const [desktopBackup, setDesktopBackup] = useState<{ address: string; mnemonic: string }>();
 
   const { isWalletLimitReached, walletCount, maxWallets } = useWalletLimit(qrlConnection.blockchain);
 
-  // Called after account is created AND seed is encrypted/stored
+  // Called after account is created AND seed is encrypted/stored (web/native),
+  // or after the signer provisioned the wallet (desktop: backup carries the
+  // address + one-time mnemonic, account is undefined).
   const onAccountCreated = async (
-    newAccount: Web3BaseWalletAccount,
+    newAccount: Web3BaseWalletAccount | undefined,
     password: string,
+    backup?: { address: string; mnemonic: string },
   ) => {
-    if (newAccount?.address) {
+    const address = newAccount?.address ?? backup?.address;
+    if (address) {
       window.scrollTo(0, 0);
       setAccount(newAccount);
+      setDesktopBackup(backup);
       setUserPassword(password);
-      await setActiveAccount(newAccount.address);
+      await setActiveAccount(address);
       setHasAccountCreated(true);
     }
   };
@@ -79,6 +87,7 @@ const CreateAccount = observer(() => {
               <MnemonicDisplay
                 account={account}
                 userPassword={userPassword}
+                desktopBackup={desktopBackup}
               />
             ) : (
               <AccountCreationForm onAccountCreated={onAccountCreated} />

--- a/src/components/Core/Body/CreateAccount/MnemonicDisplay/MnemonicDisplay.tsx
+++ b/src/components/Core/Body/CreateAccount/MnemonicDisplay/MnemonicDisplay.tsx
@@ -28,6 +28,7 @@ import { QRCodeSVG } from "qrcode.react";
 import { WalletEncryptionUtil } from "@/utils/crypto";
 import { HexSeedListing } from "@/components/UI/HexSeedListing/HexSeedListing";
 import { ROUTES } from "@/router/router";
+import { isDesktop } from "@/desktop/bridge";
 
 const MnemonicWordListing = withSuspense(
   lazy(() => import("./MnemonicWordListing/MnemonicWordListing"))
@@ -36,16 +37,23 @@ const MnemonicWordListing = withSuspense(
 type MnemonicDisplayProps = {
   account?: Web3BaseWalletAccount;
   userPassword: string;
+  // Desktop only: the signer-supplied address + one-time mnemonic. The hex seed
+  // never leaves the signer, so the hex-seed and wallet-file sections are
+  // hidden on desktop.
+  desktopBackup?: { address: string; mnemonic: string };
 };
 
 const MnemonicDisplay = ({
   account,
   userPassword,
+  desktopBackup,
 }: MnemonicDisplayProps) => {
   const navigate = useNavigate();
-  const accountAddress = account?.address;
-  const accountHexSeed = account?.seed;
-  const mnemonic = getMnemonicFromHexSeed(accountHexSeed);
+  // On desktop the address + mnemonic come from the signer; the hex seed is
+  // never available in the renderer.
+  const accountAddress = isDesktop ? desktopBackup?.address : account?.address;
+  const accountHexSeed = isDesktop ? undefined : account?.seed;
+  const mnemonic = isDesktop ? (desktopBackup?.mnemonic ?? "") : getMnemonicFromHexSeed(accountHexSeed);
   const [hasJustCopiedSeed, setHasJustCopiedSeed] = useState(false);
   const [hasJustCopiedAddress, setHasJustCopiedAddress] = useState(false);
   const [hasJustCopiedMnemonic, setHasJustCopiedMnemonic] = useState(false);
@@ -193,34 +201,41 @@ const MnemonicDisplay = ({
               {hasJustCopiedMnemonic ? "Copied" : "Copy Mnemonic"}
             </Button>
           </div>
-          <div>
-            <h3 className="text-lg font-semibold">Hex Seed</h3>
-            <p className="text-sm text-muted-foreground">Alternative method to recover your account</p>
-            <div className="mt-2 flex flex-col gap-2">
-              {accountHexSeed && <HexSeedListing hexSeed={accountHexSeed} />}
-              <Button
-                type="button"
-                variant="outline"
-                onClick={onCopyHexSeed}
-                className="w-full"
-              >
-                {hasJustCopiedSeed ? (
-                  <>
-                    <Copy className="mr-2 h-4 w-4" />
-                    Copied
-                  </>
-                ) : (
-                  <>
-                    <Copy className="mr-2 h-4 w-4" />
-                    Copy Hex Seed
-                  </>
-                )}
-              </Button>
+          {/* Hex seed is web/native only: on desktop it never leaves the
+              signer, so there is nothing to display or copy here. */}
+          {!isDesktop && (
+            <div>
+              <h3 className="text-lg font-semibold">Hex Seed</h3>
+              <p className="text-sm text-muted-foreground">Alternative method to recover your account</p>
+              <div className="mt-2 flex flex-col gap-2">
+                {accountHexSeed && <HexSeedListing hexSeed={accountHexSeed} />}
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={onCopyHexSeed}
+                  className="w-full"
+                >
+                  {hasJustCopiedSeed ? (
+                    <>
+                      <Copy className="mr-2 h-4 w-4" />
+                      Copied
+                    </>
+                  ) : (
+                    <>
+                      <Copy className="mr-2 h-4 w-4" />
+                      Copy Hex Seed
+                    </>
+                  )}
+                </Button>
+              </div>
             </div>
-          </div>
+          )}
         </div>
       </CardContent>
       <CardFooter className="flex-col gap-4">
+        {/* Wallet-file downloads require the hex seed, which the renderer does
+            not have on desktop. Hidden there; the mnemonic above is the backup. */}
+        {!isDesktop && (
         <div className="flex flex-col sm:flex-row w-full gap-3">
           <Button
             className="w-full"
@@ -264,6 +279,7 @@ const MnemonicDisplay = ({
             </DialogContent>
           </Dialog>
         </div>
+        )}
         <Dialog>
           <DialogTrigger asChild>
             <Button className="w-full" type="button">

--- a/src/components/Core/Body/CreateToken/TokenCreationForm/TokenCreationForm.tsx
+++ b/src/components/Core/Body/CreateToken/TokenCreationForm/TokenCreationForm.tsx
@@ -31,6 +31,7 @@ import { PinInput } from "@/components/UI/PinInput/PinInput";
 import { WalletEncryptionUtil } from "@/utils/crypto";
 import { StorageUtil } from "@/utils/storage";
 import { getAddressFromMnemonicAsync } from "@/utils/crypto";
+import { isDesktop } from "@/desktop/bridge";
 import { Label } from "@/components/UI/Label";
 import { isValidQrlAddress } from "@/utils/web3";
 import { containsProfanity, PROFANITY_REJECTION_MESSAGE } from "@/utils/moderation";
@@ -128,9 +129,12 @@ export const TokenCreationForm = observer(
                     return;
                 }
 
-                // Get encrypted seed and validate PIN (only for seed accounts)
+                // Get encrypted seed and validate PIN (only for web/native
+                // seed accounts). On desktop there is no PIN and no seed in the
+                // renderer: the store builds the calldata and routes through
+                // the signer, so we pass an empty mnemonic placeholder.
                 let mnemonicPhrase = "";
-                if (!isUsingExtension) {
+                if (!isUsingExtension && !isDesktop) {
                     if (!pin) {
                         setPinError("PIN is required");
                         return;
@@ -515,7 +519,9 @@ export const TokenCreationForm = observer(
                                         Please import an account with a seed phrase to create tokens.
                                     </p>
                                 </div>
-                            ) : (
+                            ) : !isDesktop ? (
+                                // PIN entry is web/native only. On desktop the signer
+                                // session authorizes the transaction (no PIN).
                                 <div className="flex flex-col">
                                     <Label htmlFor="pin" className="mb-2">
                                         Transaction PIN
@@ -530,12 +536,12 @@ export const TokenCreationForm = observer(
                                         error={pinError}
                                     />
                                 </div>
-                            )}
+                            ) : null}
 
                         </CardContent>
                         <CardFooter>
                             <ShinyButton
-                                disabled={!isValid || (!isUsingExtension && pin.length === 0) || isUsingExtension}
+                                disabled={!isValid || (!isUsingExtension && !isDesktop && pin.length === 0) || isUsingExtension}
                                 processing={isSubmitting}
                                 className="w-full"
                                 type="submit"

--- a/src/components/Core/Body/DAppConnect/DAppApprovalModal.tsx
+++ b/src/components/Core/Body/DAppConnect/DAppApprovalModal.tsx
@@ -34,6 +34,7 @@ import {
 import { Loader, Check, X, ExternalLink, Shield, Globe } from 'lucide-react';
 import type { TxProgressState } from '@/stores/dappConnectStore';
 import type { ZodError } from 'zod';
+import { isDesktop, desktopSigner } from '@/desktop/bridge';
 
 function formatZodIssues(error: ZodError): string {
   // path segments can be symbols (e.g. a MobX admin key surfaced by zod's
@@ -151,13 +152,59 @@ const DAppApprovalModal = observer(() => {
       }
 
       if (method === 'qrl_sendTransaction' || method === 'qrl_signTransaction') {
-        const pinToUse = getNativeInjectedPin() || pin;
         const activeAddress = qrlStore.activeAccount?.accountAddress;
         if (!activeAddress) {
           setError('No active account');
           setLoading(false);
           return;
         }
+
+        // Desktop: build + confirm + sign in the isolated signer (its own
+        // trusted modal), then broadcast for send / return raw for sign. No
+        // PIN, no seed in the renderer.
+        if (isDesktop) {
+          const txParamsD = (params?.[0] || {}) as Record<string, unknown>;
+          const toD = txParamsD['to'] as string;
+          const dataD = (txParamsD['data'] as string) || undefined;
+          const valueD = txParamsD['value']
+            ? BigInt(txParamsD['value'] as string).toString()
+            : '0';
+          try {
+            dappConnectStore.setTxProgress('signing');
+            if (method === 'qrl_signTransaction') {
+              const rawTx = await desktopSigner.signTransactionOnly({
+                from: activeAddress,
+                to: toD,
+                value: valueD,
+                data: dataD,
+              });
+              dappConnectStore.approveCurrentRequest(rawTx);
+              dappConnectStore.resetTxProgress();
+              setLoading(false);
+              return;
+            }
+            dappConnectStore.setTxProgress('broadcasting');
+            const { transactionHash } = await desktopSigner.signAndSendTransaction({
+              from: activeAddress,
+              to: toD,
+              value: valueD,
+              data: dataD,
+            });
+            dappConnectStore.setTxProgress('confirmed', transactionHash);
+            dappConnectStore.sendApprovalResult(transactionHash);
+            setLoading(false);
+          } catch (e) {
+            const errMsg = e instanceof Error ? e.message : String(e);
+            console.log('[DAppConnect] desktop tx error:', errMsg);
+            const userError = toUserFacingError(errMsg);
+            dappConnectStore.setTxProgress('failed', undefined, userError);
+            dappConnectStore.sendRejectionResult(`Transaction failed: ${userError}`);
+            setLoading(false);
+          }
+          return;
+        }
+
+        const pinToUse = getNativeInjectedPin() || pin;
         // Guard empty PIN *before* entering the 'signing' progress state.
         // Once txProgress leaves 'idle' the modal switches to its terminal
         // view (PIN input unmounts, only a Close button remains), so an empty
@@ -308,6 +355,20 @@ const DAppApprovalModal = observer(() => {
           setLoading(false);
           return;
         }
+        // Desktop: sign in the isolated signer (its own trusted modal); no PIN,
+        // no seed in the renderer.
+        if (isDesktop) {
+          try {
+            const result = await desktopSigner.signMessage(messageHex);
+            dappConnectStore.approveCurrentRequest(result);
+          } catch (e) {
+            const errMsg = e instanceof Error ? e.message : String(e);
+            setError(`Message signing failed: ${errMsg}`);
+            dappConnectStore.rejectCurrentRequest(`Message signing failed: ${errMsg}`);
+          }
+          setLoading(false);
+          return;
+        }
         const pinToUse = getNativeInjectedPin() || pin;
         const unlocked = await unlockHexSeed(pinToUse, activeAddress);
         if ('error' in unlocked) {
@@ -349,6 +410,23 @@ const DAppApprovalModal = observer(() => {
         }
         if (signerParam.toLowerCase() !== activeAddress.toLowerCase()) {
           setError('Signer mismatch: request is for a different account');
+          setLoading(false);
+          return;
+        }
+        // Desktop: typed-data signing is not yet supported in the signer (the
+        // hasher has not been ported). Surface a clear error instead of any
+        // in-renderer fallback.
+        if (isDesktop) {
+          try {
+            const result = await desktopSigner.signTypedData(payload);
+            dappConnectStore.approveCurrentRequest(result);
+          } catch (e) {
+            const errMsg = e instanceof Error ? e.message : String(e);
+            setError('Typed-data signing not yet supported on desktop');
+            dappConnectStore.rejectCurrentRequest(
+              `Typed-data signing not yet supported on desktop: ${errMsg}`,
+            );
+          }
           setLoading(false);
           return;
         }
@@ -603,7 +681,9 @@ const DAppApprovalModal = observer(() => {
                 </div>
               )}
 
-              {needsPin && !hasNativePin && (
+              {/* PIN entry is web/native only. On desktop the signer session is
+                  already unlocked and signing does not re-prompt. */}
+              {needsPin && !hasNativePin && !isDesktop && (
                 <div>
                   <label className="mb-1 block text-sm font-medium">Enter PIN to sign</label>
                   <input

--- a/src/components/Core/Body/Home/AccountCreateImport/AccountCreateImport.tsx
+++ b/src/components/Core/Body/Home/AccountCreateImport/AccountCreateImport.tsx
@@ -14,6 +14,7 @@ import { observer } from "mobx-react-lite";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { connectToExtension } from "@/utils/extension";
 import { isInNativeApp } from "@/utils/nativeApp";
+import { isDesktop } from "@/desktop/bridge";
 
 const accountCreateImportClasses = cva("flex gap-8", {
   variants: {
@@ -36,7 +37,9 @@ const AccountCreateImport = observer(() => {
 
   const hasActiveAccount = !!accountAddress;
   const hasAccountCreationPreference = !!state?.hasAccountCreationPreference;
-  const description = isInNativeApp()
+  // The browser-extension connect option is web-only (hidden in the native app
+  // and the desktop app), so its mention is dropped from the copy there too.
+  const description = (isInNativeApp() || isDesktop)
     ? "You are connected to the blockchain. Create a new account or import an existing account."
     : "You are connected to the blockchain. Create a new account, import an existing account, or connect using your browser extension.";
 
@@ -76,7 +79,9 @@ const AccountCreateImport = observer(() => {
               Import an existing account
             </Button>
           </Link>
-          {!isInNativeApp() && (
+          {/* Browser-extension connect is web-only. Hidden in the native app
+              and on desktop (the desktop signer is the wallet). */}
+          {!isInNativeApp() && !isDesktop && (
             <Button className="w-full" type="button" variant="outline" onClick={handleConnectExtension}>
               <Link2 className="mr-2 h-4 w-4" />
               Connect Browser Extension

--- a/src/components/Core/Body/ImportAccount/ImportAccount.tsx
+++ b/src/components/Core/Body/ImportAccount/ImportAccount.tsx
@@ -14,6 +14,7 @@ import { AlertCircle } from "lucide-react";
 import { Link } from "react-router-dom";
 import { ROUTES } from "@/router/router";
 import { Button } from "@/components/UI/Button";
+import { isDesktop } from "@/desktop/bridge";
 
 const ImportAccount = observer(() => {
   const { qrlStore } = useStore();
@@ -28,11 +29,20 @@ const ImportAccount = observer(() => {
   const onAccountImported = async (importedAccount: ExtendedWalletAccount) => {
     window.scrollTo(0, 0);
     setAccount(importedAccount);
-    await setActiveAccount(importedAccount.address);
+    // On desktop the address is not known until the signer imports the wallet
+    // (in PinSetup). Defer setActiveAccount to onPinSetupComplete.
+    if (!isDesktop) {
+      await setActiveAccount(importedAccount.address);
+    }
     setHasAccountImported(true);
   };
 
-  const onPinSetupComplete = () => {
+  // On desktop, PinSetup provisions via the signer and returns the address.
+  const onPinSetupComplete = async (provisionedAddress?: string) => {
+    if (isDesktop && provisionedAddress) {
+      setAccount((prev) => (prev ? { ...prev, address: provisionedAddress } : prev));
+      await setActiveAccount(provisionedAddress);
+    }
     setIsPinSetupComplete(true);
   };
 
@@ -76,11 +86,13 @@ const ImportAccount = observer(() => {
               isPinSetupComplete ? (
                 <AccountImportSuccess account={account} />
               ) : (
-                account && account.mnemonic && account.hexSeed ? (
+                // Desktop only needs the mnemonic (the signer derives the rest
+                // and never returns the hex seed). Web/native also need hexSeed.
+                account && account.mnemonic && (isDesktop || account.hexSeed) ? (
                   <PinSetup
                     accountAddress={account.address}
                     mnemonic={account.mnemonic}
-                    hexSeed={account.hexSeed}
+                    hexSeed={account.hexSeed ?? ""}
                     onPinSetupComplete={onPinSetupComplete}
                   />
                 ) : (
@@ -96,18 +108,26 @@ const ImportAccount = observer(() => {
                   >
                     Import with Mnemonic
                   </TabsTrigger>
-                  <TabsTrigger
-                    value="encrypted"
-                    className="w-full text-sm py-3 px-4 rounded-lg bg-card border border-border hover:bg-accent data-[state=active]:border-secondary data-[state=active]:bg-secondary/10 transition-colors"
-                  >
-                    Import Encrypted Wallet
-                  </TabsTrigger>
-                  <TabsTrigger
-                    value="hexseed"
-                    className="w-full text-sm py-3 px-4 rounded-lg bg-card border border-border hover:bg-accent data-[state=active]:border-secondary data-[state=active]:bg-secondary/10 transition-colors"
-                  >
-                    Import with Hex Seed
-                  </TabsTrigger>
+                  {/* Encrypted-wallet-file restore and raw hex-seed import are
+                      web/native only: neither has a signer intake on desktop
+                      (the signer would never accept raw hex / decrypt a file in
+                      the renderer), so the tabs are hidden there. */}
+                  {!isDesktop && (
+                    <>
+                      <TabsTrigger
+                        value="encrypted"
+                        className="w-full text-sm py-3 px-4 rounded-lg bg-card border border-border hover:bg-accent data-[state=active]:border-secondary data-[state=active]:bg-secondary/10 transition-colors"
+                      >
+                        Import Encrypted Wallet
+                      </TabsTrigger>
+                      <TabsTrigger
+                        value="hexseed"
+                        className="w-full text-sm py-3 px-4 rounded-lg bg-card border border-border hover:bg-accent data-[state=active]:border-secondary data-[state=active]:bg-secondary/10 transition-colors"
+                      >
+                        Import with Hex Seed
+                      </TabsTrigger>
+                    </>
+                  )}
                 </TabsList>
                 <TabsContent
                   value="mnemonic"
@@ -115,18 +135,22 @@ const ImportAccount = observer(() => {
                 >
                   <ImportAccountForm onAccountImported={onAccountImported} />
                 </TabsContent>
-                <TabsContent
-                  value="encrypted"
-                  className="mt-6 w-full border-none outline-none focus-visible:ring-0"
-                >
-                  <ImportEncryptedWallet onWalletImported={onAccountImported} />
-                </TabsContent>
-                <TabsContent
-                  value="hexseed"
-                  className="mt-6 w-full border-none outline-none focus-visible:ring-0"
-                >
-                  <ImportHexSeedForm onAccountImported={onAccountImported} />
-                </TabsContent>
+                {!isDesktop && (
+                  <>
+                    <TabsContent
+                      value="encrypted"
+                      className="mt-6 w-full border-none outline-none focus-visible:ring-0"
+                    >
+                      <ImportEncryptedWallet onWalletImported={onAccountImported} />
+                    </TabsContent>
+                    <TabsContent
+                      value="hexseed"
+                      className="mt-6 w-full border-none outline-none focus-visible:ring-0"
+                    >
+                      <ImportHexSeedForm onAccountImported={onAccountImported} />
+                    </TabsContent>
+                  </>
+                )}
               </Tabs>
             )}
           </div>

--- a/src/components/Core/Body/ImportAccount/ImportAccountForm/ImportAccountForm.tsx
+++ b/src/components/Core/Body/ImportAccount/ImportAccountForm/ImportAccountForm.tsx
@@ -23,6 +23,7 @@ import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { deriveHexSeedAsync } from "@/utils/crypto";
 import type { ExtendedWalletAccount } from "@/utils/crypto";
+import { isDesktop } from "@/desktop/bridge";
 
 const FormSchema = z.object({
   mnemonicPhrases: z.string().min(1, "Mnemonic phrases are required"),
@@ -51,9 +52,21 @@ export const ImportAccountForm = ({ onAccountImported }: ImportAccountFormProps)
 
   async function onSubmit(formData: z.output<typeof FormSchema>) {
     try {
+      // Desktop: do NOT derive the hex seed or build a local account (no
+      // deriveHexSeedAsync / seedToAccount). The signer owns key derivation.
+      // Forward only the mnemonic; PinSetup collects the password and calls
+      // importWallet, and the signer returns the address. We carry the
+      // mnemonic on a placeholder account (address filled in by PinSetup) so
+      // the existing import-flow plumbing is unchanged.
+      if (isDesktop) {
+        const account = { address: "", mnemonic: formData.mnemonicPhrases } as ExtendedWalletAccount;
+        onAccountImported(account);
+        return;
+      }
+
       const hexSeed = await deriveHexSeedAsync(formData.mnemonicPhrases);
       const account = qrlInstance?.accounts.seedToAccount(hexSeed) as ExtendedWalletAccount;
-      
+
       if (!account) {
         throw new Error("Failed to create account from mnemonic");
       }

--- a/src/components/Core/Body/Nfts/NftDetail.tsx
+++ b/src/components/Core/Body/Nfts/NftDetail.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/utils/web3";
 import { WalletEncryptionUtil } from "@/utils/crypto";
 import { getAddressFromMnemonicAsync } from "@/utils/crypto";
+import { isDesktop } from "@/desktop/bridge";
 import { NftImage } from "./NftImage";
 import { ROUTES } from "@/router/router";
 
@@ -128,6 +129,18 @@ const NftDetail = observer(() => {
         setSendError(
           "Extension-signed NFT transfers are coming soon. Switch to an imported account to transfer for now.",
         );
+        setIsSending(false);
+        return;
+      }
+
+      if (isDesktop) {
+        // Desktop: no PIN, no seed in the renderer. The store builds the
+        // safeTransferFrom calldata and routes through the signer; the
+        // mnemonic arg is unused.
+        const ok = await nftStore.transferNft(nft, toAddress, "", amountBig);
+        if (!ok) {
+          setSendError(qrlStore.transactionStatus.error ?? "Transfer failed.");
+        }
         setIsSending(false);
         return;
       }
@@ -335,7 +348,9 @@ const NftDetail = observer(() => {
               </div>
             )}
 
-            {!isExtension && (
+            {/* PIN entry is web/native only. On desktop the signer session
+                authorizes the transfer (no PIN). */}
+            {!isExtension && !isDesktop && (
               <div>
                 <Label>Wallet PIN</Label>
                 <PinInput

--- a/src/components/Core/Body/PinSetup/PinSetup.tsx
+++ b/src/components/Core/Body/PinSetup/PinSetup.tsx
@@ -2,14 +2,20 @@ import { useState, useEffect } from "react";
 import {
   Card,
   CardContent,
+  CardDescription,
   CardFooter,
   CardHeader,
   CardTitle,
 } from "../../../UI/Card";
 import {
   Form,
+  FormControl,
+  FormDescription,
   FormField,
+  FormItem,
+  FormMessage,
 } from "../../../UI/Form";
+import { Input } from "../../../UI/Input";
 import { PinInput } from "../../../UI/PinInput/PinInput";
 import { ShinyButton } from "../../../UI/ShinyButton";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -20,6 +26,15 @@ import { encryptSeedAsync, decryptSeedAsync, CryptoOperationError, CryptoErrorCo
 import { StorageUtil } from "@/utils/storage";
 import { useStore } from "../../../../stores/store";
 import { isInNativeApp, notifySeedStored } from "@/utils/nativeApp";
+import { isDesktop, desktopSigner } from "@/desktop/bridge";
+
+// Password must match the signer's policy; same regex the create form uses.
+const passwordValidation = z.string()
+  .min(8, "Password must be at least 8 characters")
+  .regex(/[A-Z]/, "Password must contain at least one uppercase letter")
+  .regex(/[a-z]/, "Password must contain at least one lowercase letter")
+  .regex(/\d/, "Password must contain at least one number")
+  .regex(/[!@#$%^&*(),.?":{}|<>]/, "Password must contain at least one special character (!@#$%^&*(),.?\":{}|<>)");
 
 // Base PIN validation
 const pinValidation = z.string()
@@ -52,10 +67,154 @@ type PinSetupProps = {
   accountAddress: string;
   mnemonic: string;
   hexSeed: string;
-  onPinSetupComplete: () => void;
+  // On desktop the signer provisions the wallet and returns the address, which
+  // is passed back so the caller can set it active.
+  onPinSetupComplete: (provisionedAddress?: string) => void;
 };
 
 export const PinSetup = ({
+  accountAddress,
+  mnemonic,
+  hexSeed,
+  onPinSetupComplete,
+}: PinSetupProps) => {
+  // Desktop provisioning chokepoint: collect a PASSWORD (not a PIN) and import
+  // the wallet via the signer. No seed material is encrypted or stored in the
+  // renderer (no encryptSeedAsync / storeEncryptedSeed).
+  if (isDesktop) {
+    return (
+      <DesktopPasswordSetup
+        mnemonic={mnemonic}
+        onPinSetupComplete={onPinSetupComplete}
+      />
+    );
+  }
+  return (
+    <WebPinSetup
+      accountAddress={accountAddress}
+      mnemonic={mnemonic}
+      hexSeed={hexSeed}
+      onPinSetupComplete={onPinSetupComplete}
+    />
+  );
+};
+
+type DesktopPasswordValues = {
+  password: string;
+  reEnteredPassword: string;
+};
+
+const DesktopPasswordSchema = z.object({
+  password: passwordValidation,
+  reEnteredPassword: z.string().min(1, "Please re-enter your password"),
+}).refine((data) => data.password === data.reEnteredPassword, {
+  message: "Passwords don't match",
+  path: ["reEnteredPassword"],
+});
+
+const DesktopPasswordSetup = ({
+  mnemonic,
+  onPinSetupComplete,
+}: {
+  mnemonic: string;
+  onPinSetupComplete: (provisionedAddress?: string) => void;
+}) => {
+  const [isProvisioning, setIsProvisioning] = useState(false);
+  const form = useForm<DesktopPasswordValues>({
+    resolver: zodResolver(DesktopPasswordSchema),
+    mode: "onChange",
+    reValidateMode: "onChange",
+    defaultValues: { password: "", reEnteredPassword: "" },
+  });
+  const {
+    handleSubmit,
+    control,
+    formState: { isSubmitting, isValid },
+    setError,
+  } = form;
+
+  async function onSubmit(data: DesktopPasswordValues) {
+    setIsProvisioning(true);
+    try {
+      const status = await desktopSigner.importWallet(mnemonic, data.password);
+      setIsProvisioning(false);
+      onPinSetupComplete(status.address);
+    } catch (error) {
+      setIsProvisioning(false);
+      setError("password", {
+        message: `${error instanceof Error ? error.message : String(error)} There was an error importing your wallet`,
+      });
+    }
+  }
+
+  return (
+    <Form {...form}>
+      <form className="w-full" onSubmit={handleSubmit(onSubmit)}>
+        <Card className="border-l-4 border-l-orange-500">
+          <CardHeader className="bg-gradient-to-r from-orange-500/5 to-transparent">
+            <CardTitle className="text-2xl font-bold">Set Wallet Password</CardTitle>
+            <CardDescription>
+              This password unlocks your wallet on this device. The signer
+              encrypts your seed with it; it never leaves your machine.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <FormField
+              control={control}
+              name="password"
+              render={({ field }) => (
+                <FormItem>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      disabled={isSubmitting || isProvisioning}
+                      placeholder="Password"
+                      type="password"
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    Must include uppercase, lowercase, number, and special character
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={control}
+              name="reEnteredPassword"
+              render={({ field }) => (
+                <FormItem>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      disabled={isSubmitting || isProvisioning}
+                      placeholder="Re-enter the password"
+                      type="password"
+                    />
+                  </FormControl>
+                  <FormDescription>Re-enter the password</FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </CardContent>
+          <CardFooter>
+            <ShinyButton
+              disabled={isSubmitting || !isValid || isProvisioning}
+              processing={isProvisioning}
+              className="w-full"
+              type="submit"
+            >
+              {isProvisioning ? "Importing..." : "Import Wallet"}
+            </ShinyButton>
+          </CardFooter>
+        </Card>
+      </form>
+    </Form>
+  );
+};
+
+const WebPinSetup = ({
   accountAddress,
   mnemonic,
   hexSeed,

--- a/src/components/Core/Body/Settings/Settings.tsx
+++ b/src/components/Core/Body/Settings/Settings.tsx
@@ -32,6 +32,7 @@ import { SEO } from "@/components/SEO/SEO";
 import { PinInput } from "@/components/UI/PinInput/PinInput";
 import { decryptSeedAsync, reEncryptSeedAsync } from "@/utils/crypto";
 import { isInNativeApp, sendPinChanged } from "@/utils/nativeApp";
+import { isDesktop } from "@/desktop/bridge";
 import {
     checkLockout,
     recordFailedAttempt,
@@ -241,8 +242,10 @@ const Settings = observer(() => {
                         <source src="/tree.mp4" type="video/mp4" />
                     </video> */ }
                     <div className="relative z-10 space-y-4 md:space-y-8">
-                        {/* PIN Management Card - only visible when user has encrypted seeds */}
-                        {hasEncryptedSeeds && (
+                        {/* PIN Management Card - web/native only. On desktop there
+                            is no PIN (the signer uses a password / Argon2id) and
+                            no in-renderer re-encrypt, so the card is hidden. */}
+                        {hasEncryptedSeeds && !isDesktop && (
                             <Card className="border-l-4 border-l-orange-500">
                                 <CardHeader className="bg-gradient-to-r from-orange-500/5 to-transparent">
                                     <div className="flex items-center gap-2">

--- a/src/components/Core/Body/Transfer/Transfer.tsx
+++ b/src/components/Core/Body/Transfer/Transfer.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/UI/Button";
+import { ShinyButton } from "@/components/UI/ShinyButton";
 import {
   Card,
   CardContent,
@@ -32,7 +33,6 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { utils } from "@theqrl/web3";
 import { Loader, Send, X, Copy, Coins, ExternalLink, ScanLine, Check } from "lucide-react";
 import { observer } from "mobx-react-lite";
-import { ShinyButton } from "@/components/UI/ShinyButton";
 import { useEffect, useState, useMemo, useCallback } from "react";
 import { useForm } from "react-hook-form";
 import { useNavigate, useSearchParams } from "react-router-dom";
@@ -43,6 +43,7 @@ import { getExplorerAddressUrl, getExplorerTxUrl, QRL_PROVIDER } from "@/config"
 import { Slider } from "@/components/UI/Slider";
 import { PinInput } from "@/components/UI/PinInput/PinInput";
 import { WalletEncryptionUtil, getAddressFromMnemonicAsync } from "@/utils/crypto";
+import { isDesktop } from "@/desktop/bridge";
 import { copyToClipboard, openExternalUrl, isInNativeApp, requestQRScan, subscribeToNativeMessages, triggerHaptic } from "@/utils/nativeApp";
 import type { FeeLevel } from "@/stores/qrlStore";
 import { SEO } from "@/components/SEO/SEO";
@@ -95,8 +96,10 @@ const Transfer = observer(() => {
         }
       }
 
-      // Validate PIN for non-extension accounts
-      if (!isUsingExtension) {
+      // Validate PIN for non-extension seed accounts. On desktop there is no
+      // PIN: the signer session is already unlocked, so the PIN field is
+      // hidden and not required.
+      if (!isUsingExtension && !isDesktop) {
         if (!fields.pin || fields.pin.length < 4 || fields.pin.length > 6) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
@@ -343,7 +346,17 @@ const Transfer = observer(() => {
   async function handleNativeTransfer(formData: z.infer<typeof FormSchema>) {
     const valueEther = formData.amount.toString();
 
-    if (isUsingExtension) {
+    if (isDesktop) {
+      // Desktop: no PIN, no seed in the renderer. The store routes through the
+      // signer (build + confirm + sign + broadcast); the mnemonic arg is unused.
+      try {
+        await signAndSendTransaction(accountAddress, formData.receiverAddress, valueEther, "", feeLevel);
+        resetForm();
+        window.scrollTo(0, 0);
+      } catch (error) {
+        control.setError("receiverAddress", { message: `Transaction failed: ${error instanceof Error ? error.message : String(error)}` });
+      }
+    } else if (isUsingExtension) {
       await sendTransactionViaExtension(formData.receiverAddress, valueEther, feeLevel);
       resetForm();
       window.scrollTo(0, 0);
@@ -389,6 +402,20 @@ const Transfer = observer(() => {
 
   async function handleTokenTransfer(formData: z.infer<typeof FormSchema>) {
     if (!selectedToken) return;
+
+    if (isDesktop) {
+      // Desktop: no PIN, no seed in the renderer. The store builds the transfer
+      // calldata and routes through the signer; the mnemonic arg is unused.
+      try {
+        const rawAmount = parseUnits(formData.amount.toString(), selectedToken.decimals).toString();
+        await sendTokenToStore(selectedToken, rawAmount, "", formData.receiverAddress);
+        resetForm();
+        window.scrollTo(0, 0);
+      } catch (error) {
+        control.setError("receiverAddress", { message: `Transfer failed: ${error instanceof Error ? error.message : String(error)}` });
+      }
+      return;
+    }
 
     try {
       const encryptedSeed = await StorageUtil.getEncryptedSeed(blockchain, accountAddress);
@@ -726,7 +753,7 @@ const Transfer = observer(() => {
                           </div>
                         )}
                         {!isScanning && !scanSuccess && (
-                          <FormDescription className="text-xs text-muted-foreground/70">
+                          <FormDescription>
                             Enter the receiver's account address{isInNativeApp() ? ' or scan QR' : ''}
                           </FormDescription>
                         )}
@@ -804,8 +831,9 @@ const Transfer = observer(() => {
                     )}
                   />
 
-                  {/* PIN Input */}
-                  {!isUsingExtension && (
+                  {/* PIN Input. Hidden on desktop: the signer session is
+                      already unlocked and signing does not re-prompt. */}
+                  {!isUsingExtension && !isDesktop && (
                     <FormField
                       control={control}
                       name="pin"
@@ -820,7 +848,7 @@ const Transfer = observer(() => {
                               disabled={isSubmitting}
                             />
                           </FormControl>
-                          <FormDescription className="text-xs text-muted-foreground/70">
+                          <FormDescription>
                             Enter the PIN used to encrypt your wallet seed
                           </FormDescription>
                           <FormMessage />
@@ -851,11 +879,7 @@ const Transfer = observer(() => {
                     processing={isSubmitting}
                     type="submit"
                   >
-                    {isSubmitting ? (
-                      <Loader className="mr-2 h-4 w-4 animate-spin" />
-                    ) : (
-                      <Send className="mr-2 h-4 w-4" />
-                    )}
+                    <Send className="mr-2 h-4 w-4" />
                     {isSubmitting ? `Sending ${assetSymbol}...` : `Send ${assetSymbol}`}
                   </ShinyButton>
                 </CardFooter>

--- a/src/desktop/bridge.ts
+++ b/src/desktop/bridge.ts
@@ -1,0 +1,263 @@
+/**
+ * Desktop (Electron) seam.
+ *
+ * When this web wallet runs as the renderer of the MyQRLWallet Electron
+ * desktop app, NO secret key material (mnemonic, hex extended seed, ML-DSA-87
+ * secret key) may ever be materialised in the renderer. Every key-touching
+ * operation routes through the isolated signer in the main process via the
+ * `window.qrlWallet` preload bridge.
+ *
+ * The web build does not inject `window.qrlWallet`, so `isDesktop` is false and
+ * every call site falls through to its untouched web path. Nothing in this
+ * module runs on the web build.
+ *
+ * Call sites do `if (isDesktop) return desktopSigner.X(...)` at the top of the
+ * existing function; the web path below is left identical.
+ */
+
+// ---------------------------------------------------------------------------
+// Bridge contract (mirror of window.qrlWallet). All methods async unless noted.
+// ---------------------------------------------------------------------------
+
+/** Signer wallet status snapshot returned by status/unlock/lock/create/import. */
+export interface WalletStatus {
+  hasWallet: boolean;
+  locked: boolean;
+  address: string;
+  /** Epoch ms when the current unlock session expires, if unlocked. */
+  unlockExpiresAt?: number;
+  /** True when the seed is held by the OS keychain (macOS). */
+  keychainBacked?: boolean;
+}
+
+/** Unsigned transaction shape produced by the signer (nonce/gas/chainId filled in main). */
+export interface UnsignedTransaction {
+  from: string;
+  to: string;
+  /** Smallest-unit decimal string. */
+  value: string;
+  data?: string;
+  nonce?: number | string;
+  gas?: number | string;
+  maxFeePerGas?: number | string;
+  maxPriorityFeePerGas?: number | string;
+  gasPrice?: number | string;
+  chainId?: number | string;
+  type?: string;
+}
+
+export type FeeLevelHint = 'low' | 'medium' | 'high';
+
+/** Result of a signing request handled by the signer (after its trusted confirm modal). */
+export interface SignatureResult {
+  kind: 'transaction' | 'message' | 'typedData';
+  signature: string;
+  publicKey?: string;
+  signer: string;
+  digest?: string;
+  /** Present for `kind: 'transaction'`: the broadcast-ready signed payload. */
+  rawTransaction?: string;
+}
+
+/** Discriminated union of signature requests sent to the signer. */
+export type SignatureRequest =
+  | { kind: 'transaction'; tx: UnsignedTransaction }
+  | { kind: 'message'; messageHex: string }
+  | { kind: 'typedData'; payload: unknown };
+
+export interface CreateWalletResult {
+  status: WalletStatus;
+  /** Returned ONCE for backup. The hexSeed is never returned to the renderer. */
+  mnemonic: string;
+}
+
+/**
+ * The preload-exposed bridge. Mirrors the signer contract documented in the
+ * desktop app. Kept structural (no class) so the preload's plain object
+ * satisfies it.
+ */
+export interface QrlWalletBridge {
+  createWallet(args: { password: string; useKeychain?: boolean }): Promise<CreateWalletResult>;
+  importWallet(args: {
+    mnemonic: string;
+    password: string;
+    useKeychain?: boolean;
+  }): Promise<WalletStatus>;
+  /** Omit password to attempt an OS keychain unlock (macOS). */
+  unlock(args?: { password?: string }): Promise<WalletStatus>;
+  lock(): Promise<WalletStatus>;
+  getStatus(): Promise<WalletStatus>;
+  hasWallet(): Promise<boolean>;
+  getBalance(args: { address: string }): Promise<{ address: string; balance: string }>;
+  buildTransaction(args: {
+    from: string;
+    to: string;
+    /** Smallest-unit decimal string. */
+    value: string;
+    feeLevel?: FeeLevelHint;
+    data?: string;
+  }): Promise<UnsignedTransaction>;
+  requestSignature(request: SignatureRequest): Promise<SignatureResult>;
+  sendRawTransaction(args: { rawTx: string }): Promise<{ transactionHash: string }>;
+  onLockStateChanged(cb: (locked: boolean) => void): () => void;
+}
+
+declare global {
+  interface Window {
+    qrlWallet?: QrlWalletBridge;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Detection + typed accessor
+// ---------------------------------------------------------------------------
+
+/**
+ * True only when the renderer is hosted by the Electron desktop app, which
+ * injects `window.qrlWallet` from its preload. Computed once at module load:
+ * the bridge is present for the lifetime of the renderer or not at all, so a
+ * snapshot avoids re-reading `window` on every call site.
+ */
+export const isDesktop: boolean =
+  typeof window !== 'undefined' && Boolean((window as { qrlWallet?: unknown }).qrlWallet);
+
+/**
+ * Typed accessor for the bridge. Throws if absent so a desktop-only path that
+ * somehow runs without the bridge fails loudly instead of leaking to a web
+ * fallback.
+ */
+export function qrlWallet(): QrlWalletBridge {
+  const bridge = typeof window !== 'undefined' ? window.qrlWallet : undefined;
+  if (!bridge) {
+    throw new Error('desktop: window.qrlWallet bridge is not available');
+  }
+  return bridge;
+}
+
+// ---------------------------------------------------------------------------
+// High-level adapter used by call sites
+// ---------------------------------------------------------------------------
+
+/**
+ * Thin adapter over the bridge with the high-level helpers the call sites use.
+ * Each helper keeps key material in the signer: the renderer only ever sees
+ * public addresses, unsigned/signed transaction blobs, and signatures.
+ */
+export const desktopSigner = {
+  /** Provision a fresh wallet. Returns the one-time mnemonic for backup. */
+  async createWallet(password: string, useKeychain?: boolean): Promise<CreateWalletResult> {
+    return qrlWallet().createWallet({ password, useKeychain });
+  },
+
+  /** Import an existing wallet from its mnemonic. */
+  async importWallet(
+    mnemonic: string,
+    password: string,
+    useKeychain?: boolean,
+  ): Promise<WalletStatus> {
+    return qrlWallet().importWallet({ mnemonic, password, useKeychain });
+  },
+
+  /** Unlock the signer session. Omit password for an OS keychain unlock. */
+  async unlock(password?: string): Promise<WalletStatus> {
+    return qrlWallet().unlock(password === undefined ? undefined : { password });
+  },
+
+  /** Lock the signer session (keeps the seed, drops the in-memory session). */
+  async lock(): Promise<WalletStatus> {
+    return qrlWallet().lock();
+  },
+
+  async getStatus(): Promise<WalletStatus> {
+    return qrlWallet().getStatus();
+  },
+
+  async hasWallet(): Promise<boolean> {
+    return qrlWallet().hasWallet();
+  },
+
+  /** Balance in smallest-unit decimal string for the given address. */
+  async getBalance(address: string): Promise<string> {
+    const result = await qrlWallet().getBalance({ address });
+    return result.balance;
+  },
+
+  /**
+   * Build (in main), confirm + sign (signer modal), then broadcast a
+   * transaction. `value`/`data` are pure renderer-side inputs; nonce, gas and
+   * chainId are filled by main. Returns the broadcast transaction hash.
+   */
+  async signAndSendTransaction(args: {
+    from: string;
+    to: string;
+    /** Smallest-unit decimal string. */
+    value: string;
+    data?: string;
+    feeLevel?: FeeLevelHint;
+  }): Promise<{ transactionHash: string }> {
+    const bridge = qrlWallet();
+    const tx = await bridge.buildTransaction({
+      from: args.from,
+      to: args.to,
+      value: args.value,
+      data: args.data,
+      feeLevel: args.feeLevel,
+    });
+    const signed = await bridge.requestSignature({ kind: 'transaction', tx });
+    if (!signed.rawTransaction) {
+      throw new Error('desktop: signer returned no raw transaction');
+    }
+    return bridge.sendRawTransaction({ rawTx: signed.rawTransaction });
+  },
+
+  /**
+   * Build + confirm + sign a transaction WITHOUT broadcasting. Used by the
+   * dApp `qrl_signTransaction` path which returns the raw tx to the dApp.
+   */
+  async signTransactionOnly(args: {
+    from: string;
+    to: string;
+    /** Smallest-unit decimal string. */
+    value: string;
+    data?: string;
+    feeLevel?: FeeLevelHint;
+  }): Promise<string> {
+    const bridge = qrlWallet();
+    const tx = await bridge.buildTransaction({
+      from: args.from,
+      to: args.to,
+      value: args.value,
+      data: args.data,
+      feeLevel: args.feeLevel,
+    });
+    const signed = await bridge.requestSignature({ kind: 'transaction', tx });
+    if (!signed.rawTransaction) {
+      throw new Error('desktop: signer returned no raw transaction');
+    }
+    return signed.rawTransaction;
+  },
+
+  /** Sign a hex-encoded message via the signer's trusted modal. */
+  async signMessage(messageHex: string): Promise<SignatureResult> {
+    return qrlWallet().requestSignature({ kind: 'message', messageHex });
+  },
+
+  /**
+   * Sign typed data. The signer currently THROWS (hasher not yet ported), so
+   * callers should surface a clear "not yet supported on desktop" error rather
+   * than falling back to an in-renderer signer.
+   */
+  async signTypedData(payload: unknown): Promise<SignatureResult> {
+    return qrlWallet().requestSignature({ kind: 'typedData', payload });
+  },
+
+  /** Broadcast an already-signed raw transaction. */
+  async sendRawTransaction(rawTx: string): Promise<{ transactionHash: string }> {
+    return qrlWallet().sendRawTransaction({ rawTx });
+  },
+
+  /** Subscribe to lock-state changes pushed by main. Returns an unsubscribe fn. */
+  onLockStateChanged(cb: (locked: boolean) => void): () => void {
+    return qrlWallet().onLockStateChanged(cb);
+  },
+} as const;

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter, RouterProvider } from "react-router-dom";
+import { createBrowserRouter, createHashRouter, RouterProvider } from "react-router-dom";
 import { lazy, Suspense } from "react";
 import { Loading } from "@/components/UI/Loading";
 import { Navigate } from "react-router-dom";
@@ -44,7 +44,16 @@ const ROUTES = {
   NFT_DETAIL: "/nft/:contractAddress/:tokenId",
 } as const;
 
-const router = createBrowserRouter([
+// Under the MyQRLWallet desktop shell the app is loaded from disk via
+// loadFile (file:// origin), where the HTML5 history API does not work and
+// deep links / reloads break. The desktop preload exposes `window.qrlWallet`,
+// so we detect it at runtime and use hash routing there. Web builds are
+// unchanged (no qrlWallet -> createBrowserRouter).
+const isDesktopShell =
+  typeof window !== "undefined" && Boolean((window as { qrlWallet?: unknown }).qrlWallet);
+const createAppRouter = isDesktopShell ? createHashRouter : createBrowserRouter;
+
+const router = createAppRouter([
   {
     path: ROUTES.HOME,
     element: (

--- a/src/stores/nftStore.ts
+++ b/src/stores/nftStore.ts
@@ -12,6 +12,7 @@ import { getQrlWeb3 } from "@/utils/web3";
 import { QRL_PROVIDER } from "@/config";
 import { StorageUtil } from "@/utils/storage";
 import { deriveHexSeedAsync } from "@/utils/crypto";
+import { isDesktop, desktopSigner } from "@/desktop/bridge";
 import type { NFTInterface } from "@/constants";
 import { erc721ABI } from "@/abi/ERC721ABI";
 import { erc1155ABI } from "@/abi/ERC1155ABI";
@@ -264,6 +265,83 @@ class NftStore {
     feeLevel: FeeLevel = "medium",
   ): Promise<boolean> {
     this.qrlStore.resetTransactionStatus();
+
+    // Desktop: build the safeTransferFrom calldata purely (no seed), then
+    // route build/sign/broadcast through the signer. `mnemonicPhrases` is
+    // intentionally unused (the renderer never holds it on desktop).
+    if (isDesktop) {
+      try {
+        const selectedBlockChain = await StorageUtil.getBlockChain();
+        const { url } =
+          QRL_PROVIDER[selectedBlockChain as keyof typeof QRL_PROVIDER];
+        const { default: Web3 } = await getQrlWeb3();
+        const web3 = new Web3(new Web3.providers.HttpProvider(url));
+        const from = this.qrlStore.activeAccount.accountAddress;
+
+        let data: string;
+        if (nft.standard === "ERC721") {
+          const methods = contractMethods<Erc721Methods>(
+            web3,
+            erc721ABI,
+            nft.contractAddress,
+          );
+          data = methods
+            .safeTransferFrom(from, toAddress, nft.tokenId)
+            .encodeABI();
+        } else {
+          const methods = contractMethods<Erc1155Methods>(
+            web3,
+            erc1155ABI,
+            nft.contractAddress,
+          );
+          data = methods
+            .safeTransferFrom(
+              from,
+              toAddress,
+              nft.tokenId,
+              amount.toString(),
+              "0x",
+            )
+            .encodeABI();
+        }
+
+        const { transactionHash } = await desktopSigner.signAndSendTransaction({
+          from,
+          to: nft.contractAddress,
+          value: "0",
+          data,
+          feeLevel,
+        });
+        runInAction(() => {
+          this.qrlStore.transactionStatus = {
+            state: "pending",
+            txHash: transactionHash,
+            receipt: null,
+            error: null,
+            pendingDetails: null,
+          };
+        });
+        log(`Desktop NFT transfer broadcast: ${transactionHash}`);
+        this.qrlStore.fetchPendingTxDetails(transactionHash);
+        this.qrlStore.pollForReceipt(transactionHash);
+        this.refreshNftBalances();
+        return true;
+      } catch (error) {
+        const message = getErrorMessage(error);
+        runInAction(() => {
+          this.qrlStore.transactionStatus = {
+            state: "failed",
+            txHash: null,
+            receipt: null,
+            error: `NFT transfer failed: ${message}`,
+            pendingDetails: null,
+          };
+        });
+        log(`Desktop NFT transfer preparation failed: ${message}`);
+        return false;
+      }
+    }
+
     try {
       const selectedBlockChain = await StorageUtil.getBlockChain();
       const { url } =

--- a/src/stores/qrlStore.ts
+++ b/src/stores/qrlStore.ts
@@ -1,5 +1,6 @@
 import { QRL_PROVIDER, EXPLORER_BASE, getPendingTxApiUrl } from "@/config";
 import { deriveHexSeedAsync } from "@/utils/crypto";
+import { isDesktop, desktopSigner } from "@/desktop/bridge";
 import type { AccountListItem, AccountSource } from "@/utils/storage";
 import { StorageUtil } from "@/utils/storage";
 import { log } from "@/utils";
@@ -557,6 +558,48 @@ class QrlStore {
   ) {
     // Reset status before starting a new transaction
     this.resetTransactionStatus();
+
+    // Desktop: build calldata-free native transfer in main, confirm + sign in
+    // the signer, and broadcast, all without any seed material in the renderer.
+    // `mnemonicPhrases` is intentionally unused here (the renderer never holds
+    // it on desktop). The bridge wants the value in smallest units.
+    if (isDesktop) {
+      try {
+        const utils = this._utils ?? (await getQrlWeb3()).utils;
+        const valuePlanck = BigInt(utils.toPlanck(value, "quanta")).toString();
+        const { transactionHash } = await desktopSigner.signAndSendTransaction({
+          from,
+          to,
+          value: valuePlanck,
+          feeLevel,
+        });
+        runInAction(() => {
+          this.transactionStatus = {
+            state: 'pending',
+            txHash: transactionHash,
+            receipt: null,
+            error: null,
+            pendingDetails: null,
+          };
+        });
+        log(`Desktop transaction broadcast with hash: ${transactionHash}`);
+        this.fetchPendingTxDetails(transactionHash);
+        this.pollForReceipt(transactionHash);
+      } catch (error) {
+        const message = getErrorMessage(error);
+        runInAction(() => {
+          this.transactionStatus = {
+            state: 'failed',
+            txHash: null,
+            receipt: null,
+            error: `Transaction failed: ${message}`,
+            pendingDetails: null,
+          };
+        });
+        log(`Desktop transaction failed: ${message}`);
+      }
+      return;
+    }
 
     try {
       // Fetch the next available nonce, including pending transactions

--- a/src/stores/tokenStore.ts
+++ b/src/stores/tokenStore.ts
@@ -1,5 +1,6 @@
 import { QRL_PROVIDER } from "@/config";
 import { deriveHexSeedAsync } from "@/utils/crypto";
+import { isDesktop, desktopSigner } from "@/desktop/bridge";
 import { StorageUtil } from "@/utils/storage";
 import { log } from "@/utils";
 import { getErrorMessage } from "@/utils/errors";
@@ -371,6 +372,58 @@ class TokenStore {
     feeLevel: FeeLevel = "medium",
   ) {
     this.qrlStore.resetTransactionStatus();
+
+    // Desktop: build the transfer() calldata purely (no seed), then route the
+    // build/sign/broadcast through the isolated signer. `mnemonicPhrases` is
+    // intentionally unused (the renderer never holds it on desktop).
+    if (isDesktop) {
+      try {
+        const selectedBlockChain = await StorageUtil.getBlockChain();
+        const { url } = QRL_PROVIDER[selectedBlockChain as keyof typeof QRL_PROVIDER];
+        const { default: Web3 } = await getQrlWeb3();
+        const web3 = new Web3(new Web3.providers.HttpProvider(url));
+        const from = this.qrlStore.activeAccount.accountAddress;
+        const contract = new web3.qrl.Contract(CustomERC20ABI, token.address);
+        const data = contract.methods.transfer(toAddress, amount).encodeABI();
+        const { transactionHash } = await desktopSigner.signAndSendTransaction({
+          from,
+          to: token.address,
+          value: "0",
+          data,
+          feeLevel,
+        });
+        runInAction(() => {
+          this.qrlStore.transactionStatus = {
+            state: "pending",
+            txHash: transactionHash,
+            receipt: null,
+            error: null,
+            pendingDetails: null,
+          };
+        });
+        log(`Desktop token transfer broadcast with hash: ${transactionHash}`);
+        this.qrlStore.fetchPendingTxDetails(transactionHash);
+        this.qrlStore.pollForReceipt(transactionHash);
+        // The receipt poller calls fetchAccounts on confirm; refresh token
+        // balances proactively too so the UI updates without a manual reload.
+        this.refreshTokenBalances();
+        return true;
+      } catch (error) {
+        const message = getErrorMessage(error);
+        runInAction(() => {
+          this.qrlStore.transactionStatus = {
+            state: "failed",
+            txHash: null,
+            receipt: null,
+            error: `Token transfer failed: ${message}`,
+            pendingDetails: null,
+          };
+        });
+        log(`Desktop token transfer failed: ${message}`);
+        return false;
+      }
+    }
+
     try {
       const selectedBlockChain = await StorageUtil.getBlockChain();
       const { url } = QRL_PROVIDER[selectedBlockChain as keyof typeof QRL_PROVIDER];
@@ -482,12 +535,8 @@ class TokenStore {
       this.setCreatingToken(tokenName, true);
       const selectedBlockChain = await StorageUtil.getBlockChain();
       const { url } = QRL_PROVIDER[selectedBlockChain as keyof typeof QRL_PROVIDER];
-      const seed = await deriveHexSeedAsync(mnemonicPhrases);
       const { default: Web3, utils } = await getQrlWeb3();
       const web3 = new Web3(new Web3.providers.HttpProvider(url));
-      const acc = web3.qrl.accounts.seedToAccount(seed);
-      web3.qrl.wallet?.add(seed);
-      web3.qrl.transactionConfirmationBlocks = 1;
 
       const contractAddress = import.meta.env['VITE_CUSTOMERC20FACTORY_ADDRESS'] || "";
 
@@ -502,6 +551,20 @@ class TokenStore {
         throw new Error(
           `Factory contract not deployed at address: ${contractAddress}`,
         );
+      }
+
+      // From address: on desktop the active account; on web/native the seed
+      // is derived to obtain the address. The createToken() calldata itself is
+      // pure (no key) either way.
+      let fromAddress: string;
+      if (isDesktop) {
+        fromAddress = this.qrlStore.activeAccount.accountAddress;
+      } else {
+        const seed = await deriveHexSeedAsync(mnemonicPhrases);
+        const acc = web3.qrl.accounts.seedToAccount(seed);
+        web3.qrl.wallet?.add(seed);
+        web3.qrl.transactionConfirmationBlocks = 1;
+        fromAddress = acc.address;
       }
 
       const confirmationHandler = () => {
@@ -601,8 +664,39 @@ class TokenStore {
           maxTxLimit,
         );
 
+      const data = contractCreateToken.encodeABI();
+
+      // Desktop: build/sign/broadcast through the signer, then poll for the
+      // receipt and run the same receiptHandler to extract the token address.
+      if (isDesktop) {
+        const { transactionHash } = await desktopSigner.signAndSendTransaction({
+          from: fromAddress,
+          to: contractAddress,
+          value: "0",
+          data,
+        });
+        log(`Desktop token creation broadcast with hash: ${transactionHash}`);
+        // Poll for the receipt (the signer/main already broadcast it).
+        const maxAttempts = 60;
+        const pollInterval = 5000;
+        let receiptFound = false;
+        for (let attempt = 0; attempt < maxAttempts && !receiptFound; attempt++) {
+          const rcpt = await web3.qrl.getTransactionReceipt(transactionHash).catch(() => null);
+          if (rcpt) {
+            receiptFound = true;
+            await receiptHandler(rcpt as TransactionReceipt);
+          } else {
+            await new Promise((resolve) => setTimeout(resolve, pollInterval));
+          }
+        }
+        if (!receiptFound) {
+          errorHandler(new Error("Token creation confirmation timed out."));
+        }
+        return;
+      }
+
       const estimatedGas = await contractCreateToken.estimateGas({
-        from: acc.address,
+        from: fromAddress,
       });
       const gas = (estimatedGas * 12n) / 10n;
       const currentGasPrice = await web3.qrl.getGasPrice();
@@ -611,8 +705,8 @@ class TokenStore {
       const txObj = {
         gas,
         gasPrice,
-        from: acc.address,
-        data: contractCreateToken.encodeABI(),
+        from: fromAddress,
+        data,
         to: contractAddress,
       };
 

--- a/src/utils/crypto/cryptoWorkerClient.ts
+++ b/src/utils/crypto/cryptoWorkerClient.ts
@@ -17,6 +17,16 @@ import {
   PinDecryptionError,
   OutdatedWalletFormatError,
 } from './walletEncryption';
+import { isDesktop } from '@/desktop/bridge';
+
+/**
+ * Defense-in-depth: on desktop the seed never leaves the isolated signer, so
+ * deriving a hex seed or encrypting/decrypting seed material in the renderer
+ * is a bug. These wrappers throw loudly so any un-rerouted caller fails rather
+ * than leaking. The web build (isDesktop === false) is unaffected.
+ */
+const DESKTOP_SEED_GUARD_MESSAGE =
+  'desktop: key material lives in the signer, not the renderer';
 
 // Vite worker import syntax
 import CryptoWorker from './cryptoWorker?worker';
@@ -58,6 +68,9 @@ export async function encryptSeedAsync(
   hexSeed: string,
   pin: string
 ): Promise<string> {
+  if (isDesktop) {
+    throw new Error(DESKTOP_SEED_GUARD_MESSAGE);
+  }
   try {
     return await WalletEncryptionUtil.encryptSeedWithPin(mnemonic, hexSeed, pin);
   } catch (error) {
@@ -72,6 +85,9 @@ export async function decryptSeedAsync(
   encryptedData: string,
   pin: string
 ): Promise<{ mnemonic: string; hexSeed: string }> {
+  if (isDesktop) {
+    throw new Error(DESKTOP_SEED_GUARD_MESSAGE);
+  }
   try {
     return await WalletEncryptionUtil.decryptSeedWithPin(encryptedData, pin);
   } catch (error) {
@@ -87,6 +103,9 @@ export async function reEncryptSeedAsync(
   oldPin: string,
   newPin: string
 ): Promise<string> {
+  if (isDesktop) {
+    throw new Error(DESKTOP_SEED_GUARD_MESSAGE);
+  }
   try {
     return await WalletEncryptionUtil.reEncryptSeed(encryptedSeed, oldPin, newPin);
   } catch (error) {
@@ -217,6 +236,9 @@ function postToWorker<T extends CryptoWorkerResponse['type']>(
  * undefined / empty / whitespace-only input without acquiring a worker.
  */
 export async function deriveHexSeedAsync(mnemonic: string): Promise<string> {
+  if (isDesktop) {
+    throw new Error(DESKTOP_SEED_GUARD_MESSAGE);
+  }
   if (!mnemonic || !mnemonic.trim()) {
     return "";
   }

--- a/src/utils/crypto/walletEncryption.ts
+++ b/src/utils/crypto/walletEncryption.ts
@@ -1,5 +1,15 @@
 import type { Web3BaseWalletAccount } from '@theqrl/web3';
 import { isInNativeApp, shareContent } from '@/utils/nativeApp';
+import { isDesktop } from '@/desktop/bridge';
+
+/**
+ * Defense-in-depth: on desktop the seed lives only in the isolated signer, so
+ * any renderer code path that tries to materialise or re-encrypt seed material
+ * is a bug. These primitives throw loudly instead of leaking. The web build
+ * (isDesktop === false) is unaffected.
+ */
+const DESKTOP_SEED_GUARD_MESSAGE =
+  'desktop: key material lives in the signer, not the renderer';
 
 export interface WalletData {
   address: string;
@@ -156,6 +166,9 @@ export class WalletEncryptionUtil {
     encryptedWallet: EncryptedWallet,
     password: string,
   ): Promise<WalletData> {
+    if (isDesktop) {
+      throw new Error(DESKTOP_SEED_GUARD_MESSAGE);
+    }
     try {
       const json = await aesGcmDecrypt(
         {
@@ -264,6 +277,9 @@ export class WalletEncryptionUtil {
 
   // PIN-based encryption for localStorage (WebCrypto AES-256-GCM + PBKDF2-SHA256)
   static async encryptSeedWithPin(mnemonic: string, hexSeed: string, pin: string): Promise<string> {
+    if (isDesktop) {
+      throw new Error(DESKTOP_SEED_GUARD_MESSAGE);
+    }
     if (!this.validatePin(pin)) {
       throw new Error('Invalid PIN format');
     }
@@ -284,6 +300,9 @@ export class WalletEncryptionUtil {
     encryptedData: string,
     pin: string,
   ): Promise<{ mnemonic: string; hexSeed: string }> {
+    if (isDesktop) {
+      throw new Error(DESKTOP_SEED_GUARD_MESSAGE);
+    }
     let parsed;
     try {
       parsed = JSON.parse(encryptedData);
@@ -334,6 +353,9 @@ export class WalletEncryptionUtil {
 
   // Re-encrypt a seed with a new PIN (for Change PIN feature)
   static async reEncryptSeed(encryptedSeed: string, oldPin: string, newPin: string): Promise<string> {
+    if (isDesktop) {
+      throw new Error(DESKTOP_SEED_GUARD_MESSAGE);
+    }
     // Decrypt with old PIN (throws if oldPin is incorrect)
     const decrypted = await this.decryptSeedWithPin(encryptedSeed, oldPin);
 

--- a/src/utils/logout.ts
+++ b/src/utils/logout.ts
@@ -3,6 +3,7 @@ import StorageUtil from "./storage/storage";
 import { QRL_PROVIDER } from "@/config";
 import { isInNativeApp } from "./nativeApp";
 import { clearAttemptTracker } from "./crypto/pinAttemptTracker";
+import { isDesktop, desktopSigner } from "@/desktop/bridge";
 
 /**
  * A utility function to handle logout by clearing
@@ -18,6 +19,22 @@ import { clearAttemptTracker } from "./crypto/pinAttemptTracker";
  */
 export const handleLogout = async (navigate: (path: string) => void) => {
     try {
+        // Desktop: the seed lives in the isolated signer, NOT in localStorage,
+        // so logout LOCKS the signer session (drops the in-memory keys) instead
+        // of wiping. A wipe here would clear the UI's account list while the
+        // encrypted seed file persists in the signer, orphaning the wallet.
+        // Re-entry is a password unlock (the desktop unlock screen). Fully
+        // removing the wallet from the device is a separate, explicit action
+        // that deletes the signer's seed file, not this button.
+        if (isDesktop) {
+            await desktopSigner
+                .lock()
+                .catch((err) => console.error("Desktop logout: signer lock failed", err));
+            navigate(ROUTES.HOME);
+            window.location.reload();
+            return;
+        }
+
         // Get all blockchain types
         const blockchains = Object.keys(QRL_PROVIDER);
 

--- a/src/utils/signing/sign.ts
+++ b/src/utils/signing/sign.ts
@@ -17,6 +17,7 @@ import {
 import { computeMessageDigest } from './messageDigest';
 import { computeTypedDataDigest, type TypedDataPayload } from './typedData';
 import { bytesToHex, hexToBytes } from './bytes';
+import { isDesktop } from '@/desktop/bridge';
 
 export interface SignWithSchemeParams {
   /** SHAKE256 digest (64 bytes) produced by the per-scheme hasher. */
@@ -70,6 +71,12 @@ export function signWithScheme({
   hexSeed,
   randomized = true,
 }: SignWithSchemeParams): SignWithSchemeResult {
+  // Defense-in-depth: on desktop ML-DSA-87 signing happens only in the
+  // isolated signer. The renderer must never derive the secret key from a
+  // hex seed, so fail loudly if any path reaches here.
+  if (isDesktop) {
+    throw new Error('desktop: signing happens in the signer, not the renderer');
+  }
   ensureDigest(digest);
   if (!(ctx instanceof Uint8Array) || ctx.length > 255) {
     throw new Error('ctx must be a Uint8Array under 256 bytes');

--- a/src/utils/storage/autoLock.ts
+++ b/src/utils/storage/autoLock.ts
@@ -4,6 +4,7 @@ import StorageUtil, {
   STORAGE_EVENT_WALLET_SETTINGS,
 } from './storage';
 import { isInNativeApp } from '../nativeApp';
+import { isDesktop, desktopSigner } from '@/desktop/bridge';
 
 let autoLockTimer: NodeJS.Timeout | null = null;
 let lastActivityTime: number = Date.now();
@@ -108,10 +109,17 @@ export const startAutoLockTimer = async (navigate: (path: string) => void) => {
       console.log(`⏱️ Auto-lock: ${(remainingTime / 1000).toFixed(0)} seconds until lock`);
     }
 
-    // If user has been inactive for longer than the timeout, log them out
+    // If user has been inactive for longer than the timeout, lock the wallet.
     if (inactiveTime >= timeoutMs) {
       console.log(`🔐 Auto-lock: TRIGGERED - No activity detected for ${minutes.toFixed(1)} minutes`);
-      if (navigateFunction) {
+      if (isDesktop) {
+        // Desktop: drop the signer session but KEEP the seed (it lives in the
+        // signer). A seed-wipe logout would force a re-import; here the user
+        // just re-enters their password to unlock.
+        desktopSigner.lock().catch((err) => {
+          console.error('Auto-lock: signer lock failed', err);
+        });
+      } else if (navigateFunction) {
         handleLogout(navigateFunction);
       }
       clearAutoLockTimer();

--- a/src/utils/storage/storage.ts
+++ b/src/utils/storage/storage.ts
@@ -1,6 +1,7 @@
 import { QRL_PROVIDER } from "@/config";
 import type { TokenInterface, NFTInterface } from "@/constants";
 import { isInNativeApp } from "@/utils/nativeApp";
+import { isDesktop } from "@/desktop/bridge";
 
 const ACTIVE_PAGE_IDENTIFIER = "ACTIVE_PAGE";
 const BLOCKCHAIN_SELECTION_IDENTIFIER = "BLOCKCHAIN_SELECTION";
@@ -382,6 +383,12 @@ class StorageUtil {
    * @param encryptedSeed The encrypted seed data from WalletEncryptionUtil.encryptSeedWithPin
    */
   static async storeEncryptedSeed(blockchain: string, address: string, encryptedSeed: string) {
+    // Defense-in-depth: on desktop the seed lives only in the isolated signer
+    // and must NEVER be written to renderer localStorage. Throw loudly so any
+    // missed reroute fails rather than silently persisting key material.
+    if (isDesktop) {
+      throw new Error('desktop: encrypted seeds must never be stored in the renderer');
+    }
     const encryptedSeedsKey = `${blockchain}_${ENCRYPTED_SEEDS_IDENTIFIER}`;
     const encryptedSeeds = this.getItem<EncryptedSeedData[]>(encryptedSeedsKey) ?? [];
 


### PR DESCRIPTION
## What

Adapts the web wallet to run as the renderer of the **MyQRLWallet Electron desktop app** (`DigitalGuards/myqrlwallet-desktop`), where no secret key material may live in the renderer. Every key-touching operation routes through the isolated signer `utilityProcess` via the `window.qrlWallet` preload bridge.

All changes are gated on `isDesktop = Boolean(window.qrlWallet)`. The web build is **unaffected** (the bridge is never injected on web), so this is web-safe.

## Changes

- **`src/desktop/bridge.ts`** (new): the desktop seam. `isDesktop`, a typed `window.qrlWallet`, and the `desktopSigner` adapter (create / import / unlock / lock / sign / send).
- **Rerouted to the signer**: wallet create + import + unlock, native transfer, QRC20 token transfer + creation, NFT transfer, and the dApp-connect `signTransaction` / `sendTransaction` / `signMessage` / `signTypedData` paths.
- **No PIN on desktop**: PIN UI is hidden and not required; the unlocked signer session authorizes spends.
- **Logout locks, never wipes**: on desktop, logout drops the signer session (keeps the seed). A wipe would clear the UI's account list while the encrypted seed file persists in the signer, orphaning the wallet.
- **Defense-in-depth**: the in-renderer seed/sign primitives (`walletEncryption`, `cryptoWorkerClient`, `storeEncryptedSeed`, `signWithScheme`) throw under desktop.
- **`file://` hosting**: Vite `base: './'` under `VITE_DESKTOP=1`, plus a runtime `createHashRouter` switch. Both web-safe.

## Verification

- `npm run lint`: clean
- `npm run build` (tsc + vite): clean
- `npm test`: **114/114** jest pass
- Verified in isolation: the desktop changes were committed alone and the suite was run with no other working-tree changes present.

## Scope notes

- This PR is **only** the desktop reroute. The in-progress 64-byte-address work is deliberately excluded (64-byte is not live on testnet yet, so no port). It remains as local WIP.
- Pairs with the desktop repo, which is configured as a `dev.qrlwallet.com` staging build.

## Known follow-up

Desktop has **no re-unlock UI** yet: after any lock (auto-lock or logout) the signer session cannot be reopened from the renderer. A desktop unlock screen (calling `desktopSigner.unlock(password)`, wired to startup lock-state detection + `onLockStateChanged`) is the next step to make lock/auto-lock/logout fully usable.