### PR TITLE
Remove QRC20 button from sidebar and mobile nav

### DIFF
--- a/src/components/Core/Layout/MobileNav.tsx
+++ b/src/components/Core/Layout/MobileNav.tsx
@@ -1,4 +1,4 @@
-import { Wallet, ArrowRight, Settings as SettingsIcon, Plus, LogOut } from "lucide-react"
+import { Wallet, ArrowRight, Settings as SettingsIcon, LogOut } from "lucide-react"
 import { useNavigate, useLocation } from "react-router-dom";
 import { ROUTES } from "@/router/router";
 import { handleLogout } from "@/utils/logout";
@@ -16,11 +16,6 @@ const navItems = [
         icon: Wallet,
         label: "Wallets",
         path: ROUTES.ACCOUNT_LIST,
-    },
-    {
-        icon: Plus,
-        label: "QRC20",
-        path: ROUTES.CREATE_TOKEN,
     },
     {
         icon: SettingsIcon,

--- a/src/components/Core/Layout/app-sidebar.tsx
+++ b/src/components/Core/Layout/app-sidebar.tsx
@@ -1,4 +1,4 @@
-import { LogOut, Lock, Wallet, ArrowRight, Settings as SettingsIcon, Plus } from "lucide-react"
+import { LogOut, Lock, Wallet, ArrowRight, Settings as SettingsIcon } from "lucide-react"
 
 import {
     Sidebar,
@@ -33,12 +33,6 @@ const sidebarItems = [
         url: ROUTES.TRANSFER,
         label: "Send",
         icon: ArrowRight,
-    },
-    {
-        title: "Create Token",
-        url: ROUTES.CREATE_TOKEN,
-        label: "QRC20",
-        icon: Plus,
     },
     {
         title: "Settings",


### PR DESCRIPTION
## Summary

Removes the redundant **QRC20** menu entry from both navigation bars. Token creation is already accessible from the Tokens card, so the dedicated menu button is no longer needed.

## Changes

- `app-sidebar.tsx` (vertical menu) — removed the "Create Token" / QRC20 entry
- `MobileNav.tsx` (horizontal menu) — removed the QRC20 entry
- Dropped the now-unused `Plus` icon import from both files

## Verification

- `npm run lint` passes with zero warnings (confirms no unused imports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vt5ruGBXekSf7ARysjwyVy)_