### PR TITLE
fix(desktop): hydrate the wallet list from the signer (source of truth)

### DIFF
--- a/src/desktop/__tests__/walletHydration.test.ts
+++ b/src/desktop/__tests__/walletHydration.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for the desktop wallet hydration helpers: merging the signer's
+ * wallet addresses into the renderer's account list, and choosing an active
+ * wallet to adopt. These back the fix for the "signer can unlock a wallet but
+ * the renderer shows 0 wallets" divergence.
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import { mergeSignerWalletsIntoList, pickActiveWallet } from '../walletHydration';
+import type { AccountListItem } from '@/utils/storage';
+
+const A = 'Q1111111111111111111111111111111111111111';
+const B = 'Q2222222222222222222222222222222222222222';
+const C = 'Q3333333333333333333333333333333333333333';
+
+describe('mergeSignerWalletsIntoList', () => {
+  it('adds a signer wallet missing from an empty list (the reported bug)', () => {
+    const { list, added } = mergeSignerWalletsIntoList([], [A]);
+    expect(added).toBe(true);
+    expect(list).toEqual([{ address: A, source: 'seed' }]);
+  });
+
+  it('reports nothing added when every signer wallet is already known', () => {
+    const stored: AccountListItem[] = [{ address: A, source: 'seed' }];
+    const { list, added } = mergeSignerWalletsIntoList(stored, [A]);
+    expect(added).toBe(false);
+    expect(list).toEqual(stored);
+  });
+
+  it('preserves existing entries and their source, appending only the new ones', () => {
+    const stored: AccountListItem[] = [{ address: A, source: 'extension' }];
+    const { list, added } = mergeSignerWalletsIntoList(stored, [A, B]);
+    expect(added).toBe(true);
+    expect(list).toEqual([
+      { address: A, source: 'extension' },
+      { address: B, source: 'seed' },
+    ]);
+  });
+
+  it('matches known addresses case-insensitively (no duplicate)', () => {
+    const stored: AccountListItem[] = [{ address: A, source: 'seed' }];
+    const { list, added } = mergeSignerWalletsIntoList(stored, [A.toLowerCase()]);
+    expect(added).toBe(false);
+    expect(list).toHaveLength(1);
+  });
+
+  it('dedupes repeats within the signer list', () => {
+    const { list, added } = mergeSignerWalletsIntoList([], [B, B, C]);
+    expect(added).toBe(true);
+    expect(list.map((a) => a.address)).toEqual([B, C]);
+  });
+
+  it('skips empty addresses', () => {
+    const { list, added } = mergeSignerWalletsIntoList([], ['']);
+    expect(added).toBe(false);
+    expect(list).toEqual([]);
+  });
+
+  it('does not mutate the input array', () => {
+    const stored: AccountListItem[] = [{ address: A, source: 'seed' }];
+    mergeSignerWalletsIntoList(stored, [B]);
+    expect(stored).toEqual([{ address: A, source: 'seed' }]);
+  });
+});
+
+describe('pickActiveWallet', () => {
+  it('prefers the signer active pointer when it is a real wallet', () => {
+    expect(pickActiveWallet([A, B], B)).toBe(B);
+  });
+
+  it('matches the active pointer case-insensitively', () => {
+    expect(pickActiveWallet([A, B], B.toLowerCase())).toBe(B.toLowerCase());
+  });
+
+  it('falls back to the first wallet when active is null', () => {
+    expect(pickActiveWallet([A, B], null)).toBe(A);
+  });
+
+  it('falls back to the first wallet when active is not among the wallets', () => {
+    expect(pickActiveWallet([A, B], C)).toBe(A);
+  });
+
+  it('returns undefined when there are no wallets', () => {
+    expect(pickActiveWallet([], null)).toBeUndefined();
+  });
+});

--- a/src/desktop/__tests__/walletHydration.test.ts
+++ b/src/desktop/__tests__/walletHydration.test.ts
@@ -61,6 +61,18 @@ describe('mergeSignerWalletsIntoList', () => {
     mergeSignerWalletsIntoList(stored, [B]);
     expect(stored).toEqual([{ address: A, source: 'seed' }]);
   });
+
+  it('tolerates a malformed stored entry (no throw) and still merges', () => {
+    // localStorage is unvalidated: an entry missing address must not blow up
+    // the whole reconcile. It is preserved verbatim; the new wallet is added.
+    // Built via JSON.parse so the malformed shape is a genuine runtime value
+    // (not a compile-time cast the hardened lint bans).
+    const stored = JSON.parse(`[{"source":"seed"},{"address":"${A}","source":"seed"}]`) as AccountListItem[];
+    const { list, added } = mergeSignerWalletsIntoList(stored, [B]);
+    expect(added).toBe(true);
+    expect(list).toHaveLength(3);
+    expect(list[2]).toEqual({ address: B, source: 'seed' });
+  });
 });
 
 describe('pickActiveWallet', () => {

--- a/src/desktop/walletHydration.ts
+++ b/src/desktop/walletHydration.ts
@@ -1,0 +1,60 @@
+/**
+ * Desktop wallet hydration helpers.
+ *
+ * On desktop the SIGNER (its encrypted seed files on disk) is the source of
+ * truth for which wallets exist, not the renderer's localStorage account list.
+ * The list is only written during the in-renderer import/create flow, so any
+ * divergence (localStorage cleared, a wallet provisioned in another session,
+ * a per-network list mismatch) leaves the renderer showing "0 wallets" even
+ * though the signer can unlock one. qrlStore reconciles by merging the
+ * signer's wallet addresses into the account list on startup and on unlock.
+ *
+ * This module holds only the pure merge so it is trivially unit-testable; the
+ * bridge calls and storage writes live in qrlStore.
+ */
+
+import type { AccountListItem } from '@/utils/storage';
+
+/**
+ * Merge the signer's wallet addresses into the renderer's stored account list,
+ * preserving existing entries (and their source) and appending any signer
+ * wallet the list does not yet know, as a 'seed' account. Address comparison
+ * is case-insensitive. Returns the new list and whether anything was added, so
+ * the caller can skip the storage write when nothing changed.
+ */
+export function mergeSignerWalletsIntoList(
+  stored: AccountListItem[],
+  signerAddresses: string[],
+): { list: AccountListItem[]; added: boolean } {
+  const known = new Set(stored.map((a) => a.address.toLowerCase()));
+  const list = [...stored];
+  let added = false;
+  for (const address of signerAddresses) {
+    if (!address) continue;
+    const key = address.toLowerCase();
+    if (!known.has(key)) {
+      list.push({ address, source: 'seed' });
+      known.add(key);
+      added = true;
+    }
+  }
+  return { list, added };
+}
+
+/**
+ * Pick which wallet to adopt as active when the renderer has none stored:
+ * prefer the signer's own active pointer when it is a real wallet, else the
+ * first signer wallet. Returns undefined when there is nothing to adopt.
+ */
+export function pickActiveWallet(
+  signerAddresses: string[],
+  signerActive: string | null | undefined,
+): string | undefined {
+  if (
+    signerActive &&
+    signerAddresses.some((a) => a.toLowerCase() === signerActive.toLowerCase())
+  ) {
+    return signerActive;
+  }
+  return signerAddresses[0];
+}

--- a/src/desktop/walletHydration.ts
+++ b/src/desktop/walletHydration.ts
@@ -26,7 +26,14 @@ export function mergeSignerWalletsIntoList(
   stored: AccountListItem[],
   signerAddresses: string[],
 ): { list: AccountListItem[]; added: boolean } {
-  const known = new Set(stored.map((a) => a.address.toLowerCase()));
+  // stored comes from localStorage unvalidated; tolerate a malformed entry
+  // (missing/non-string address) rather than throwing out the whole reconcile.
+  // Such entries are preserved verbatim in the list, just not matched against.
+  const known = new Set(
+    stored
+      .map((a) => (typeof a?.address === 'string' ? a.address.toLowerCase() : null))
+      .filter((k): k is string => k !== null),
+  );
   const list = [...stored];
   let added = false;
   for (const address of signerAddresses) {

--- a/src/stores/qrlStore.ts
+++ b/src/stores/qrlStore.ts
@@ -408,18 +408,37 @@ class QrlStore {
 
     if (!this._desktopUnlockListenerBound) {
       this._desktopUnlockListenerBound = true;
-      desktopSigner.onLockStateChanged((locked) => {
-        if (locked) return;
-        // Re-run the FULL init sequence for the list: hydrate, refetch, then
-        // validateActiveAccount, which is the only thing that copies the
-        // stored active account into the activeAccount observable the Home
-        // screen gates on. Without it, a first hydration that found nothing
-        // (signer mid-restart at boot) would populate the list on unlock but
-        // still show the "Let's start" onboarding card until an app restart.
-        void this.hydrateDesktopWalletsFromSigner()
-          .then(() => this.fetchAccounts())
-          .then(() => this.validateActiveAccount());
-      });
+      try {
+        desktopSigner.onLockStateChanged((locked) => {
+          if (locked) return;
+          // Re-run the FULL init sequence for the list: hydrate, refetch, then
+          // validateActiveAccount, which is the only thing that copies the
+          // stored active account into the activeAccount observable the Home
+          // screen gates on. Without it, a first hydration that found nothing
+          // (signer mid-restart at boot) would populate the list on unlock but
+          // still show the "Let's start" onboarding card until an app restart.
+          void this.hydrateDesktopWalletsFromSigner()
+            .then(() => this.fetchAccounts())
+            .then(async () => {
+              const before = this.activeAccount.accountAddress;
+              await this.validateActiveAccount();
+              const after = this.activeAccount.accountAddress;
+              // Adoption on this path changes the active account outside
+              // setActiveAccount, and TokenStore/NftStore are purely
+              // hook-driven: fire the same hook so token/NFT state re-scopes
+              // to the adopted account instead of staying on the boot-time
+              // (possibly empty) scope.
+              if (after && after !== before) await this.onActiveAccountChanged?.(after);
+            })
+            .catch((error: unknown) => {
+              console.error('Desktop unlock re-hydration failed:', error);
+            });
+        });
+      } catch (error) {
+        // A shell predating onLockStateChanged must not abort blockchain init;
+        // the one-shot hydration below still runs.
+        console.error('Desktop lock-state listener unavailable:', error);
+      }
     }
 
     let signerAddresses: string[] = [];
@@ -463,8 +482,13 @@ class QrlStore {
           // Store the address exactly as it appears in the merged list, so the
           // strict-equality check in validateActiveAccount matches it (a
           // pre-existing entry may hold a different casing than the signer's).
+          // Same malformed-entry tolerance as mergeSignerWalletsIntoList: a
+          // stored entry without a string address must not throw here, or the
+          // adoption is silently lost on every run.
           const canonical =
-            list.find((a) => a.address.toLowerCase() === adopt.toLowerCase())?.address ?? adopt;
+            list.find(
+              (a) => typeof a?.address === 'string' && a.address.toLowerCase() === adopt.toLowerCase(),
+            )?.address ?? adopt;
           await StorageUtil.setActiveAccount(blockchain, canonical);
         }
       }

--- a/src/stores/qrlStore.ts
+++ b/src/stores/qrlStore.ts
@@ -410,7 +410,15 @@ class QrlStore {
       this._desktopUnlockListenerBound = true;
       desktopSigner.onLockStateChanged((locked) => {
         if (locked) return;
-        void this.hydrateDesktopWalletsFromSigner().then(() => this.fetchAccounts());
+        // Re-run the FULL init sequence for the list: hydrate, refetch, then
+        // validateActiveAccount, which is the only thing that copies the
+        // stored active account into the activeAccount observable the Home
+        // screen gates on. Without it, a first hydration that found nothing
+        // (signer mid-restart at boot) would populate the list on unlock but
+        // still show the "Let's start" onboarding card until an app restart.
+        void this.hydrateDesktopWalletsFromSigner()
+          .then(() => this.fetchAccounts())
+          .then(() => this.validateActiveAccount());
       });
     }
 
@@ -434,17 +442,34 @@ class QrlStore {
     }
     if (signerAddresses.length === 0) return;
 
-    const blockchain = this.qrlConnection.blockchain;
-    const stored = await StorageUtil.getAccountList(blockchain);
-    const { list, added } = mergeSignerWalletsIntoList(stored, signerAddresses);
-    if (added) await StorageUtil.setAccountList(blockchain, list);
+    // Storage reconcile is best-effort and MUST NOT throw: this method runs
+    // inside initializeBlockchain's try, so an uncaught throw here (e.g. a
+    // corrupt stored account list entry, or a localStorage quota error) would
+    // skip fetchAccounts, validateActiveAccount, and token/NFT init. Contain
+    // it so a hydration failure only loses the reconcile, never the rest of
+    // blockchain init.
+    try {
+      const blockchain = this.qrlConnection.blockchain;
+      const stored = await StorageUtil.getAccountList(blockchain);
+      const { list, added } = mergeSignerWalletsIntoList(stored, signerAddresses);
+      if (added) await StorageUtil.setAccountList(blockchain, list);
 
-    // Adopt an active wallet only when the renderer has none, so we never
-    // override a selection the user already made.
-    const storedActive = await StorageUtil.getActiveAccount(blockchain);
-    if (!storedActive) {
-      const adopt = pickActiveWallet(signerAddresses, signerActive);
-      if (adopt) await StorageUtil.setActiveAccount(blockchain, adopt);
+      // Adopt an active wallet only when the renderer has none, so we never
+      // override a selection the user already made.
+      const storedActive = await StorageUtil.getActiveAccount(blockchain);
+      if (!storedActive) {
+        const adopt = pickActiveWallet(signerAddresses, signerActive);
+        if (adopt) {
+          // Store the address exactly as it appears in the merged list, so the
+          // strict-equality check in validateActiveAccount matches it (a
+          // pre-existing entry may hold a different casing than the signer's).
+          const canonical =
+            list.find((a) => a.address.toLowerCase() === adopt.toLowerCase())?.address ?? adopt;
+          await StorageUtil.setActiveAccount(blockchain, canonical);
+        }
+      }
+    } catch (error) {
+      console.error('Desktop wallet hydration: storage reconcile failed:', error);
     }
   }
 

--- a/src/stores/qrlStore.ts
+++ b/src/stores/qrlStore.ts
@@ -1,6 +1,7 @@
 import { QRL_PROVIDER, EXPLORER_BASE, getPendingTxApiUrl } from "@/config";
 import { deriveHexSeedAsync } from "@/utils/crypto";
 import { isDesktop, desktopSigner } from "@/desktop/bridge";
+import { mergeSignerWalletsIntoList, pickActiveWallet } from "@/desktop/walletHydration";
 import type { AccountListItem, AccountSource } from "@/utils/storage";
 import { StorageUtil } from "@/utils/storage";
 import { log } from "@/utils";
@@ -106,6 +107,10 @@ class QrlStore {
   // makeAutoObservable below — it's a non-observable runtime handle.
   _receiptPollerIntervalId: ReturnType<typeof setInterval> | null = null;
 
+  // Desktop only: guards one-time registration of the signer lock-state
+  // listener that re-hydrates the wallet list on unlock. Non-observable.
+  _desktopUnlockListenerBound = false;
+
   // Callbacks wired by Store after construction so token/NFT init can run
   // *after* QrlStore has a live qrlInstance and network selection — and
   // without QrlStore taking a direct dependency on the other stores.
@@ -155,7 +160,9 @@ class QrlStore {
       _utils: false,
       _Web3: false,
       _receiptPollerIntervalId: false,
+      _desktopUnlockListenerBound: false,
       cancelReceiptPoller: false,
+      hydrateDesktopWalletsFromSigner: false,
       // Callback hooks injected by Store — not observable.
       onBlockchainReady: false,
       onActiveAccountChanged: false,
@@ -259,6 +266,10 @@ class QrlStore {
       });
 
       await this.fetchQrlConnection();
+      // Desktop: reconcile the account list against the signer (source of
+      // truth for which wallets exist) BEFORE fetchAccounts reads the list,
+      // so a wallet the signer can unlock is never shown as "0 wallets".
+      if (isDesktop) await this.hydrateDesktopWalletsFromSigner();
       await this.fetchAccounts();
       this.fetchQrlPrice(); // Fire-and-forget, non-blocking
       await this.validateActiveAccount();
@@ -373,6 +384,67 @@ class QrlStore {
       runInAction(() => {
         this.qrlConnection = { ...this.qrlConnection, isLoading: false };
       });
+    }
+  }
+
+  /**
+   * Desktop: reconcile the renderer's account list with the signer's wallets.
+   *
+   * The signer (encrypted seed files on disk) is the source of truth for which
+   * wallets exist; the renderer's localStorage list is only written during the
+   * in-renderer import/create flow, so the two can diverge (localStorage
+   * cleared, a wallet provisioned in another session, a per-network list
+   * mismatch), which would strand a real wallet behind the empty "Let's start"
+   * screen even though the native unlock window can open it.
+   *
+   * listWallets returns addresses only (no decryption), so this works even
+   * while the signer is locked at startup. Also registers, once, a lock-state
+   * listener that re-runs on unlock (covering wallets added/removed in-session
+   * and any main that gates listWallets behind an open session). Best-effort:
+   * any bridge failure leaves the localStorage list untouched.
+   */
+  async hydrateDesktopWalletsFromSigner(): Promise<void> {
+    if (!isDesktop) return;
+
+    if (!this._desktopUnlockListenerBound) {
+      this._desktopUnlockListenerBound = true;
+      desktopSigner.onLockStateChanged((locked) => {
+        if (locked) return;
+        void this.hydrateDesktopWalletsFromSigner().then(() => this.fetchAccounts());
+      });
+    }
+
+    let signerAddresses: string[] = [];
+    let signerActive: string | null = null;
+    try {
+      const { wallets, active } = await desktopSigner.listWallets();
+      signerAddresses = (wallets ?? []).map((w) => w.address);
+      signerActive = active;
+    } catch {
+      // Older mains may not implement listWallets: fall back to the single
+      // active address from getStatus.
+      try {
+        const status = await desktopSigner.getStatus();
+        if (status.address) signerAddresses = [status.address];
+        signerActive = status.activeAddress ?? status.address ?? null;
+      } catch (error) {
+        console.error('Desktop wallet hydration failed:', error);
+        return;
+      }
+    }
+    if (signerAddresses.length === 0) return;
+
+    const blockchain = this.qrlConnection.blockchain;
+    const stored = await StorageUtil.getAccountList(blockchain);
+    const { list, added } = mergeSignerWalletsIntoList(stored, signerAddresses);
+    if (added) await StorageUtil.setAccountList(blockchain, list);
+
+    // Adopt an active wallet only when the renderer has none, so we never
+    // override a selection the user already made.
+    const storedActive = await StorageUtil.getActiveAccount(blockchain);
+    if (!storedActive) {
+      const adopt = pickActiveWallet(signerAddresses, signerActive);
+      if (adopt) await StorageUtil.setActiveAccount(blockchain, adopt);
     }
   }
 


### PR DESCRIPTION
## Symptom

On the desktop app, unlock succeeds in the native unlock window (the dropdown even lists the wallet address), but the main wallet screen then shows "0 imported wallets" and the Create/Import prompt. Field-hit on the 2026-07 Windows install.

## Cause

On desktop the renderer built its account list ONLY from localStorage (`StorageUtil.getAccountList`), which is written solely during the in-renderer import/create flow. The signer's encrypted seed files on disk are the real source of truth for which wallets exist (they are what the native unlock window enumerates). When the two diverge, the renderer never learns about a wallet the signer can unlock:

- localStorage cleared or on a fresh renderer origin/partition
- a wallet provisioned in another session/machine
- per-network account list mismatch (`getAccountList` is keyed by blockchain; the signer is network-agnostic)

## Fix

`qrlStore.hydrateDesktopWalletsFromSigner()`:
- merges the signer's wallet addresses (`desktopSigner.listWallets()`, addresses only, no decryption, so it works while the signer is locked at startup) into the account list, BEFORE `fetchAccounts()` reads it in `initializeBlockchain`
- adopts an active wallet (signer's active pointer, else first) only when the renderer has none stored, so it never overrides a user selection
- registers a one-time `onLockStateChanged` listener that re-hydrates + refetches on unlock, covering in-session add/remove and any main that gates `listWallets` behind an open session
- falls back to `getStatus().address` for older mains, and is fully best-effort: any bridge failure leaves localStorage untouched

Confirmed against the desktop main: `LIST_WALLETS` reads seed-file addresses without a session (works while locked), and `finishUnlock` sends `LOCK_STATE_CHANGED(false)` to the renderer.

Pure merge / active-pick logic is extracted to `src/desktop/walletHydration.ts` with 12 unit tests. All changes are `isDesktop`-gated; web and mobile are untouched.

## Validation

lint (0 warnings), test (185/185, +12 new), build (tsc + vite) all green locally.