### PR TITLE
feat(desktop): multi-wallet + hexseed/wallet-file import via the signer bridge

### DIFF
--- a/src/components/Core/Body/ImportAccount/ImportAccount.tsx
+++ b/src/components/Core/Body/ImportAccount/ImportAccount.tsx
@@ -86,12 +86,15 @@ const ImportAccount = observer(() => {
               isPinSetupComplete ? (
                 <AccountImportSuccess account={account} />
               ) : (
-                // Desktop only needs the mnemonic (the signer derives the rest
-                // and never returns the hex seed). Web/native also need hexSeed.
-                account && account.mnemonic && (isDesktop || account.hexSeed) ? (
+                // Desktop needs the mnemonic OR the hex seed (the signer accepts
+                // either and derives the rest). Web/native need both.
+                account &&
+                (isDesktop
+                  ? account.mnemonic || account.hexSeed
+                  : account.mnemonic && account.hexSeed) ? (
                   <PinSetup
                     accountAddress={account.address}
-                    mnemonic={account.mnemonic}
+                    mnemonic={account.mnemonic ?? ""}
                     hexSeed={account.hexSeed ?? ""}
                     onPinSetupComplete={onPinSetupComplete}
                   />
@@ -108,26 +111,22 @@ const ImportAccount = observer(() => {
                   >
                     Import with Mnemonic
                   </TabsTrigger>
-                  {/* Encrypted-wallet-file restore and raw hex-seed import are
-                      web/native only: neither has a signer intake on desktop
-                      (the signer would never accept raw hex / decrypt a file in
-                      the renderer), so the tabs are hidden there. */}
-                  {!isDesktop && (
-                    <>
-                      <TabsTrigger
-                        value="encrypted"
-                        className="w-full text-sm py-3 px-4 rounded-lg bg-card border border-border hover:bg-accent data-[state=active]:border-secondary data-[state=active]:bg-secondary/10 transition-colors"
-                      >
-                        Import Encrypted Wallet
-                      </TabsTrigger>
-                      <TabsTrigger
-                        value="hexseed"
-                        className="w-full text-sm py-3 px-4 rounded-lg bg-card border border-border hover:bg-accent data-[state=active]:border-secondary data-[state=active]:bg-secondary/10 transition-colors"
-                      >
-                        Import with Hex Seed
-                      </TabsTrigger>
-                    </>
-                  )}
+                  {/* Encrypted-wallet-file restore and raw hex-seed import work
+                      on desktop too: both forms recover the secret in-page
+                      (exactly like typing a mnemonic) and hand it to the signer
+                      via importWallet, which accepts mnemonic OR hexSeed. */}
+                  <TabsTrigger
+                    value="encrypted"
+                    className="w-full text-sm py-3 px-4 rounded-lg bg-card border border-border hover:bg-accent data-[state=active]:border-secondary data-[state=active]:bg-secondary/10 transition-colors"
+                  >
+                    Import Encrypted Wallet
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="hexseed"
+                    className="w-full text-sm py-3 px-4 rounded-lg bg-card border border-border hover:bg-accent data-[state=active]:border-secondary data-[state=active]:bg-secondary/10 transition-colors"
+                  >
+                    Import with Hex Seed
+                  </TabsTrigger>
                 </TabsList>
                 <TabsContent
                   value="mnemonic"
@@ -135,22 +134,18 @@ const ImportAccount = observer(() => {
                 >
                   <ImportAccountForm onAccountImported={onAccountImported} />
                 </TabsContent>
-                {!isDesktop && (
-                  <>
-                    <TabsContent
-                      value="encrypted"
-                      className="mt-6 w-full border-none outline-none focus-visible:ring-0"
-                    >
-                      <ImportEncryptedWallet onWalletImported={onAccountImported} />
-                    </TabsContent>
-                    <TabsContent
-                      value="hexseed"
-                      className="mt-6 w-full border-none outline-none focus-visible:ring-0"
-                    >
-                      <ImportHexSeedForm onAccountImported={onAccountImported} />
-                    </TabsContent>
-                  </>
-                )}
+                <TabsContent
+                  value="encrypted"
+                  className="mt-6 w-full border-none outline-none focus-visible:ring-0"
+                >
+                  <ImportEncryptedWallet onWalletImported={onAccountImported} />
+                </TabsContent>
+                <TabsContent
+                  value="hexseed"
+                  className="mt-6 w-full border-none outline-none focus-visible:ring-0"
+                >
+                  <ImportHexSeedForm onAccountImported={onAccountImported} />
+                </TabsContent>
               </Tabs>
             )}
           </div>

--- a/src/components/Core/Body/ImportAccount/ImportEncryptedWallet/ImportEncryptedWallet.tsx
+++ b/src/components/Core/Body/ImportAccount/ImportEncryptedWallet/ImportEncryptedWallet.tsx
@@ -17,6 +17,7 @@ import { useForm } from "react-hook-form";
 import { useState } from "react";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { isDesktop } from "@/desktop/bridge";
 
 const FormSchema = z.object({
   password: z.string().min(1, "Password is required"),
@@ -77,6 +78,21 @@ export const ImportEncryptedWallet = ({
         encryptedWallet,
         formData.password
       );
+
+      // Desktop: decrypting the file in-page is unavoidable (same exposure as
+      // typing a mnemonic), but skip the in-renderer account derivation.
+      // Forward the recovered secret on a placeholder account; PinSetup hands
+      // it to the signer, which derives the address (mnemonic preferred,
+      // hexSeed fallback when the file lacks one).
+      if (isDesktop) {
+        const account = {
+          address: "",
+          hexSeed: decryptedWallet.hexSeed,
+          mnemonic: decryptedWallet.mnemonic,
+        } as ExtendedWalletAccount;
+        onWalletImported(account);
+        return;
+      }
 
       const account = qrlInstance?.accounts.seedToAccount(decryptedWallet.hexSeed) as ExtendedWalletAccount;
       if (!account) {

--- a/src/components/Core/Body/ImportAccount/ImportHexSeedForm/ImportHexSeedForm.tsx
+++ b/src/components/Core/Body/ImportAccount/ImportHexSeedForm/ImportHexSeedForm.tsx
@@ -9,6 +9,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
 import { getMnemonicFromHexSeed } from "@/utils/crypto";
+import { isDesktop } from "@/desktop/bridge";
 
 const FormSchema = z.object({
   hexSeed: z
@@ -40,8 +41,18 @@ export const ImportHexSeedForm = ({ onAccountImported }: ImportHexSeedFormProps)
 
   async function onSubmit(formData: z.output<typeof FormSchema>) {
     try {
+      // Desktop: no in-renderer derivation (no seedToAccount, no mnemonic
+      // reconstruction). Forward only the hex seed on a placeholder account;
+      // PinSetup collects the password, the signer derives address + canonical
+      // mnemonic and returns the address (same pattern as the mnemonic form).
+      if (isDesktop) {
+        const account = { address: "", hexSeed: formData.hexSeed } as ExtendedWalletAccount;
+        onAccountImported(account);
+        return;
+      }
+
       const account = qrlInstance?.accounts.seedToAccount(formData.hexSeed) as ExtendedWalletAccount;
-      
+
       if (!account) {
         throw new Error("Failed to create account from hex seed");
       }

--- a/src/components/Core/Body/PinSetup/PinSetup.tsx
+++ b/src/components/Core/Body/PinSetup/PinSetup.tsx
@@ -85,6 +85,7 @@ export const PinSetup = ({
     return (
       <DesktopPasswordSetup
         mnemonic={mnemonic}
+        hexSeed={hexSeed}
         onPinSetupComplete={onPinSetupComplete}
       />
     );
@@ -114,9 +115,11 @@ const DesktopPasswordSchema = z.object({
 
 const DesktopPasswordSetup = ({
   mnemonic,
+  hexSeed,
   onPinSetupComplete,
 }: {
   mnemonic: string;
+  hexSeed?: string;
   onPinSetupComplete: (provisionedAddress?: string) => void;
 }) => {
   const [isProvisioning, setIsProvisioning] = useState(false);
@@ -136,7 +139,11 @@ const DesktopPasswordSetup = ({
   async function onSubmit(data: DesktopPasswordValues) {
     setIsProvisioning(true);
     try {
-      const status = await desktopSigner.importWallet(mnemonic, data.password);
+      // Mnemonic and hex seed are two encodings of the same bytes; the signer
+      // accepts either. Prefer the mnemonic when the form produced one, else
+      // fall back to the hex seed (e.g. a wallet file missing its mnemonic).
+      const source = mnemonic ? { mnemonic } : { hexSeed };
+      const status = await desktopSigner.importWallet(source, data.password);
       setIsProvisioning(false);
       onPinSetupComplete(status.address);
     } catch (error) {

--- a/src/components/Core/Body/Settings/DesktopSettings/DesktopSettings.tsx
+++ b/src/components/Core/Body/Settings/DesktopSettings/DesktopSettings.tsx
@@ -12,7 +12,7 @@ import { Button } from "@/components/UI/Button";
 import { StorageUtil } from "@/utils/storage";
 import { ROUTES } from "@/router/router";
 import { QRL_PROVIDER } from "@/config";
-import { desktopSigner } from "@/desktop/bridge";
+import { desktopSigner, type WalletStatus } from "@/desktop/bridge";
 
 /**
  * Desktop-only (Electron) settings. Rendered by Settings behind an isDesktop
@@ -32,11 +32,16 @@ export const DesktopSettings = () => {
         if (isRemoving) return;
         setIsRemoving(true);
         setRemoveError(null);
+        let removedAddress: string | undefined;
+        let statusAfter: WalletStatus | undefined;
         try {
-            // Main draws the trusted confirmation dialog (default Cancel) and,
-            // on approval, deletes the encrypted seed + clears the keychain +
-            // locks the signer. A cancel rejects here and is a no-op.
-            await desktopSigner.removeWallet();
+            // Capture which account is being removed (the active one), then let
+            // main draw the trusted confirmation dialog (default Cancel) and,
+            // on approval, delete that seed + clear its keychain entry + drop
+            // the session if it owned it. A cancel rejects here and is a no-op.
+            const before = await desktopSigner.getStatus();
+            removedAddress = before.activeAddress ?? before.address ?? undefined;
+            statusAfter = await desktopSigner.removeWallet();
         } catch (error) {
             setIsRemoving(false);
             const message = error instanceof Error ? error.message : String(error);
@@ -45,19 +50,37 @@ export const DesktopSettings = () => {
             setRemoveError(message || "Failed to remove the wallet.");
             return;
         }
-        // The seed is gone in main. Clear the renderer's local state (mirroring
-        // the mobile CLEAR_WALLET wipe) best-effort, then ALWAYS reload so the
-        // UI re-evaluates to the create/import screen even if a clear hiccups.
+        // The seed is gone in main. Clear the renderer's local state
+        // best-effort, then ALWAYS reload so the UI re-evaluates cleanly.
         try {
             const blockchains = Object.keys(QRL_PROVIDER);
-            for (const blockchain of blockchains) {
-                await StorageUtil.clearActiveAccount(blockchain);
-                await StorageUtil.clearTransactionValues(blockchain);
-                StorageUtil.clearAllEncryptedSeeds(blockchain);
-                StorageUtil.clearAccountList(blockchain);
+            if (statusAfter?.hasWallet && removedAddress) {
+                // Other wallets remain: scope the cleanup to the removed
+                // account (drop it from the local list, clear the active
+                // pointer); the desktop raises its native unlock window for
+                // the next account.
+                const removed = removedAddress.toLowerCase();
+                for (const blockchain of blockchains) {
+                    const list = await StorageUtil.getAccountList(blockchain);
+                    await StorageUtil.setAccountList(
+                        blockchain,
+                        list.filter((item) => item.address.toLowerCase() !== removed),
+                    );
+                    await StorageUtil.clearActiveAccount(blockchain);
+                    await StorageUtil.clearTransactionValues(blockchain);
+                }
+            } else {
+                // Last wallet removed: full local wipe (mirrors the mobile
+                // CLEAR_WALLET), back to the create/import screen.
+                for (const blockchain of blockchains) {
+                    await StorageUtil.clearActiveAccount(blockchain);
+                    await StorageUtil.clearTransactionValues(blockchain);
+                    StorageUtil.clearAllEncryptedSeeds(blockchain);
+                    StorageUtil.clearAccountList(blockchain);
+                }
+                StorageUtil.clearAllTokenData();
+                StorageUtil.clearAllNftData();
             }
-            StorageUtil.clearAllTokenData();
-            StorageUtil.clearAllNftData();
         } catch (cleanupError) {
             console.error("Post-wipe local cleanup failed (reloading anyway):", cleanupError);
         }
@@ -73,8 +96,9 @@ export const DesktopSettings = () => {
                     <CardTitle className="text-2xl font-bold">Remove Wallet</CardTitle>
                 </div>
                 <CardDescription>
-                    Permanently remove this wallet from this device. The encrypted seed is
-                    deleted and you will need your recovery phrase to restore it.
+                    Permanently remove the active account from this device. Its encrypted
+                    seed is deleted and you will need the recovery phrase (or hex seed) to
+                    restore it. Other accounts on this device are not affected.
                 </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
@@ -91,7 +115,7 @@ export const DesktopSettings = () => {
                     onClick={() => void onRemoveWallet()}
                 >
                     <Trash2 className="mr-2 h-4 w-4" />
-                    {isRemoving ? "Removing..." : "Remove wallet from this device"}
+                    {isRemoving ? "Removing..." : "Remove active account from this device"}
                 </Button>
                 <p className="text-xs text-muted-foreground">
                     You will be asked to confirm. This cannot be undone without your recovery phrase.

--- a/src/components/Core/Body/Settings/DesktopSettings/DesktopSettings.tsx
+++ b/src/components/Core/Body/Settings/DesktopSettings/DesktopSettings.tsx
@@ -56,17 +56,23 @@ export const DesktopSettings = () => {
             const blockchains = Object.keys(QRL_PROVIDER);
             if (statusAfter?.hasWallet && removedAddress) {
                 // Other wallets remain: scope the cleanup to the removed
-                // account (drop it from the local list, clear the active
-                // pointer); the desktop raises its native unlock window for
-                // the next account.
+                // account (drop it from the local list) and adopt the new
+                // active account the desktop self-healed to, instead of
+                // clearing it, so reload lands on that wallet (post-unlock)
+                // rather than an empty active-account state.
                 const removed = removedAddress.toLowerCase();
+                const nextActive = statusAfter.activeAddress ?? null;
                 for (const blockchain of blockchains) {
                     const list = await StorageUtil.getAccountList(blockchain);
                     await StorageUtil.setAccountList(
                         blockchain,
                         list.filter((item) => item.address.toLowerCase() !== removed),
                     );
-                    await StorageUtil.clearActiveAccount(blockchain);
+                    if (nextActive) {
+                        await StorageUtil.setActiveAccount(blockchain, nextActive);
+                    } else {
+                        await StorageUtil.clearActiveAccount(blockchain);
+                    }
                     await StorageUtil.clearTransactionValues(blockchain);
                 }
             } else {

--- a/src/desktop/bridge.ts
+++ b/src/desktop/bridge.ts
@@ -19,6 +19,13 @@
 // Bridge contract (mirror of window.qrlWallet). All methods async unless noted.
 // ---------------------------------------------------------------------------
 
+/** One provisioned desktop wallet (public data only). */
+export interface DesktopWalletInfo {
+  address: string;
+  /** True when this wallet's KEK is held by the OS keychain (macOS). */
+  keychainBacked: boolean;
+}
+
 /** Signer wallet status snapshot returned by status/unlock/lock/create/import. */
 export interface WalletStatus {
   hasWallet: boolean;
@@ -28,6 +35,10 @@ export interface WalletStatus {
   unlockExpiresAt?: number;
   /** True when the seed is held by the OS keychain (macOS). */
   keychainBacked?: boolean;
+  /** Every wallet on this device (multi-wallet desktops; absent on older mains). */
+  wallets?: DesktopWalletInfo[];
+  /** The active wallet's address (multi-wallet desktops; absent on older mains). */
+  activeAddress?: string | null;
 }
 
 /** Unsigned transaction shape produced by the signer (nonce/gas/chainId filled in main). */
@@ -78,18 +89,26 @@ export interface CreateWalletResult {
  */
 export interface QrlWalletBridge {
   createWallet(args: { password: string; useKeychain?: boolean }): Promise<CreateWalletResult>;
+  /** Import from a mnemonic OR a 51-byte hex extended seed (exactly one). */
   importWallet(args: {
-    mnemonic: string;
+    mnemonic?: string;
+    hexSeed?: string;
     password: string;
     useKeychain?: boolean;
   }): Promise<WalletStatus>;
-  /** Omit password to attempt an OS keychain unlock (macOS). */
-  unlock(args?: { password?: string }): Promise<WalletStatus>;
+  /** Omit password to attempt an OS keychain unlock (macOS); omit address to
+   * unlock the active wallet. */
+  unlock(args?: { password?: string; address?: string }): Promise<WalletStatus>;
   lock(): Promise<WalletStatus>;
-  /** Destructively remove the wallet from this device (delete the seed + clear
-   * the keychain). Requires re-import. Returns the post-wipe status. */
-  removeWallet(): Promise<WalletStatus>;
+  /** Destructively remove ONE wallet from this device (the active one when
+   * argless): delete its seed + clear its keychain entry. Requires re-import. */
+  removeWallet(args?: { address?: string }): Promise<WalletStatus>;
   getStatus(): Promise<WalletStatus>;
+  /** Every wallet on this device + the active one. */
+  listWallets(): Promise<{ wallets: DesktopWalletInfo[]; active: string | null }>;
+  /** Switch the active wallet. When the session belongs to a different account
+   * the desktop locks and raises its native unlock window. */
+  setActiveWallet(args: { address: string }): Promise<WalletStatus>;
   hasWallet(): Promise<boolean>;
   getBalance(args: { address: string }): Promise<{ address: string; balance: string }>;
   buildTransaction(args: {
@@ -152,13 +171,15 @@ export const desktopSigner = {
     return qrlWallet().createWallet({ password, useKeychain });
   },
 
-  /** Import an existing wallet from its mnemonic. */
+  /** Import an existing wallet from its mnemonic OR its hex extended seed
+   * (exactly one). The signer regenerates the canonical mnemonic from a hex
+   * seed, so both routes store an identical encrypted envelope. */
   async importWallet(
-    mnemonic: string,
+    source: { mnemonic?: string; hexSeed?: string },
     password: string,
     useKeychain?: boolean,
   ): Promise<WalletStatus> {
-    return qrlWallet().importWallet({ mnemonic, password, useKeychain });
+    return qrlWallet().importWallet({ ...source, password, useKeychain });
   },
 
   /** Unlock the signer session. Omit password for an OS keychain unlock. */
@@ -171,10 +192,23 @@ export const desktopSigner = {
     return qrlWallet().lock();
   },
 
-  /** Destructively remove the wallet from this device (delete the seed + clear
-   * the keychain). The caller still clears the renderer's local account state. */
-  async removeWallet(): Promise<WalletStatus> {
-    return qrlWallet().removeWallet();
+  /** Destructively remove ONE wallet from this device (the active one when no
+   * address is given). The caller still clears the renderer's local account
+   * state for that account. */
+  async removeWallet(address?: string): Promise<WalletStatus> {
+    return qrlWallet().removeWallet(address === undefined ? undefined : { address });
+  },
+
+  /** Every wallet on this device + the active one. */
+  async listWallets(): Promise<{ wallets: DesktopWalletInfo[]; active: string | null }> {
+    return qrlWallet().listWallets();
+  },
+
+  /** Switch the active desktop wallet. When the signer session belongs to a
+   * different account the desktop locks and raises its native unlock window
+   * (each wallet unlocks with its own password). */
+  async setActiveWallet(address: string): Promise<WalletStatus> {
+    return qrlWallet().setActiveWallet({ address });
   },
 
   async getStatus(): Promise<WalletStatus> {

--- a/src/stores/qrlStore.ts
+++ b/src/stores/qrlStore.ts
@@ -283,6 +283,23 @@ class QrlStore {
 
   async setActiveAccount(newActiveAccount?: string, source: AccountSource = 'seed') {
     const currentBlockchain = this.qrlConnection.blockchain;
+
+    // Desktop: keep the signer's active wallet in step with the UI selection.
+    // Best-effort: a watch-only address is not a desktop wallet ("no such
+    // wallet on this device"), and switching to a NON-session wallet makes the
+    // desktop lock and raise its native unlock window, which is the intended
+    // per-account password UX. Never block the renderer-side switch on it.
+    if (isDesktop && newActiveAccount) {
+      try {
+        const { wallets } = await desktopSigner.listWallets();
+        if (wallets.some((w) => w.address.toLowerCase() === newActiveAccount.toLowerCase())) {
+          await desktopSigner.setActiveWallet(newActiveAccount);
+        }
+      } catch (error) {
+        console.error('Desktop setActiveWallet failed (continuing with UI switch):', error);
+      }
+    }
+
     await StorageUtil.setActiveAccount(
       currentBlockchain,
       newActiveAccount,

--- a/src/stores/qrlStore.ts
+++ b/src/stores/qrlStore.ts
@@ -291,7 +291,8 @@ class QrlStore {
     // per-account password UX. Never block the renderer-side switch on it.
     if (isDesktop && newActiveAccount) {
       try {
-        const { wallets } = await desktopSigner.listWallets();
+        const list = await desktopSigner.listWallets();
+        const wallets = Array.isArray(list?.wallets) ? list.wallets : [];
         if (wallets.some((w) => w.address.toLowerCase() === newActiveAccount.toLowerCase())) {
           await desktopSigner.setActiveWallet(newActiveAccount);
         }


### PR DESCRIPTION
Pairs with DigitalGuards/myqrlwallet-desktop#4 (multi-wallet + hex-seed signer intake). Every change is behind `isDesktop`: the web build's behavior is byte-identical, so the dev auto-deploy is safe.

## What this enables on desktop

- **All three import routes**: mnemonic, raw hex seed, and encrypted wallet file. The hex-seed and wallet-file tabs were hidden on desktop because the signer had no intake; desktop#4 adds it (`importWallet({ hexSeed })`), and the forms now mirror the mnemonic form's pattern: no in-renderer derivation (no `seedToAccount`, no mnemonic reconstruction), just forward the recovered secret to PinSetup, where the signer derives the address. Decrypting a wallet file in-page is unavoidable and equivalent in exposure to typing a mnemonic.
- **Multiple accounts**: importing/creating additional accounts now works (the desktop dropped its single-wallet guard). `setActiveAccount` syncs the desktop's active wallet best-effort via `setActiveWallet`; switching to an account whose session is not open makes the desktop lock and raise its native unlock window with the account picker (each wallet has its own password). Watch-only addresses are skipped and bridge failures never block the UI switch.
- **Scoped removal in Settings**: "Remove active account" now removes only the active account's local state when other accounts remain (the desktop self-heals its active pointer and raises the unlock window); the full local wipe happens only after removing the last wallet.

## Bridge contract (desktop#4)

`importWallet({ mnemonic | hexSeed, password, useKeychain? })`, `listWallets()`, `setActiveWallet({ address })`, `removeWallet({ address }?)`, and `WalletStatus` gains optional `wallets` + `activeAddress` (optional so older desktop mains still type-check). Documented on the desktop side in `docs/FRONTEND_INTEGRATION.md`.

## Validation

- `npm run lint` clean, `npm test` 114/114, `npm run build` (tsc + vite) green.
- The desktop-side flows behind these calls were verified live against the real IPC surface (see desktop#4): second-account import by mnemonic, import by hex seed, duplicate rejection, list, switch + relock + picker unlock, legacy seed migration.

## Merge order

Merge desktop#3 then desktop#4 first (or at least before shipping a desktop build with this frontend): the new bridge calls (`listWallets`/`setActiveWallet`) exist only on that desktop main. On an older desktop main the new tabs would import but account switching falls back to UI-only (the try/catch swallows the missing-channel error).
