### PR TITLE
test(dapp-connect): unit coverage for qrUri parser, desktop bridge sanitiser, store consent flow

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,9 +1,11 @@
 /**
  * Single Jest config for the repo's pure unit tests: the post-quantum signing
- * module (`src/utils/signing/__tests__`) and the content-moderation helpers
- * (`src/utils/moderation`). React component coverage stays with Vite/Vitest.
+ * module (`src/utils/signing/__tests__`), the content-moderation helpers
+ * (`src/utils/moderation`), and the dApp-connect logic (qrUri parser, desktop
+ * bridge sanitiser, dappConnectStore with the service seam mocked). React
+ * component coverage stays with Vite/Vitest.
  *
- * Both suites run under the node environment (no DOM needed). `@noble/*` and
+ * All suites run under the node environment (no DOM needed). `@noble/*` and
  * `@theqrl/*` ship ESM with `.js`-extension imports, so they must be
  * transformed by babel-jest (the transformIgnorePatterns carve-out) rather
  * than left as raw ESM for jest's CommonJS runtime.

--- a/src/desktop/__tests__/bridge.test.ts
+++ b/src/desktop/__tests__/bridge.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Unit tests for the desktop bridge's pure logic: buildDappOrigin, the
+ * sanitiser that maps dApp-supplied ORIGINATOR_INFO (attacker-controlled)
+ * into the desktop main process's strict DAppOriginSchema bounds
+ * (name <= 64 chars no control chars, http(s)-or-empty url <= 256 chars,
+ * hex/uuid channelId <= 64). A value that would be zod-rejected by main must
+ * be repaired here, because a rejected signature request strands the dApp.
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import { buildDappOrigin } from '../bridge';
+
+const CHANNEL = '0199aabb-ccdd-eeff-0011-223344556677';
+
+describe('buildDappOrigin', () => {
+  it('passes through clean values with via=dapp', () => {
+    const origin = buildDappOrigin('Test dApp', 'https://zondscan.com/dapp-example', CHANNEL);
+    expect(origin).toEqual({
+      via: 'dapp',
+      name: 'Test dApp',
+      url: 'https://zondscan.com/dapp-example',
+      channelId: CHANNEL,
+    });
+  });
+
+  describe('channelId gate (returns undefined: request proceeds without provenance)', () => {
+    it.each([
+      ['empty', ''],
+      ['non-hex chars', 'not-a-channel!'],
+      ['over 64 chars', 'a'.repeat(65)],
+      ['whitespace', '0199 aabb'],
+    ])('drops origin for %s channelId', (_label, channelId) => {
+      expect(buildDappOrigin('dApp', 'https://a.example', channelId)).toBeUndefined();
+    });
+
+    it('accepts plain hex without dashes', () => {
+      expect(buildDappOrigin('d', undefined, 'abcdef0123456789')?.channelId).toBe(
+        'abcdef0123456789'
+      );
+    });
+  });
+
+  describe('name sanitising', () => {
+    it('strips control characters and trims', () => {
+      const origin = buildDappOrigin('\u0000\u001f My\u007fdApp \u0001', undefined, CHANNEL);
+      expect(origin?.name).toBe('MydApp');
+    });
+
+    it('clamps to 64 chars', () => {
+      const origin = buildDappOrigin('x'.repeat(65), undefined, CHANNEL);
+      expect(origin?.name).toBe('x'.repeat(64));
+    });
+
+    it.each([
+      ['undefined', undefined],
+      ['empty', ''],
+      ['all control chars', '\u0000\u0001\u0002'],
+      ['whitespace only', '   '],
+    ])('falls back to "Unknown dApp" for %s name', (_label, name) => {
+      expect(buildDappOrigin(name, undefined, CHANNEL)?.name).toBe('Unknown dApp');
+    });
+  });
+
+  describe('url sanitising (http(s)-or-empty, validate BEFORE bounding)', () => {
+    it.each([
+      ['javascript scheme', 'javascript:alert(1)'],
+      ['file scheme', 'file:///etc/passwd'],
+      ['ftp scheme', 'ftp://a.example'],
+      ['unparseable', 'not a url'],
+      ['undefined', undefined],
+      ['empty', ''],
+    ])('maps %s to empty string', (_label, url) => {
+      expect(buildDappOrigin('d', url, CHANNEL)?.url).toBe('');
+    });
+
+    it('keeps http and https URLs', () => {
+      expect(buildDappOrigin('d', 'http://a.example', CHANNEL)?.url).toBe('http://a.example');
+      expect(buildDappOrigin('d', 'https://a.example', CHANNEL)?.url).toBe('https://a.example');
+    });
+
+    it('keeps a valid URL of exactly 256 chars', () => {
+      const url = `https://a.example/${'p'.repeat(256 - 'https://a.example/'.length)}`;
+      expect(url).toHaveLength(256);
+      expect(buildDappOrigin('d', url, CHANNEL)?.url).toBe(url);
+    });
+
+    it('drops (not truncates) a valid URL longer than 256 chars', () => {
+      // Regression guard: slicing to 256 before parsing used to turn a
+      // long-but-valid URL into a truncated string that either failed to
+      // parse or, worse, parsed into a valid-but-wrong URL shown in the
+      // trusted confirm. Over-cap URLs can never pass main's schema, so the
+      // only honest mapping is '' ("(not provided)").
+      const url = `https://a.example/${'p'.repeat(300)}`;
+      expect(buildDappOrigin('d', url, CHANNEL)?.url).toBe('');
+    });
+  });
+});

--- a/src/services/dappConnect/__tests__/qrUri.test.ts
+++ b/src/services/dappConnect/__tests__/qrUri.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Unit tests for the wallet-side PQP2 qrlconnect:// URI parser.
+ *
+ * This parser is the single hostile-input choke point for dApp-connect
+ * ingress (QR scan, mobile deep link, desktop protocol handler, desktop
+ * paste). Fixtures are built the same way the SDK's generator builds real
+ * URIs: URLSearchParams over base45(PQP2 || cid || fp), optional sibling
+ * r= relay param.
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import {
+  parseConnectionURI,
+  computeFingerprint,
+  fingerprintEquals,
+  cidToString,
+  cidFromString,
+  CID_LEN,
+  FP_LEN,
+  BLOB_LEN,
+} from '../qrUri';
+import { base45Encode } from '../base45';
+
+const MAGIC = [0x50, 0x51, 0x50, 0x32]; // "PQP2"
+const PQP1_MAGIC = [0x50, 0x51, 0x50, 0x31]; // "PQP1"
+
+function makeCid(fill = 0xab): Uint8Array {
+  const cid = new Uint8Array(CID_LEN);
+  cid.fill(fill);
+  // Vary a few bytes so cidToString formatting is meaningfully exercised.
+  cid[0] = 0x01;
+  cid[CID_LEN - 1] = 0xfe;
+  return cid;
+}
+
+function makeFp(fill = 0x5c): Uint8Array {
+  const fp = new Uint8Array(FP_LEN);
+  fp.fill(fill);
+  return fp;
+}
+
+function makeBlob(cid: Uint8Array, fp: Uint8Array, magic: number[] = MAGIC): Uint8Array {
+  const blob = new Uint8Array(4 + cid.length + fp.length);
+  blob.set(magic, 0);
+  blob.set(cid, 4);
+  blob.set(fp, 4 + cid.length);
+  return blob;
+}
+
+/** Build a URI exactly like the SDK generator does (URLSearchParams-encoded). */
+function makeUri(blob: Uint8Array, relayUrl?: string): string {
+  const params = new URLSearchParams({ q: base45Encode(blob) });
+  if (relayUrl) params.set('r', relayUrl);
+  return `qrlconnect://?${params.toString()}`;
+}
+
+describe('parseConnectionURI', () => {
+  it('parses a valid PQP2 URI (round-trips cid and fp, no relay)', async () => {
+    const cid = makeCid();
+    const fp = makeFp();
+    const parsed = await parseConnectionURI(makeUri(makeBlob(cid, fp)));
+    expect(Array.from(parsed.cid)).toEqual(Array.from(cid));
+    expect(Array.from(parsed.fp)).toEqual(Array.from(fp));
+    expect(parsed.relayUrl).toBeUndefined();
+  });
+
+  it('returns the r= relay param verbatim', async () => {
+    const uri = makeUri(makeBlob(makeCid(), makeFp()), 'https://dev.qrlwallet.com');
+    const parsed = await parseConnectionURI(uri);
+    expect(parsed.relayUrl).toBe('https://dev.qrlwallet.com');
+  });
+
+  it('accepts an uppercase scheme', async () => {
+    const uri = makeUri(makeBlob(makeCid(), makeFp())).replace(/^qrlconnect/, 'QRLCONNECT');
+    const parsed = await parseConnectionURI(uri);
+    expect(parsed.cid).toHaveLength(CID_LEN);
+  });
+
+  it('sees an r= param hidden behind a second "?" (naive split-parsers do not)', async () => {
+    // Regression guard for the consent-modal display fix: the modal must
+    // derive the shown relay from THIS parser, because a URI like
+    // qrlconnect://?q=..&x=?&r=<relay> defeats uri.split('?')[1]-style
+    // parsing (r appears absent) while the WHATWG query used here (and by
+    // the connect path) still resolves r. If the two disagreed, the user
+    // would consent to a different relay than the wallet dials.
+    const base = makeUri(makeBlob(makeCid(), makeFp()));
+    const uri = `${base}&x=?&r=https://evil.example`;
+    expect(base.split('?')[1]?.includes('r=')).toBe(false); // the naive read
+    const parsed = await parseConnectionURI(uri);
+    expect(parsed.relayUrl).toBe('https://evil.example'); // the real read
+  });
+
+  it('rejects a non-qrlconnect scheme', async () => {
+    await expect(parseConnectionURI('https://qrlwallet.com/?q=abc')).rejects.toThrow(
+      'not a qrlconnect URI'
+    );
+  });
+
+  it('rejects an empty URI', async () => {
+    await expect(parseConnectionURI('')).rejects.toThrow('empty URI');
+  });
+
+  it('rejects a scheme-only URI with no query (q lands in the path)', async () => {
+    // "qrlconnect:q=..." has no "?": after the dummy-scheme swap the blob is
+    // path, not query, so the parser must reject rather than loosely match.
+    const q = base45Encode(makeBlob(makeCid(), makeFp()));
+    await expect(parseConnectionURI(`qrlconnect:q=${q}`)).rejects.toThrow('missing q parameter');
+  });
+
+  it('rejects legacy v1 URIs by their channelId/pubKey params', async () => {
+    await expect(
+      parseConnectionURI('qrlconnect://?channelId=abc&pubKey=def')
+    ).rejects.toThrow('legacy v1 URI');
+  });
+
+  it('rejects a q param that is not base45', async () => {
+    await expect(parseConnectionURI('qrlconnect://?q=%7F%7F')).rejects.toThrow(
+      'base45 decode failed'
+    );
+  });
+
+  it('rejects a blob of the wrong length', async () => {
+    const short = new Uint8Array(BLOB_LEN - 1).fill(1);
+    await expect(parseConnectionURI(makeUri(short))).rejects.toThrow(
+      `expected ${BLOB_LEN}-byte blob`
+    );
+  });
+
+  it('gives the legacy hint for a PQP1-magic 1208-byte blob', async () => {
+    const legacy = new Uint8Array(1208).fill(0x11);
+    legacy.set(PQP1_MAGIC, 0);
+    await expect(parseConnectionURI(makeUri(legacy))).rejects.toThrow('legacy PQP1 URI');
+  });
+
+  it('rejects a 52-byte blob with the wrong magic', async () => {
+    const blob = makeBlob(makeCid(), makeFp(), [0x41, 0x42, 0x43, 0x44]);
+    await expect(parseConnectionURI(makeUri(blob))).rejects.toThrow('bad PQP2 magic');
+  });
+});
+
+describe('computeFingerprint', () => {
+  it('matches SHA-256("pq-fp/v2" || cid || pk)', async () => {
+    const cid = makeCid();
+    const pk = new Uint8Array(64).fill(0x77);
+    const label = new TextEncoder().encode('pq-fp/v2');
+    const buf = new Uint8Array(label.length + cid.length + pk.length);
+    buf.set(label, 0);
+    buf.set(cid, label.length);
+    buf.set(pk, label.length + cid.length);
+    const expected = new Uint8Array(await globalThis.crypto.subtle.digest('SHA-256', buf));
+
+    const fp = await computeFingerprint(cid, pk);
+    expect(fp).toHaveLength(FP_LEN);
+    expect(fingerprintEquals(fp, expected)).toBe(true);
+  });
+
+  it('rejects a wrong-length cid', async () => {
+    await expect(computeFingerprint(new Uint8Array(3), new Uint8Array(4))).rejects.toThrow(
+      `cid must be ${CID_LEN} bytes`
+    );
+  });
+});
+
+describe('fingerprintEquals', () => {
+  it('is true only for identical bytes', () => {
+    const a = makeFp(0x01);
+    const b = makeFp(0x01);
+    expect(fingerprintEquals(a, b)).toBe(true);
+    b[FP_LEN - 1] = 0x02;
+    expect(fingerprintEquals(a, b)).toBe(false);
+  });
+
+  it('is false for different lengths', () => {
+    expect(fingerprintEquals(new Uint8Array(4), new Uint8Array(5))).toBe(false);
+  });
+});
+
+describe('cidToString / cidFromString', () => {
+  it('formats as a uuid-shaped hex string and round-trips', () => {
+    const cid = makeCid();
+    const s = cidToString(cid);
+    expect(s).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    expect(Array.from(cidFromString(s))).toEqual(Array.from(cid));
+  });
+
+  it('cidToString rejects a wrong-length cid', () => {
+    expect(() => cidToString(new Uint8Array(8))).toThrow(`expected ${CID_LEN}-byte cid`);
+  });
+
+  it('cidFromString rejects non-128-bit-hex input', () => {
+    expect(() => cidFromString('zz')).toThrow('not a 128-bit hex string');
+  });
+});

--- a/src/stores/__tests__/dappConnectStore.test.ts
+++ b/src/stores/__tests__/dappConnectStore.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Unit tests for DAppConnectStore: the desktop consent staging flow
+ * (requestDesktopConnect / confirmDesktopConnect), the approval queue, and
+ * the approve/reject passthrough to the service (including the EIP-1193
+ * error-code plumbing the desktop chain-pinning path relies on).
+ *
+ * The DAppConnectService singleton is mocked at the module seam: its real
+ * module transitively imports the whole wallet store graph (qrlStore,
+ * import.meta.env config), which jest's node runtime cannot load, and these
+ * tests are about the store's contract with the service, not the service.
+ */
+
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import type { DAppSession, PendingDAppRequest } from '@/services/dappConnect/types';
+import { SessionStatus } from '@/services/dappConnect/types';
+
+jest.mock('@/services/dappConnect/DAppConnectService', () => {
+  const dappConnectService = {
+    setHandlers: jest.fn(),
+    getActiveSessions: jest.fn(() => []),
+    reconnectAll: jest.fn(async () => undefined),
+    handleConnectionURI: jest.fn(async () => ({ success: true })),
+    approveRequest: jest.fn(),
+    rejectRequest: jest.fn(),
+    disconnectSession: jest.fn(async () => undefined),
+    disconnectAll: jest.fn(async () => undefined),
+  };
+  class DAppConnectService {
+    // Mirrors the real static (a one-line scheme regex); re-declared here so
+    // the mock factory does not have to load the real module graph.
+    static isConnectionURI(uri: string): boolean {
+      return /^qrlconnect:/i.test(uri);
+    }
+  }
+  return { dappConnectService, DAppConnectService };
+});
+
+jest.mock('@/desktop/bridge', () => ({
+  isDesktop: false,
+  desktopSigner: {
+    dappRequestAttention: jest.fn(async () => undefined),
+  },
+}));
+
+import DAppConnectStore from '@/stores/dappConnectStore';
+import { dappConnectService } from '@/services/dappConnect/DAppConnectService';
+
+const mockService = jest.mocked(dappConnectService);
+
+const URI_A = 'qrlconnect://?q=blobA';
+const URI_B = 'qrlconnect://?q=blobB';
+
+function makeSession(): DAppSession {
+  return {
+    version: 2,
+    id: 'c1',
+    dappInfo: { name: 'Test dApp', url: 'https://a.example', chainId: '0x1' },
+    connectedAccount: 'Q0000000000000000000000000000000000000000',
+    keyExchange: {
+      cid: 'c1',
+      kAeadRaw: '',
+      htx: '',
+      sendDir: 'w2d',
+      recvDir: 'd2w',
+      sendSeq: 0,
+      recvSeq: 0,
+    },
+    status: SessionStatus.CONNECTED,
+    createdAt: 0,
+    lastActivity: 0,
+  };
+}
+
+function makeRequest(overrides: Partial<PendingDAppRequest> = {}): PendingDAppRequest {
+  return {
+    id: 1,
+    sessionId: 'session-1',
+    method: 'qrl_signMessage',
+    params: [],
+    dappInfo: { name: 'Test dApp', url: 'https://a.example', chainId: '0x1' },
+    timestamp: 0,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockService.getActiveSessions.mockReturnValue([]);
+  mockService.handleConnectionURI.mockResolvedValue({ success: true });
+});
+
+describe('constructor wiring', () => {
+  it('registers service handlers and loads sessions without reconnect when none stored', () => {
+    new DAppConnectStore();
+    expect(mockService.setHandlers).toHaveBeenCalledTimes(1);
+    expect(mockService.reconnectAll).not.toHaveBeenCalled();
+  });
+
+  it('auto-reconnects when stored sessions exist', () => {
+    mockService.getActiveSessions.mockReturnValue([makeSession()]);
+    const store = new DAppConnectStore();
+    expect(store.sessionCount).toBe(1);
+    expect(mockService.reconnectAll).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('requestDesktopConnect', () => {
+  it('stages a valid URI with its source', () => {
+    const store = new DAppConnectStore();
+    store.requestDesktopConnect(URI_A, 'paste');
+    expect(store.desktopConnectUri).toBe(URI_A);
+    expect(store.desktopConnectSource).toBe('paste');
+  });
+
+  it('defaults the source to deeplink', () => {
+    const store = new DAppConnectStore();
+    store.requestDesktopConnect(URI_A);
+    expect(store.desktopConnectSource).toBe('deeplink');
+  });
+
+  it('drops a non-qrlconnect URI with a warning and stages nothing', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      const store = new DAppConnectStore();
+      store.requestDesktopConnect('https://evil.example/?q=x', 'deeplink');
+      expect(store.desktopConnectUri).toBeNull();
+      expect(warn).toHaveBeenCalledTimes(1);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('latest request wins while consent is pending', () => {
+    const store = new DAppConnectStore();
+    store.requestDesktopConnect(URI_A, 'deeplink');
+    store.requestDesktopConnect(URI_B, 'paste');
+    expect(store.desktopConnectUri).toBe(URI_B);
+    expect(store.desktopConnectSource).toBe('paste');
+  });
+});
+
+describe('clearDesktopConnect', () => {
+  it('dismisses the staged URI', () => {
+    const store = new DAppConnectStore();
+    store.requestDesktopConnect(URI_A);
+    store.clearDesktopConnect();
+    expect(store.desktopConnectUri).toBeNull();
+  });
+});
+
+describe('confirmDesktopConnect', () => {
+  it('fails without touching the service when nothing is staged', async () => {
+    const store = new DAppConnectStore();
+    const result = await store.confirmDesktopConnect();
+    expect(result).toEqual({ success: false, error: 'No pending connection' });
+    expect(mockService.handleConnectionURI).not.toHaveBeenCalled();
+  });
+
+  it('maps a deeplink source to the deeplink origin and clears on success', async () => {
+    const store = new DAppConnectStore();
+    store.requestDesktopConnect(URI_A, 'deeplink');
+    const result = await store.confirmDesktopConnect();
+    expect(result.success).toBe(true);
+    expect(mockService.handleConnectionURI).toHaveBeenCalledWith(URI_A, 'deeplink');
+    expect(store.desktopConnectUri).toBeNull();
+  });
+
+  it('maps a paste source to the qr origin (dApp may be on another device)', async () => {
+    const store = new DAppConnectStore();
+    store.requestDesktopConnect(URI_A, 'paste');
+    await store.confirmDesktopConnect();
+    expect(mockService.handleConnectionURI).toHaveBeenCalledWith(URI_A, 'qr');
+  });
+
+  it('keeps the staged URI when the connect fails (modal shows the error)', async () => {
+    mockService.handleConnectionURI.mockResolvedValue({ success: false, error: 'relay down' });
+    const store = new DAppConnectStore();
+    store.requestDesktopConnect(URI_A, 'paste');
+    const result = await store.confirmDesktopConnect();
+    expect(result).toEqual({ success: false, error: 'relay down' });
+    expect(store.desktopConnectUri).toBe(URI_A);
+  });
+
+  it('does not clobber a newer URI staged during the awaited handshake', async () => {
+    // Regression guard: URI B arrives (protocol handler) while URI A's
+    // handshake is in flight. A's success must not clear B, or B's consent
+    // modal would never appear and the request would vanish silently.
+    const store = new DAppConnectStore();
+    store.requestDesktopConnect(URI_A, 'deeplink');
+    mockService.handleConnectionURI.mockImplementation(async () => {
+      store.requestDesktopConnect(URI_B, 'deeplink');
+      return { success: true };
+    });
+    const result = await store.confirmDesktopConnect();
+    expect(result.success).toBe(true);
+    expect(store.desktopConnectUri).toBe(URI_B);
+  });
+});
+
+describe('approval queue passthrough', () => {
+  it('approveCurrentRequest forwards the result and advances the queue', () => {
+    const store = new DAppConnectStore();
+    const first = makeRequest({ id: 1 });
+    const second = makeRequest({ id: 2 });
+    store.pendingRequests = [first, second];
+    store.currentApproval = first;
+    store.approvalModalOpen = true;
+
+    store.approveCurrentRequest('0xresult');
+
+    expect(mockService.approveRequest).toHaveBeenCalledWith('session-1', 1, '0xresult');
+    // mobx wraps queued requests in observable proxies; compare identity.
+    expect(store.currentApproval?.id).toBe(second.id);
+    expect(store.approvalModalOpen).toBe(true);
+  });
+
+  it('rejectCurrentRequest forwards message AND error code (desktop 4902 chain pinning)', () => {
+    const store = new DAppConnectStore();
+    const req = makeRequest({ method: 'wallet_switchQrlChain' });
+    store.pendingRequests = [req];
+    store.currentApproval = req;
+
+    store.rejectCurrentRequest('The desktop wallet is pinned to its configured chain', 4902);
+
+    expect(mockService.rejectRequest).toHaveBeenCalledWith(
+      'session-1',
+      1,
+      'The desktop wallet is pinned to its configured chain',
+      4902
+    );
+    expect(store.currentApproval).toBeNull();
+    expect(store.approvalModalOpen).toBe(false);
+  });
+
+  it('rejectCurrentRequest with no code leaves the code to the service default (4001)', () => {
+    const store = new DAppConnectStore();
+    const req = makeRequest();
+    store.pendingRequests = [req];
+    store.currentApproval = req;
+
+    store.rejectCurrentRequest('User rejected');
+
+    expect(mockService.rejectRequest).toHaveBeenCalledWith('session-1', 1, 'User rejected', undefined);
+  });
+
+  it('sendApprovalResult keeps the modal open (progress UI)', () => {
+    const store = new DAppConnectStore();
+    const req = makeRequest();
+    store.pendingRequests = [req];
+    store.currentApproval = req;
+    store.approvalModalOpen = true;
+
+    store.sendApprovalResult('0xhash');
+
+    expect(mockService.approveRequest).toHaveBeenCalledWith('session-1', 1, '0xhash');
+    expect(store.currentApproval?.id).toBe(req.id);
+    expect(store.approvalModalOpen).toBe(true);
+  });
+
+  it('is a no-op with no current approval', () => {
+    const store = new DAppConnectStore();
+    store.approveCurrentRequest('x');
+    store.rejectCurrentRequest('y', 4001);
+    expect(mockService.approveRequest).not.toHaveBeenCalled();
+    expect(mockService.rejectRequest).not.toHaveBeenCalled();
+  });
+});
+
+describe('service handler callbacks', () => {
+  function capturedHandlers() {
+    const call = mockService.setHandlers.mock.calls[0];
+    if (!call) throw new Error('setHandlers not called');
+    return call[0] as {
+      onPendingRequest: (r: PendingDAppRequest) => void;
+      onSessionDisconnected: (sessionId: string) => void;
+    };
+  }
+
+  it('onPendingRequest queues and auto-shows the first request only', () => {
+    const store = new DAppConnectStore();
+    const handlers = capturedHandlers();
+    const first = makeRequest({ id: 1 });
+    const second = makeRequest({ id: 2 });
+
+    handlers.onPendingRequest(first);
+    handlers.onPendingRequest(second);
+
+    expect(store.pendingRequests).toHaveLength(2);
+    expect(store.currentApproval?.id).toBe(first.id);
+    expect(store.approvalModalOpen).toBe(true);
+  });
+
+  it('onSessionDisconnected clears that session\'s pending requests and modal', () => {
+    const store = new DAppConnectStore();
+    const handlers = capturedHandlers();
+    const mine = makeRequest({ id: 1, sessionId: 'session-1' });
+    const other = makeRequest({ id: 2, sessionId: 'session-2' });
+    handlers.onPendingRequest(mine);
+    handlers.onPendingRequest(other);
+
+    handlers.onSessionDisconnected('session-1');
+
+    expect(store.pendingRequests.map((r) => r.id)).toEqual([other.id]);
+    expect(store.currentApproval).toBeNull();
+    expect(store.approvalModalOpen).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

The dApp-connect stack had zero frontend unit tests: the existing 8 jest suites (114 tests) are all under src/utils (signing, crypto, web3, moderation). This adds 59 tests across three new suites, taking the run to 173. Test-only change plus a jest.config comment update; no production code touched.

### src/services/dappConnect/__tests__/qrUri.test.ts (24 tests)

The single hostile-input parser for every ingress (QR scan, mobile deep link, desktop protocol handler, desktop paste):

- PQP2 blob round trip using fixtures built exactly like the SDK generator (URLSearchParams over base45(PQP2 || cid || fp))
- r= relay extraction, including the second-'?' adversarial URI that defeats naive split('?') parsing: the regression guard for the PR #208 consent-modal relay display fix
- Legacy rejection paths (v1 channelId/pubKey params, PQP1 1208-byte blob hint), bad magic/length/base45, scheme-only URI, uppercase scheme
- computeFingerprint against a reference SHA-256("pq-fp/v2" || cid || pk), fingerprintEquals, cidToString/cidFromString round trip

### src/desktop/__tests__/bridge.test.ts (16 tests)

buildDappOrigin (dApp-supplied ORIGINATOR_INFO -> desktop main's strict DAppOriginSchema), bounds cross-checked against myqrlwallet-desktop#10:

- channelId hex/uuid gate (undefined = request proceeds without provenance)
- name: control-char strip, trim, 64-char clamp, Unknown-dApp fallback
- url: http(s)-or-empty policy, and the validate-before-bound regression guard (a valid URL over 256 chars drops to '' instead of being truncated into junk)

### src/stores/__tests__/dappConnectStore.test.ts (19 tests)

Desktop consent staging + approval queue, with the service singleton mocked at the module seam (the real module transitively imports the import.meta-dependent store graph jest's node runtime cannot load):

- stage/clear/latest-wins, invalid-URI warn (mis-registered handler debuggability)
- confirmDesktopConnect: deeplink->deeplink / paste->qr origin mapping, failure keeps the staged URI, and the in-flight clobber guard from the PR #208 review (URI B staged during URI A's handshake survives A's success)
- approve/reject passthrough incl. the 4902 chain-pinning error code, queue advance, sendApprovalResult keeps the modal, session-disconnect cleanup via the captured service handlers

## Validation

lint (0 warnings), test (173/173), build (tsc + vite) all green locally.