### PR TITLE
feat(desktop): Lock button + Remove-wallet wipe (Settings)

### DIFF
--- a/src/components/Core/Body/Settings/DesktopSettings/DesktopSettings.tsx
+++ b/src/components/Core/Body/Settings/DesktopSettings/DesktopSettings.tsx
@@ -1,0 +1,104 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Trash2, AlertTriangle } from "lucide-react";
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "@/components/UI/Card";
+import { Button } from "@/components/UI/Button";
+import { StorageUtil } from "@/utils/storage";
+import { ROUTES } from "@/router/router";
+import { QRL_PROVIDER } from "@/config";
+import { desktopSigner } from "@/desktop/bridge";
+
+/**
+ * Desktop-only (Electron) settings. Rendered by Settings behind an isDesktop
+ * gate. Today this is the destructive "remove wallet" (wipe), mirroring the
+ * mobile app: locking is the everyday action (sidebar); this is the deliberate
+ * removal that deletes the encrypted seed from this device and requires
+ * re-import. The actual confirmation is a trusted main-process dialog (the
+ * renderer cannot draw the security gate); this button just triggers it.
+ * Future desktop lock options (auto-lock, unlock method) belong here too.
+ */
+export const DesktopSettings = () => {
+    const navigate = useNavigate();
+    const [isRemoving, setIsRemoving] = useState(false);
+    const [removeError, setRemoveError] = useState<string | null>(null);
+
+    async function onRemoveWallet() {
+        if (isRemoving) return;
+        setIsRemoving(true);
+        setRemoveError(null);
+        try {
+            // Main draws the trusted confirmation dialog (default Cancel) and,
+            // on approval, deletes the encrypted seed + clears the keychain +
+            // locks the signer. A cancel rejects here and is a no-op.
+            await desktopSigner.removeWallet();
+        } catch (error) {
+            setIsRemoving(false);
+            const message = error instanceof Error ? error.message : String(error);
+            // Trusted dialog cancelled: silently abort, no error banner.
+            if (/reject|cancel/i.test(message)) return;
+            setRemoveError(message || "Failed to remove the wallet.");
+            return;
+        }
+        // The seed is gone in main. Clear the renderer's local state (mirroring
+        // the mobile CLEAR_WALLET wipe) best-effort, then ALWAYS reload so the
+        // UI re-evaluates to the create/import screen even if a clear hiccups.
+        try {
+            const blockchains = Object.keys(QRL_PROVIDER);
+            for (const blockchain of blockchains) {
+                await StorageUtil.clearActiveAccount(blockchain);
+                await StorageUtil.clearTransactionValues(blockchain);
+                StorageUtil.clearAllEncryptedSeeds(blockchain);
+                StorageUtil.clearAccountList(blockchain);
+            }
+            StorageUtil.clearAllTokenData();
+            StorageUtil.clearAllNftData();
+        } catch (cleanupError) {
+            console.error("Post-wipe local cleanup failed (reloading anyway):", cleanupError);
+        }
+        navigate(ROUTES.HOME);
+        window.location.reload();
+    }
+
+    return (
+        <Card className="border-l-4 border-l-destructive">
+            <CardHeader className="bg-gradient-to-r from-destructive/5 to-transparent">
+                <div className="flex items-center gap-2">
+                    <AlertTriangle className="h-6 w-6 text-destructive" />
+                    <CardTitle className="text-2xl font-bold">Remove Wallet</CardTitle>
+                </div>
+                <CardDescription>
+                    Permanently remove this wallet from this device. The encrypted seed is
+                    deleted and you will need your recovery phrase to restore it.
+                </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+                {removeError && (
+                    <div role="alert" className="rounded-md bg-destructive/15 p-3 text-sm text-destructive">
+                        {removeError}
+                    </div>
+                )}
+                <Button
+                    type="button"
+                    variant="destructive"
+                    className="w-full"
+                    disabled={isRemoving}
+                    onClick={() => void onRemoveWallet()}
+                >
+                    <Trash2 className="mr-2 h-4 w-4" />
+                    {isRemoving ? "Removing..." : "Remove wallet from this device"}
+                </Button>
+                <p className="text-xs text-muted-foreground">
+                    You will be asked to confirm. This cannot be undone without your recovery phrase.
+                </p>
+            </CardContent>
+        </Card>
+    );
+};
+
+export default DesktopSettings;

--- a/src/components/Core/Body/Settings/Settings.tsx
+++ b/src/components/Core/Body/Settings/Settings.tsx
@@ -33,6 +33,7 @@ import { PinInput } from "@/components/UI/PinInput/PinInput";
 import { decryptSeedAsync, reEncryptSeedAsync } from "@/utils/crypto";
 import { isInNativeApp, sendPinChanged } from "@/utils/nativeApp";
 import { isDesktop } from "@/desktop/bridge";
+import { DesktopSettings } from "./DesktopSettings/DesktopSettings";
 import {
     checkLockout,
     recordFailedAttempt,
@@ -462,6 +463,11 @@ const Settings = observer(() => {
                                 </form>
                             </Form>
                         </Card>
+
+                        {/* Desktop-only settings (wallet removal now, lock
+                            options later) live in their own component instead of
+                            crowding this one. */}
+                        {isDesktop && <DesktopSettings />}
                     </div>
                 </div>
             </div>

--- a/src/components/Core/Layout/app-sidebar.tsx
+++ b/src/components/Core/Layout/app-sidebar.tsx
@@ -1,4 +1,4 @@
-import { LogOut, Wallet, ArrowRight, Settings as SettingsIcon, Plus } from "lucide-react"
+import { LogOut, Lock, Wallet, ArrowRight, Settings as SettingsIcon, Plus } from "lucide-react"
 
 import {
     Sidebar,
@@ -16,6 +16,7 @@ import { ROUTES } from "@/router/router";
 import MyQRLWalletLogo from "../Header/MyQRLWalletLogo/MyQRLWalletLogo";
 import { handleLogout } from "@/utils/logout";
 import { isInNativeApp } from "@/utils/nativeApp";
+import { isDesktop, desktopSigner } from "@/desktop/bridge";
 import { navigateTo } from "@/utils/navigation";
 import { cn } from "@/utils/cn";
 
@@ -52,6 +53,13 @@ export function AppSidebar() {
     const location = useLocation();
     const onLogoutClick = () => {
         handleLogout(navigate);
+    };
+    // Desktop: there is no "logout" (the seed lives in the signer, not here).
+    // The footer button locks the signer session instead; main then shows the
+    // native unlock window. Removing the wallet entirely is a separate,
+    // confirmed action under Settings.
+    const onLockClick = () => {
+        void desktopSigner.lock();
     };
     const isActive = (url: string) =>
         location.pathname === url || location.pathname.startsWith(`${url}/`);
@@ -97,15 +105,23 @@ export function AppSidebar() {
                     </SidebarGroupContent>
                 </SidebarGroup>
             </SidebarContent>
-            {/* Hide logout button when running in native app - wallet removal is handled in native settings */}
+            {/* Native app hides this entirely (wallet removal lives in native
+                settings). Desktop shows Lock (not Logout): the seed stays in the
+                signer and locking surfaces the native unlock window. Web keeps
+                the seed-wiping Logout. */}
             {!isInNativeApp() && (
                 <SidebarFooter>
                     <SidebarMenu>
                         <SidebarMenuItem className="py-2">
-                            <SidebarMenuButton asChild className="py-2 h-auto" onClick={onLogoutClick} tooltip={{ side: "right", children: "Log out of wallet" }}>
+                            <SidebarMenuButton
+                                asChild
+                                className="py-2 h-auto"
+                                onClick={isDesktop ? onLockClick : onLogoutClick}
+                                tooltip={{ side: "right", children: isDesktop ? "Lock wallet" : "Log out of wallet" }}
+                            >
                                 <div className="flex flex-col justify-evenly items-center cursor-pointer [&>svg]:!size-8 text-muted-foreground hover:text-foreground">
-                                    <LogOut />
-                                    <span className="block text-xs font-medium">Logout</span>
+                                    {isDesktop ? <Lock /> : <LogOut />}
+                                    <span className="block text-xs font-medium">{isDesktop ? "Lock" : "Logout"}</span>
                                 </div>
                             </SidebarMenuButton>
                         </SidebarMenuItem>

--- a/src/desktop/bridge.ts
+++ b/src/desktop/bridge.ts
@@ -86,6 +86,9 @@ export interface QrlWalletBridge {
   /** Omit password to attempt an OS keychain unlock (macOS). */
   unlock(args?: { password?: string }): Promise<WalletStatus>;
   lock(): Promise<WalletStatus>;
+  /** Destructively remove the wallet from this device (delete the seed + clear
+   * the keychain). Requires re-import. Returns the post-wipe status. */
+  removeWallet(): Promise<WalletStatus>;
   getStatus(): Promise<WalletStatus>;
   hasWallet(): Promise<boolean>;
   getBalance(args: { address: string }): Promise<{ address: string; balance: string }>;
@@ -166,6 +169,12 @@ export const desktopSigner = {
   /** Lock the signer session (keeps the seed, drops the in-memory session). */
   async lock(): Promise<WalletStatus> {
     return qrlWallet().lock();
+  },
+
+  /** Destructively remove the wallet from this device (delete the seed + clear
+   * the keychain). The caller still clears the renderer's local account state. */
+  async removeWallet(): Promise<WalletStatus> {
+    return qrlWallet().removeWallet();
   },
 
   async getStatus(): Promise<WalletStatus> {


### PR DESCRIPTION
## What
Desktop-only renderer controls for the native lock / wipe model. All `isDesktop`-gated; the **web build is unchanged**.

- **Sidebar: Lock (not Logout) on desktop** - calls `desktopSigner.lock()`, which surfaces the native unlock window (built in the desktop app). Web keeps the seed-wiping Logout; native app still hides the button.
- **Settings: Remove wallet from this device** (new `DesktopSettings` component, kept out of `Settings.tsx`) - the destructive wipe, mirroring the mobile `CLEAR_WALLET`. Calls `window.qrlWallet.removeWallet()` (main draws a **trusted** confirm dialog, deletes the encrypted seed, clears the keychain, locks the signer), then clears the renderer's local state and reloads to create/import.
- `src/desktop/bridge.ts`: `removeWallet()` on the desktop signer surface.

## Pairs with
Desktop repo `myqrlwallet-desktop` (`main`): the `removeWallet` IPC op + `confirmRemoveWallet` trusted dialog, and the native unlock window.

## Verification
- `npm run lint`: clean
- `npm run build` (tsc + vite): clean
- `npm test`: 114/114
- Adversarial review workflow over the lock/wipe change (3 dimensions + per-finding verify): web-safety dimension clean; the one medium it raised (renderer-triggerable wipe needs a trusted gate) is fixed in the desktop repo via the main-drawn `confirmRemoveWallet` dialog.

## Notes
- The everyday action is **Lock**; **Remove wallet** is the deliberate, confirmed removal (re-import required). The actual confirmation is a main-process dialog (the renderer cannot draw the security gate).
- Not UI-tested in CI (no display); verify on a desktop build.