### PR TITLE
feat(desktop): dApp-connect ingress, consent gate, provenance + chain pinning

### DIFF
--- a/src/components/Core/Body/DAppConnect/DAppApprovalModal.tsx
+++ b/src/components/Core/Body/DAppConnect/DAppApprovalModal.tsx
@@ -34,7 +34,7 @@ import {
 import { Loader, Check, X, ExternalLink, Shield, Globe } from 'lucide-react';
 import type { TxProgressState } from '@/stores/dappConnectStore';
 import type { ZodError } from 'zod';
-import { isDesktop, desktopSigner } from '@/desktop/bridge';
+import { isDesktop, desktopSigner, buildDappOrigin } from '@/desktop/bridge';
 
 function formatZodIssues(error: ZodError): string {
   // path segments can be symbols (e.g. a MobX admin key surfaced by zod's
@@ -138,6 +138,16 @@ const DAppApprovalModal = observer(() => {
       // toJS is digest-neutral: the encoder reads fields by name in type order.
       const params = toJS(currentApproval.params);
 
+      // Desktop: dApp provenance for the trusted confirm modal (sanitised to
+      // the desktop schema; the modal labels it unverified/dApp-supplied).
+      const dappOrigin = isDesktop
+        ? buildDappOrigin(
+            currentApproval.dappInfo.name,
+            currentApproval.dappInfo.url,
+            currentApproval.sessionId,
+          )
+        : undefined;
+
       if (method === 'qrl_requestAccounts') {
         const activeAddress = qrlStore.activeAccount?.accountAddress;
         dappConnectStore.approveCurrentRequest(activeAddress ? [activeAddress] : []);
@@ -146,6 +156,18 @@ const DAppApprovalModal = observer(() => {
       }
 
       if (method === 'wallet_addQrlChain' || method === 'wallet_switchQrlChain') {
+        // Desktop is single-network: main builds/signs/broadcasts against its
+        // configured RPC + chain id, so honouring a renderer-side switch would
+        // silently sign for a different chain than the dApp expects. Reject
+        // with 4901 (chain not available) instead of flipping renderer state.
+        if (isDesktop) {
+          dappConnectStore.rejectCurrentRequest(
+            'The desktop wallet is pinned to its configured chain',
+            4901,
+          );
+          setPin('');
+          return;
+        }
         dappConnectStore.approveCurrentRequest(null);
         setPin('');
         return;
@@ -172,24 +194,30 @@ const DAppApprovalModal = observer(() => {
           try {
             dappConnectStore.setTxProgress('signing');
             if (method === 'qrl_signTransaction') {
-              const rawTx = await desktopSigner.signTransactionOnly({
-                from: activeAddress,
-                to: toD,
-                value: valueD,
-                data: dataD,
-              });
+              const rawTx = await desktopSigner.signTransactionOnly(
+                {
+                  from: activeAddress,
+                  to: toD,
+                  value: valueD,
+                  data: dataD,
+                },
+                dappOrigin,
+              );
               dappConnectStore.approveCurrentRequest(rawTx);
               dappConnectStore.resetTxProgress();
               setLoading(false);
               return;
             }
             dappConnectStore.setTxProgress('broadcasting');
-            const { transactionHash } = await desktopSigner.signAndSendTransaction({
-              from: activeAddress,
-              to: toD,
-              value: valueD,
-              data: dataD,
-            });
+            const { transactionHash } = await desktopSigner.signAndSendTransaction(
+              {
+                from: activeAddress,
+                to: toD,
+                value: valueD,
+                data: dataD,
+              },
+              dappOrigin,
+            );
             dappConnectStore.setTxProgress('confirmed', transactionHash);
             dappConnectStore.sendApprovalResult(transactionHash);
             setLoading(false);
@@ -359,7 +387,7 @@ const DAppApprovalModal = observer(() => {
         // no seed in the renderer.
         if (isDesktop) {
           try {
-            const result = await desktopSigner.signMessage(messageHex);
+            const result = await desktopSigner.signMessage(messageHex, dappOrigin);
             dappConnectStore.approveCurrentRequest(result);
           } catch (e) {
             const errMsg = e instanceof Error ? e.message : String(e);
@@ -418,7 +446,7 @@ const DAppApprovalModal = observer(() => {
         // in-renderer fallback.
         if (isDesktop) {
           try {
-            const result = await desktopSigner.signTypedData(payload);
+            const result = await desktopSigner.signTypedData(payload, dappOrigin);
             dappConnectStore.approveCurrentRequest(result);
           } catch (e) {
             const errMsg = e instanceof Error ? e.message : String(e);

--- a/src/components/Core/Body/DAppConnect/DAppApprovalModal.tsx
+++ b/src/components/Core/Body/DAppConnect/DAppApprovalModal.tsx
@@ -159,11 +159,13 @@ const DAppApprovalModal = observer(() => {
         // Desktop is single-network: main builds/signs/broadcasts against its
         // configured RPC + chain id, so honouring a renderer-side switch would
         // silently sign for a different chain than the dApp expects. Reject
-        // with 4901 (chain not available) instead of flipping renderer state.
+        // with 4902 (EIP-3326 unrecognized/unavailable chain) instead of
+        // flipping renderer state; 4901 would falsely signal a transient
+        // provider disconnect and invite reconnect loops.
         if (isDesktop) {
           dappConnectStore.rejectCurrentRequest(
             'The desktop wallet is pinned to its configured chain',
-            4901,
+            4902,
           );
           setPin('');
           return;

--- a/src/components/Core/Body/DAppConnect/DAppConnectConsentModal.tsx
+++ b/src/components/Core/Body/DAppConnect/DAppConnectConsentModal.tsx
@@ -13,7 +13,7 @@
  * anchors consent to the user's own action ("did you just click Connect?").
  */
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { observer } from 'mobx-react-lite';
 import { useNavigate } from 'react-router-dom';
 import { useStore } from '@/stores/store';
@@ -27,27 +27,41 @@ import {
 } from '@/components/UI/Dialog';
 import { Button } from '@/components/UI/Button';
 import { Loader, Plug } from 'lucide-react';
+import { parseConnectionURI } from '@/services/dappConnect/qrUri';
+import { DEFAULT_RELAY_URL } from '@/services/dappConnect/DAppConnectService';
 
-/** Relay the wallet will contact if the user consents (r= param, else prod). */
-function relayOriginFromUri(uri: string): string {
-  try {
-    const query = uri.split('?')[1] ?? '';
-    const r = new URLSearchParams(query).get('r');
-    if (r) return new URL(r).origin;
-  } catch {
-    /* fall through to the default */
-  }
-  return 'https://qrlwallet.com';
-}
+/** Origin the wallet dials when a URI carries no r= param. */
+const DEFAULT_RELAY_ORIGIN = new URL(DEFAULT_RELAY_URL).origin;
 
 const DAppConnectConsentModal = observer(() => {
   const { dappConnectStore } = useStore();
   const navigate = useNavigate();
   const [connecting, setConnecting] = useState(false);
   const [error, setError] = useState('');
+  // Relay origin the wallet will actually dial. Resolved via the SAME audited
+  // parser the connect path uses (parseConnectionURI) so the displayed relay
+  // cannot diverge from the one handleConnectionURI contacts; defaults until
+  // the async parse resolves and on any parse failure.
+  const [relayOrigin, setRelayOrigin] = useState(DEFAULT_RELAY_ORIGIN);
 
   const uri = dappConnectStore.desktopConnectUri;
   const source = dappConnectStore.desktopConnectSource;
+
+  useEffect(() => {
+    if (!uri) return;
+    let cancelled = false;
+    void parseConnectionURI(uri)
+      .then((parsed) => {
+        if (cancelled) return;
+        setRelayOrigin(parsed.relayUrl ? new URL(parsed.relayUrl).origin : DEFAULT_RELAY_ORIGIN);
+      })
+      .catch(() => {
+        if (!cancelled) setRelayOrigin(DEFAULT_RELAY_ORIGIN);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [uri]);
 
   const handleCancel = useCallback(() => {
     if (connecting) return;
@@ -71,8 +85,6 @@ const DAppConnectConsentModal = observer(() => {
   }, [dappConnectStore, navigate]);
 
   if (!uri) return null;
-
-  const relayOrigin = relayOriginFromUri(uri);
 
   return (
     <Dialog

--- a/src/components/Core/Body/DAppConnect/DAppConnectConsentModal.tsx
+++ b/src/components/Core/Body/DAppConnect/DAppConnectConsentModal.tsx
@@ -1,0 +1,130 @@
+/**
+ * Desktop dApp-connect consent modal.
+ *
+ * On mobile the physical QR scan IS the user's consent to pair. On desktop
+ * the qrlconnect:// OS protocol handler lets ANY webpage or local process
+ * fire connection URIs at the wallet, so this modal restores the missing
+ * consent step: no relay contact, no handshake, and no account disclosure
+ * happen until the user explicitly confirms. Declining drops the URI with
+ * zero network traffic.
+ *
+ * The dApp's identity is only learned AFTER the handshake (ORIGINATOR_INFO),
+ * so the modal can only show the relay the URI points at; the copy therefore
+ * anchors consent to the user's own action ("did you just click Connect?").
+ */
+
+import { useCallback, useState } from 'react';
+import { observer } from 'mobx-react-lite';
+import { useNavigate } from 'react-router-dom';
+import { useStore } from '@/stores/store';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/UI/Dialog';
+import { Button } from '@/components/UI/Button';
+import { Loader, Plug } from 'lucide-react';
+
+/** Relay the wallet will contact if the user consents (r= param, else prod). */
+function relayOriginFromUri(uri: string): string {
+  try {
+    const query = uri.split('?')[1] ?? '';
+    const r = new URLSearchParams(query).get('r');
+    if (r) return new URL(r).origin;
+  } catch {
+    /* fall through to the default */
+  }
+  return 'https://qrlwallet.com';
+}
+
+const DAppConnectConsentModal = observer(() => {
+  const { dappConnectStore } = useStore();
+  const navigate = useNavigate();
+  const [connecting, setConnecting] = useState(false);
+  const [error, setError] = useState('');
+
+  const uri = dappConnectStore.desktopConnectUri;
+  const source = dappConnectStore.desktopConnectSource;
+
+  const handleCancel = useCallback(() => {
+    if (connecting) return;
+    setError('');
+    dappConnectStore.clearDesktopConnect();
+  }, [connecting, dappConnectStore]);
+
+  const handleConnect = useCallback(async () => {
+    setError('');
+    setConnecting(true);
+    try {
+      const result = await dappConnectStore.confirmDesktopConnect();
+      if (result.success) {
+        navigate('/dapp-sessions');
+      } else {
+        setError(result.error || 'Connection failed');
+      }
+    } finally {
+      setConnecting(false);
+    }
+  }, [dappConnectStore, navigate]);
+
+  if (!uri) return null;
+
+  const relayOrigin = relayOriginFromUri(uri);
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) handleCancel();
+      }}
+    >
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Plug className="h-5 w-5" />
+            Connect to a dApp?
+          </DialogTitle>
+          <DialogDescription>
+            {source === 'paste'
+              ? 'You pasted a dApp connection code.'
+              : 'A dApp is requesting to connect to your wallet via QRL Connect.'}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-2 text-sm">
+          <p className="text-muted-foreground">
+            Relay: <span className="font-mono">{relayOrigin}</span>
+          </p>
+          <p>
+            Connecting shares your active account address with the dApp. Its
+            name and site are only verified after the encrypted channel is
+            established. Only continue if you just clicked Connect in a dApp
+            or pasted its connection code yourself.
+          </p>
+          {error && <p className="text-destructive">{error}</p>}
+        </div>
+
+        <DialogFooter className="gap-2">
+          <Button variant="outline" onClick={handleCancel} disabled={connecting}>
+            Cancel
+          </Button>
+          <Button onClick={() => void handleConnect()} disabled={connecting}>
+            {connecting ? (
+              <>
+                <Loader className="mr-2 h-4 w-4 animate-spin" />
+                Connecting...
+              </>
+            ) : (
+              'Connect'
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+});
+
+export default DAppConnectConsentModal;

--- a/src/components/Core/Body/DAppConnect/DAppSessionsList.tsx
+++ b/src/components/Core/Body/DAppConnect/DAppSessionsList.tsx
@@ -3,10 +3,14 @@
  * Accessible from Settings.
  */
 
+import { useState } from 'react';
 import { observer } from 'mobx-react-lite';
 import { useStore } from '@/stores/store';
 import { Button } from '@/components/UI/Button';
+import { Input } from '@/components/UI/Input';
 import { SessionStatus } from '@/services/dappConnect/types';
+import { DAppConnectService } from '@/services/dappConnect/DAppConnectService';
+import { isDesktop } from '@/desktop/bridge';
 
 const statusDotColors: Record<SessionStatus, string> = {
   [SessionStatus.CONNECTED]: '#3b82f6',     // blue-500
@@ -47,6 +51,73 @@ const DAppPulsingDot = ({ status }: { status: SessionStatus }) => {
   );
 };
 
+/**
+ * Desktop-only paste entry: the fallback ingress when the qrlconnect://
+ * protocol handler is unavailable (unregistered, blocked, or the dApp is on
+ * another machine so only its QR/URI text can travel). Feeds the exact same
+ * consent modal as the deep link; no relay contact happens here.
+ */
+const DesktopPasteConnect = observer(() => {
+  const { dappConnectStore } = useStore();
+  const [open, setOpen] = useState(false);
+  const [uri, setUri] = useState('');
+  const [error, setError] = useState('');
+
+  const submit = () => {
+    const trimmed = uri.trim();
+    if (!DAppConnectService.isConnectionURI(trimmed)) {
+      setError('Not a qrlconnect:// connection code');
+      return;
+    }
+    setError('');
+    setUri('');
+    setOpen(false);
+    dappConnectStore.requestDesktopConnect(trimmed, 'paste');
+  };
+
+  if (!open) {
+    return (
+      <Button variant="outline" size="sm" onClick={() => setOpen(true)}>
+        Connect a dApp
+      </Button>
+    );
+  }
+
+  return (
+    <div className="flex w-full max-w-xl items-start gap-2">
+      <div className="flex-1 space-y-1">
+        <Input
+          value={uri}
+          onChange={(e) => {
+            setUri(e.target.value);
+            if (error) setError('');
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') submit();
+          }}
+          placeholder="Paste a qrlconnect:// connection code"
+          autoFocus
+        />
+        {error && <p className="text-xs text-destructive">{error}</p>}
+      </div>
+      <Button size="sm" onClick={submit}>
+        Connect
+      </Button>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => {
+          setOpen(false);
+          setUri('');
+          setError('');
+        }}
+      >
+        Cancel
+      </Button>
+    </div>
+  );
+});
+
 const DAppSessionsList = observer(() => {
   const { dappConnectStore } = useStore();
   const { activeSessions } = dappConnectStore;
@@ -74,9 +145,13 @@ const DAppSessionsList = observer(() => {
         )}
       </div>
 
+      {isDesktop && <DesktopPasteConnect />}
+
       {activeSessions.length === 0 ? (
         <p className="text-sm text-muted-foreground">
-          No dApps connected. Scan a QR code from a dApp to connect.
+          {isDesktop
+            ? 'No dApps connected. Click "Open in QRL Wallet" in a dApp, or paste its connection code above.'
+            : 'No dApps connected. Scan a QR code from a dApp to connect.'}
         </p>
       ) : (
         <div className="space-y-3">

--- a/src/components/Core/MyQRLWallet.tsx
+++ b/src/components/Core/MyQRLWallet.tsx
@@ -5,6 +5,7 @@ import { lazy, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { setupActivityTracking, startAutoLockTimer, clearAutoLockTimer } from "@/utils/storage";
 import NativeAppBridge from "@/components/NativeAppBridge";
+import { isDesktop } from "@/desktop/bridge";
 import Layout from "./Layout/Layout";
 import Body from "./Body/Body";
 
@@ -13,6 +14,9 @@ import Body from "./Body/Body";
 // MyQRLWallet chunk from rendering on normal page loads.
 const DAppApprovalModal = withSuspense(lazy(() => import("./Body/DAppConnect/DAppApprovalModal")));
 const DAppConnectionBanner = withSuspense(lazy(() => import("./Body/DAppConnect/DAppConnectionBanner")));
+// Desktop-only: qrlconnect:// protocol-handler ingress + consent modal.
+// Lazy so the web build never loads it (isDesktop is false there).
+const DesktopDAppBridge = withSuspense(lazy(() => import("@/components/DesktopDAppBridge")));
 
 const MyQRLWallet = observer(() => {
   const navigate = useNavigate();
@@ -34,6 +38,7 @@ const MyQRLWallet = observer(() => {
     <Layout>
       <RouteMonitor />
       <NativeAppBridge />
+      {isDesktop && <DesktopDAppBridge />}
       <DAppConnectionBanner />
       <DAppApprovalModal />
       {/* <Header /> */}

--- a/src/components/DesktopDAppBridge.tsx
+++ b/src/components/DesktopDAppBridge.tsx
@@ -1,0 +1,36 @@
+/**
+ * Desktop dApp-connect bridge (analogue of NativeAppBridge for the Electron
+ * shell). Mounted only when running inside the desktop app (isDesktop):
+ *
+ *  - subscribes to qrlconnect:// URIs forwarded by the main process (OS
+ *    protocol handler, cold or warm start) and stages them behind the
+ *    consent modal (dappConnectStore.requestDesktopConnect); the modal is
+ *    the single gate before any relay contact.
+ *  - renders that consent modal.
+ *
+ * Main already shape-validates and rate-limits the URIs; parsing and
+ * fingerprint pinning happen in the audited dApp-connect stack only after
+ * the user consents.
+ */
+
+import { useEffect } from 'react';
+import { useStore } from '@/stores/store';
+import { desktopSigner, isDesktop } from '@/desktop/bridge';
+import DAppConnectConsentModal from './Core/Body/DAppConnect/DAppConnectConsentModal';
+
+const DesktopDAppBridge = () => {
+  const { dappConnectStore } = useStore();
+
+  useEffect(() => {
+    if (!isDesktop) return;
+    const unsubscribe = desktopSigner.onDAppConnectUri((uri) => {
+      dappConnectStore.requestDesktopConnect(uri, 'deeplink');
+    });
+    return unsubscribe;
+  }, [dappConnectStore]);
+
+  if (!isDesktop) return null;
+  return <DAppConnectConsentModal />;
+};
+
+export default DesktopDAppBridge;

--- a/src/desktop/bridge.ts
+++ b/src/desktop/bridge.ts
@@ -59,11 +59,26 @@ export interface SignatureResult {
   rawTransaction?: string;
 }
 
+/**
+ * dApp-connect provenance attached to a signature request that originated
+ * from a connected dApp session. Rendered by the desktop's trusted confirm
+ * modal under an explicit "unverified, dApp-supplied" label. The desktop
+ * schema is strict (bounded lengths, no control chars, http(s)-or-empty
+ * url), so build values with {@link buildDappOrigin} rather than passing
+ * raw ORIGINATOR_INFO through.
+ */
+export interface DAppOriginMeta {
+  via: 'dapp';
+  name: string;
+  url: string;
+  channelId: string;
+}
+
 /** Discriminated union of signature requests sent to the signer. */
 export type SignatureRequest =
-  | { kind: 'transaction'; tx: UnsignedTransaction }
-  | { kind: 'message'; messageHex: string }
-  | { kind: 'typedData'; payload: unknown };
+  | { kind: 'transaction'; tx: UnsignedTransaction; origin?: DAppOriginMeta }
+  | { kind: 'message'; messageHex: string; origin?: DAppOriginMeta }
+  | { kind: 'typedData'; payload: unknown; origin?: DAppOriginMeta };
 
 export interface CreateWalletResult {
   status: WalletStatus;
@@ -102,7 +117,15 @@ export interface QrlWalletBridge {
   }): Promise<UnsignedTransaction>;
   requestSignature(request: SignatureRequest): Promise<SignatureResult>;
   sendRawTransaction(args: { rawTx: string }): Promise<{ transactionHash: string }>;
+  /** Surface the wallet window (taskbar flash / dock bounce, no focus steal)
+   * because a dApp request needs the user. Rate-limited by main. Optional:
+   * absent on desktop shells that predate dApp-connect. */
+  dappRequestAttention?(): Promise<void>;
   onLockStateChanged(cb: (locked: boolean) => void): () => void;
+  /** Subscribe to qrlconnect:// URIs arriving via the OS protocol handler.
+   * Returns an unsubscribe. Optional: absent on desktop shells that predate
+   * dApp-connect. */
+  onDAppConnectUri?(cb: (uri: string) => void): () => void;
 }
 
 declare global {
@@ -135,6 +158,44 @@ export function qrlWallet(): QrlWalletBridge {
     throw new Error('desktop: window.qrlWallet bridge is not available');
   }
   return bridge;
+}
+
+// ---------------------------------------------------------------------------
+// dApp origin sanitiser
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a desktop-schema-safe origin block from dApp-supplied session info.
+ * The desktop main process zod-rejects oversized / control-char / non-http(s)
+ * values outright, and a rejected signature request would strand the dApp, so
+ * sanitise here: clamp lengths, strip control chars, and map an unusable URL
+ * to '' (the confirm modal shows "(not provided)"). Returns undefined only
+ * when the channelId itself is unusable, in which case the request proceeds
+ * without provenance rather than failing.
+ */
+export function buildDappOrigin(
+  name: string | undefined,
+  url: string | undefined,
+  channelId: string,
+): DAppOriginMeta | undefined {
+  if (!/^[0-9a-fA-F-]{1,64}$/.test(channelId)) return undefined;
+  const cleanName =
+    (name ?? '')
+      // eslint-disable-next-line no-control-regex -- stripping control chars is the point
+      .replace(/[\u0000-\u001f\u007f]/g, '')
+      .trim()
+      .slice(0, 64) || 'Unknown dApp';
+  let cleanUrl = '';
+  if (url) {
+    const candidate = url.slice(0, 256);
+    try {
+      const proto = new URL(candidate).protocol;
+      if (proto === 'https:' || proto === 'http:') cleanUrl = candidate;
+    } catch {
+      /* unusable URL: leave '' */
+    }
+  }
+  return { via: 'dapp', name: cleanName, url: cleanUrl, channelId };
 }
 
 // ---------------------------------------------------------------------------
@@ -196,14 +257,17 @@ export const desktopSigner = {
    * transaction. `value`/`data` are pure renderer-side inputs; nonce, gas and
    * chainId are filled by main. Returns the broadcast transaction hash.
    */
-  async signAndSendTransaction(args: {
-    from: string;
-    to: string;
-    /** Smallest-unit decimal string. */
-    value: string;
-    data?: string;
-    feeLevel?: FeeLevelHint;
-  }): Promise<{ transactionHash: string }> {
+  async signAndSendTransaction(
+    args: {
+      from: string;
+      to: string;
+      /** Smallest-unit decimal string. */
+      value: string;
+      data?: string;
+      feeLevel?: FeeLevelHint;
+    },
+    origin?: DAppOriginMeta,
+  ): Promise<{ transactionHash: string }> {
     const bridge = qrlWallet();
     const tx = await bridge.buildTransaction({
       from: args.from,
@@ -212,7 +276,7 @@ export const desktopSigner = {
       data: args.data,
       feeLevel: args.feeLevel,
     });
-    const signed = await bridge.requestSignature({ kind: 'transaction', tx });
+    const signed = await bridge.requestSignature({ kind: 'transaction', tx, origin });
     if (!signed.rawTransaction) {
       throw new Error('desktop: signer returned no raw transaction');
     }
@@ -223,14 +287,17 @@ export const desktopSigner = {
    * Build + confirm + sign a transaction WITHOUT broadcasting. Used by the
    * dApp `qrl_signTransaction` path which returns the raw tx to the dApp.
    */
-  async signTransactionOnly(args: {
-    from: string;
-    to: string;
-    /** Smallest-unit decimal string. */
-    value: string;
-    data?: string;
-    feeLevel?: FeeLevelHint;
-  }): Promise<string> {
+  async signTransactionOnly(
+    args: {
+      from: string;
+      to: string;
+      /** Smallest-unit decimal string. */
+      value: string;
+      data?: string;
+      feeLevel?: FeeLevelHint;
+    },
+    origin?: DAppOriginMeta,
+  ): Promise<string> {
     const bridge = qrlWallet();
     const tx = await bridge.buildTransaction({
       from: args.from,
@@ -239,7 +306,7 @@ export const desktopSigner = {
       data: args.data,
       feeLevel: args.feeLevel,
     });
-    const signed = await bridge.requestSignature({ kind: 'transaction', tx });
+    const signed = await bridge.requestSignature({ kind: 'transaction', tx, origin });
     if (!signed.rawTransaction) {
       throw new Error('desktop: signer returned no raw transaction');
     }
@@ -247,8 +314,8 @@ export const desktopSigner = {
   },
 
   /** Sign a hex-encoded message via the signer's trusted modal. */
-  async signMessage(messageHex: string): Promise<SignatureResult> {
-    return qrlWallet().requestSignature({ kind: 'message', messageHex });
+  async signMessage(messageHex: string, origin?: DAppOriginMeta): Promise<SignatureResult> {
+    return qrlWallet().requestSignature({ kind: 'message', messageHex, origin });
   },
 
   /**
@@ -256,8 +323,27 @@ export const desktopSigner = {
    * callers should surface a clear "not yet supported on desktop" error rather
    * than falling back to an in-renderer signer.
    */
-  async signTypedData(payload: unknown): Promise<SignatureResult> {
-    return qrlWallet().requestSignature({ kind: 'typedData', payload });
+  async signTypedData(payload: unknown, origin?: DAppOriginMeta): Promise<SignatureResult> {
+    return qrlWallet().requestSignature({ kind: 'typedData', payload, origin });
+  },
+
+  /**
+   * Ask main to surface the wallet window because a dApp request is waiting
+   * (taskbar flash / dock bounce; rate-limited in main). Optional-called so a
+   * renderer paired with an older desktop shell degrades to a no-op.
+   */
+  async dappRequestAttention(): Promise<void> {
+    await qrlWallet().dappRequestAttention?.();
+  },
+
+  /**
+   * Subscribe to qrlconnect:// URIs from the OS protocol handler. Returns an
+   * unsubscribe; a no-op unsubscribe when the shell predates the feature.
+   */
+  onDAppConnectUri(cb: (uri: string) => void): () => void {
+    const bridge = qrlWallet();
+    if (typeof bridge.onDAppConnectUri !== 'function') return () => undefined;
+    return bridge.onDAppConnectUri(cb);
   },
 
   /** Broadcast an already-signed raw transaction. */

--- a/src/desktop/bridge.ts
+++ b/src/desktop/bridge.ts
@@ -186,11 +186,14 @@ export function buildDappOrigin(
       .trim()
       .slice(0, 64) || 'Unknown dApp';
   let cleanUrl = '';
-  if (url) {
-    const candidate = url.slice(0, 256);
+  // Validate the WHOLE url, then accept it only if it is a well-formed http(s)
+  // URL within the schema's 256-char cap. Slicing before parsing would truncate
+  // a long-but-valid URL into junk (dropped to '' or, worse, a valid-but-wrong
+  // prefix), so an over-cap URL maps cleanly to '' instead.
+  if (url && url.length <= 256) {
     try {
-      const proto = new URL(candidate).protocol;
-      if (proto === 'https:' || proto === 'http:') cleanUrl = candidate;
+      const proto = new URL(url).protocol;
+      if (proto === 'https:' || proto === 'http:') cleanUrl = url;
     } catch {
       /* unusable URL: leave '' */
     }

--- a/src/services/dappConnect/DAppConnectService.ts
+++ b/src/services/dappConnect/DAppConnectService.ts
@@ -34,7 +34,7 @@ function dlog(msg: string): void {
   logToNative(`[DAppConnect] ${msg}`);
 }
 
-const DEFAULT_RELAY_URL = 'https://qrlwallet.com';
+export const DEFAULT_RELAY_URL = 'https://qrlwallet.com';
 // Grace period before a dApp that left the relay channel is torn down. On a
 // same-device deep-link round trip the dApp's browser tab is suspended while
 // the wallet is foregrounded, so its relay socket drops; the relay buffer
@@ -550,8 +550,9 @@ export class DAppConnectService {
     sessionId: string,
     requestId: string | number,
     message = 'User rejected the request',
-    // 4001 = user rejected (EIP-1193). Desktop passes 4901 for chain-switch
-    // requests it cannot honour (single configured chain).
+    // 4001 = user rejected (EIP-1193). Desktop passes 4902 (EIP-3326
+    // unrecognized chain) for chain-switch requests it cannot honour
+    // (single configured chain).
     code = 4001
   ): void {
     void this.sendJsonRpcResponse(sessionId, {

--- a/src/services/dappConnect/DAppConnectService.ts
+++ b/src/services/dappConnect/DAppConnectService.ts
@@ -549,12 +549,15 @@ export class DAppConnectService {
   rejectRequest(
     sessionId: string,
     requestId: string | number,
-    message = 'User rejected the request'
+    message = 'User rejected the request',
+    // 4001 = user rejected (EIP-1193). Desktop passes 4901 for chain-switch
+    // requests it cannot honour (single configured chain).
+    code = 4001
   ): void {
     void this.sendJsonRpcResponse(sessionId, {
       jsonrpc: '2.0',
       id: requestId,
-      error: { code: 4001, message },
+      error: { code, message },
     }).then((sent) => {
       if (sent) this.maybeReturnToDApp(sessionId);
       else console.error('[DAppConnect] reject response not sent; skipping return-to-dApp');

--- a/src/stores/dappConnectStore.ts
+++ b/src/stores/dappConnectStore.ts
@@ -102,7 +102,12 @@ class DAppConnectStore {
    * single gate before any relay contact.
    */
   requestDesktopConnect(uri: string, source: DesktopConnectSource = 'deeplink'): void {
-    if (!DAppConnectService.isConnectionURI(uri)) return;
+    if (!DAppConnectService.isConnectionURI(uri)) {
+      // Surface the drop: an invalid URI arriving via the OS protocol handler
+      // is otherwise indistinguishable from a mis-registered handler.
+      console.warn('[DAppConnect] ignoring non-qrlconnect desktop connect URI');
+      return;
+    }
     this.desktopConnectUri = uri;
     this.desktopConnectSource = source;
   }
@@ -124,7 +129,10 @@ class DAppConnectStore {
     const origin = this.desktopConnectSource === 'deeplink' ? 'deeplink' : 'qr';
     const result = await dappConnectService.handleConnectionURI(uri, origin);
     runInAction(() => {
-      if (result.success) this.desktopConnectUri = null;
+      // Only clear if a newer URI wasn't staged during the awaited handshake;
+      // otherwise the latest-wins staging would silently drop that pending URI
+      // and its consent modal would never appear.
+      if (result.success && this.desktopConnectUri === uri) this.desktopConnectUri = null;
     });
     return result;
   }

--- a/src/stores/dappConnectStore.ts
+++ b/src/stores/dappConnectStore.ts
@@ -4,10 +4,14 @@
  */
 
 import { makeAutoObservable, runInAction } from 'mobx';
-import { dappConnectService } from '@/services/dappConnect/DAppConnectService';
+import { dappConnectService, DAppConnectService } from '@/services/dappConnect/DAppConnectService';
 import type { DAppSession, PendingDAppRequest } from '@/services/dappConnect/types';
+import { isDesktop, desktopSigner } from '@/desktop/bridge';
 
 export type TxProgressState = 'idle' | 'signing' | 'broadcasting' | 'confirming' | 'confirmed' | 'failed';
+
+/** How a desktop connect URI reached the wallet (protocol handler vs paste). */
+export type DesktopConnectSource = 'deeplink' | 'paste';
 
 class DAppConnectStore {
   activeSessions: DAppSession[] = [];
@@ -22,6 +26,13 @@ class DAppConnectStore {
   txProgress: TxProgressState = 'idle';
   txHash: string | null = null;
   txError: string | null = null;
+  /**
+   * Desktop only: a qrlconnect:// URI awaiting the user's consent (from the
+   * OS protocol handler or the paste field). The consent modal observes this;
+   * NO relay contact happens until the user confirms. Latest request wins.
+   */
+  desktopConnectUri: string | null = null;
+  desktopConnectSource: DesktopConnectSource = 'deeplink';
 
   constructor() {
     makeAutoObservable(this);
@@ -42,6 +53,15 @@ class DAppConnectStore {
             this.approvalModalOpen = true;
           }
         });
+        // Desktop analogue of the mobile DAPP_SHOW_WEBVIEW contract: a
+        // restricted request arriving while the window is hidden/unfocused
+        // flashes the taskbar (main is rate-limited; never steals focus).
+        if (
+          isDesktop &&
+          (document.visibilityState === 'hidden' || !document.hasFocus())
+        ) {
+          void desktopSigner.dappRequestAttention().catch(() => undefined);
+        }
       },
       onSessionConnected: (sessionId) => {
         runInAction(() => {
@@ -76,6 +96,39 @@ class DAppConnectStore {
     return dappConnectService.handleConnectionURI(uri);
   }
 
+  /**
+   * Desktop: stage a qrlconnect:// URI behind the consent modal. Called by
+   * the protocol-handler bridge and the paste field; the consent modal is the
+   * single gate before any relay contact.
+   */
+  requestDesktopConnect(uri: string, source: DesktopConnectSource = 'deeplink'): void {
+    if (!DAppConnectService.isConnectionURI(uri)) return;
+    this.desktopConnectUri = uri;
+    this.desktopConnectSource = source;
+  }
+
+  /** Desktop: dismiss the staged connect request (consent declined/finished). */
+  clearDesktopConnect(): void {
+    this.desktopConnectUri = null;
+  }
+
+  /**
+   * Desktop: user consented in the modal. Runs the normal connect path; the
+   * 'deeplink' origin only ever gates the native return-to-dApp redirect,
+   * which is a no-op outside the mobile app, so paste + deeplink both map to
+   * their honest origin ('qr' for paste: the dApp may be on another device).
+   */
+  async confirmDesktopConnect(): Promise<{ success: boolean; error?: string }> {
+    const uri = this.desktopConnectUri;
+    if (!uri) return { success: false, error: 'No pending connection' };
+    const origin = this.desktopConnectSource === 'deeplink' ? 'deeplink' : 'qr';
+    const result = await dappConnectService.handleConnectionURI(uri, origin);
+    runInAction(() => {
+      if (result.success) this.desktopConnectUri = null;
+    });
+    return result;
+  }
+
   /** Approve the current request with a result */
   approveCurrentRequest(result: unknown): void {
     if (!this.currentApproval) return;
@@ -90,13 +143,14 @@ class DAppConnectStore {
   }
 
   /** Reject the current request */
-  rejectCurrentRequest(message?: string): void {
+  rejectCurrentRequest(message?: string, code?: number): void {
     if (!this.currentApproval) return;
 
     dappConnectService.rejectRequest(
       this.currentApproval.sessionId,
       this.currentApproval.id,
-      message
+      message,
+      code
     );
 
     this.removeCurrentApproval();


### PR DESCRIPTION
## What

PR 2 of the desktop dApp-connect plan (design: myqrlwallet-collection PR #3, plans/desktop-dapp-connect.md). All changes are isDesktop-gated; web and mobile behaviour untouched.

- DesktopDAppBridge + DAppConnectConsentModal: protocol-handler URIs stage behind an explicit consent modal (shows relay origin); zero relay contact until the user confirms. On mobile the physical QR scan is the consent; this restores that step for the OS-wide protocol handler.
- Paste-URI entry on the dApp sessions page feeding the same consent gate.
- Desktop signing paths carry sanitised dApp provenance (buildDappOrigin) into the trusted confirm; wallet_addQrlChain / wallet_switchQrlChain return 4901 on desktop (main signs against its configured chain).
- Attention flash (dappRequestAttention) when a restricted request arrives while the window is hidden or unfocused.

## Provenance

Authored in a remote Claude Code session that only had push access to the collection repo; landed here via git am of the gate-validated patch (original commit preserved) on base 4b72636. Merges clean into current dev (verified with git merge-tree).

## Validation (re-run locally on this exact head)

- lint (0 warnings): green
- test: 114/114 pass (jest)
- build (tsc + vite): green
- Desktop pairing: the myqrlwallet-desktop feat/dapp-connect-shell build stages this branch as renderer and its full gate suite is green against it.

## Pairs with

myqrlwallet-desktop PR #10 (shell ingress + attention IPC + origin in trusted confirm). Either merges independently; the feature needs both.

## Known limits

- Consent modal cannot verify dApp identity pre-handshake (identity arrives only in ORIGINATOR_INFO); copy anchors consent to the user's own click, and the signature confirm remains the spend gate.
- qrl_signTypedData still errors by design on desktop until the typed-data hasher is ported into the signer (PR 3 in the plan).