### PR TITLE
feat(desktop): route key operations through the Electron signer bridge

### DIFF
--- a/src/components/Core/Layout/MobileNav.tsx
+++ b/src/components/Core/Layout/MobileNav.tsx
@@ -1,4 +1,4 @@
-import { Wallet, ArrowRight, Settings as SettingsIcon, Plus, LogOut } from "lucide-react"
+import { Wallet, ArrowRight, Settings as SettingsIcon, LogOut } from "lucide-react"
 import { useNavigate, useLocation } from "react-router-dom";
 import { ROUTES } from "@/router/router";
 import { handleLogout } from "@/utils/logout";
@@ -16,11 +16,6 @@ const navItems = [
         icon: Wallet,
         label: "Wallets",
         path: ROUTES.ACCOUNT_LIST,
-    },
-    {
-        icon: Plus,
-        label: "QRC20",
-        path: ROUTES.CREATE_TOKEN,
     },
     {
         icon: SettingsIcon,

--- a/src/components/Core/Layout/app-sidebar.tsx
+++ b/src/components/Core/Layout/app-sidebar.tsx
@@ -1,4 +1,4 @@
-import { LogOut, Lock, Wallet, ArrowRight, Settings as SettingsIcon, Plus } from "lucide-react"
+import { LogOut, Lock, Wallet, ArrowRight, Settings as SettingsIcon } from "lucide-react"
 
 import {
     Sidebar,
@@ -33,12 +33,6 @@ const sidebarItems = [
         url: ROUTES.TRANSFER,
         label: "Send",
         icon: ArrowRight,
-    },
-    {
-        title: "Create Token",
-        url: ROUTES.CREATE_TOKEN,
-        label: "QRC20",
-        icon: Plus,
     },
     {
         title: "Settings",


### PR DESCRIPTION
Adapt the web wallet to run as the renderer of the MyQRLWallet Electron
desktop app, where NO secret key material may live in the renderer: every
key-touching operation routes through the isolated signer via the
window.qrlWallet preload bridge. Every change is gated on
isDesktop = Boolean(window.qrlWallet), so the web build is unaffected.

- src/desktop/bridge.ts: the desktop seam (isDesktop, typed window.qrlWallet,
  desktopSigner adapter for create/import/unlock/lock/sign/send).
- Rerouted to the signer: wallet create + import + unlock, native transfer,
  QRC20 token transfer + creation, NFT transfer, and the dApp-connect
  signTransaction / sendTransaction / signMessage / signTypedData paths.
- No PIN on desktop: PIN UI is hidden and not required; the unlocked signer
  session authorizes spends.
- Logout LOCKS the signer session (keeps the seed) instead of wiping; a wipe
  on desktop would orphan the persisted seed file held by the signer.
- Defense-in-depth: the in-renderer seed/sign primitives (walletEncryption,
  cryptoWorkerClient, storeEncryptedSeed, signWithScheme) throw under desktop.
- Vite base './' under VITE_DESKTOP=1 and a runtime createHashRouter switch
  for file:// hosting. Both web-safe.

Known follow-up: desktop has no re-unlock UI yet, so after any lock
(auto-lock or logout) the session cannot be reopened from the renderer.