### PR TITLE
fix(desktop): bind dApp signature requests to the active account + forward schemeVersion

### DIFF
--- a/src/components/Core/Body/DAppConnect/DAppApprovalModal.tsx
+++ b/src/components/Core/Body/DAppConnect/DAppApprovalModal.tsx
@@ -3,7 +3,7 @@
  * Single source of truth for all dApp request approvals.
  */
 
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { toJS } from 'mobx';
 import { observer } from 'mobx-react-lite';
 import { useStore } from '@/stores/store';
@@ -123,6 +123,15 @@ const DAppApprovalModal = observer(() => {
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
 
+  // When the current approval changes (a queued request gets promoted after
+  // the previous one is answered), briefly ignore dismissals: a double-click
+  // on the X must not reject a request the user never saw rendered.
+  const approvalShownAtRef = useRef(0);
+  const approvalKey = currentApproval ? `${currentApproval.sessionId}:${currentApproval.id}` : '';
+  useEffect(() => {
+    approvalShownAtRef.current = Date.now();
+  }, [approvalKey]);
+
   const blockchain = qrlStore.qrlConnection.blockchain;
 
   const handleApprove = useCallback(async () => {
@@ -130,6 +139,12 @@ const DAppApprovalModal = observer(() => {
 
     setError('');
     setLoading(true);
+
+    // Answer THIS request, never "whatever is current when an await resolves":
+    // a session disconnect promotes the next queued request while PIN unlock,
+    // the desktop trusted confirm, or a broadcast is in flight, and answering
+    // the live currentApproval would route this result to that other request.
+    const { sessionId: approvalSessionId, id: approvalId } = currentApproval;
 
     try {
       const { method } = currentApproval;
@@ -152,7 +167,7 @@ const DAppApprovalModal = observer(() => {
 
       if (method === 'qrl_requestAccounts') {
         const activeAddress = qrlStore.activeAccount?.accountAddress;
-        dappConnectStore.approveCurrentRequest(activeAddress ? [activeAddress] : []);
+        dappConnectStore.approveRequestById(approvalSessionId, approvalId, activeAddress ? [activeAddress] : []);
         setPin('');
         return;
       }
@@ -165,14 +180,14 @@ const DAppApprovalModal = observer(() => {
         // flipping renderer state; 4901 would falsely signal a transient
         // provider disconnect and invite reconnect loops.
         if (isDesktop) {
-          dappConnectStore.rejectCurrentRequest(
+          dappConnectStore.rejectRequestById(approvalSessionId, approvalId, 
             'The desktop wallet is pinned to its configured chain',
             4902,
           );
           setPin('');
           return;
         }
-        dappConnectStore.approveCurrentRequest(null);
+        dappConnectStore.approveRequestById(approvalSessionId, approvalId, null);
         setPin('');
         return;
       }
@@ -207,7 +222,7 @@ const DAppApprovalModal = observer(() => {
                 },
                 dappOrigin,
               );
-              dappConnectStore.approveCurrentRequest(rawTx);
+              dappConnectStore.approveRequestById(approvalSessionId, approvalId, rawTx);
               dappConnectStore.resetTxProgress();
               setLoading(false);
               return;
@@ -223,14 +238,14 @@ const DAppApprovalModal = observer(() => {
               dappOrigin,
             );
             dappConnectStore.setTxProgress('confirmed', transactionHash);
-            dappConnectStore.sendApprovalResult(transactionHash);
+            dappConnectStore.sendApprovalResultById(approvalSessionId, approvalId, transactionHash);
             setLoading(false);
           } catch (e) {
             const errMsg = e instanceof Error ? e.message : String(e);
             console.log('[DAppConnect] desktop tx error:', errMsg);
             const userError = toUserFacingError(errMsg);
             dappConnectStore.setTxProgress('failed', undefined, userError);
-            dappConnectStore.sendRejectionResult(`Transaction failed: ${userError}`);
+            dappConnectStore.sendRejectionResultById(approvalSessionId, approvalId, `Transaction failed: ${userError}`);
             setLoading(false);
           }
           return;
@@ -262,7 +277,7 @@ const DAppApprovalModal = observer(() => {
             // Non-recoverable (e.g. no stored seed). Answer the dApp so its
             // request does not hang, then show the terminal failed state.
             dappConnectStore.setTxProgress('failed', undefined, unlocked.error);
-            dappConnectStore.sendRejectionResult(unlocked.error);
+            dappConnectStore.sendRejectionResultById(approvalSessionId, approvalId, unlocked.error);
           }
           setLoading(false);
           return;
@@ -274,7 +289,7 @@ const DAppApprovalModal = observer(() => {
         if (!web3) {
           setError('Web3 not initialized');
           dappConnectStore.setTxProgress('failed', undefined, 'Web3 not initialized');
-          dappConnectStore.sendRejectionResult('Web3 not initialized');
+          dappConnectStore.sendRejectionResultById(approvalSessionId, approvalId, 'Web3 not initialized');
           setLoading(false);
           return;
         }
@@ -319,13 +334,13 @@ const DAppApprovalModal = observer(() => {
 
         if (!signedTx.rawTransaction) {
           dappConnectStore.setTxProgress('failed', undefined, 'Failed to sign transaction');
-          dappConnectStore.sendRejectionResult('Failed to sign transaction');
+          dappConnectStore.sendRejectionResultById(approvalSessionId, approvalId, 'Failed to sign transaction');
           setLoading(false);
           return;
         }
 
         if (method === 'qrl_signTransaction') {
-          dappConnectStore.approveCurrentRequest(signedTx.rawTransaction);
+          dappConnectStore.approveRequestById(approvalSessionId, approvalId, signedTx.rawTransaction);
           setPin('');
           setLoading(false);
           return;
@@ -346,7 +361,7 @@ const DAppApprovalModal = observer(() => {
                 : String(receipt.transactionHash);
               dappConnectStore.setTxProgress('confirmed', hash);
               // Send result to dApp but keep modal open to show confirmed state
-              dappConnectStore.sendApprovalResult(hash);
+              dappConnectStore.sendApprovalResultById(approvalSessionId, approvalId, hash);
               setPin('');
               setLoading(false);
               resolve();
@@ -359,7 +374,7 @@ const DAppApprovalModal = observer(() => {
               console.log('[DAppConnect] tx broadcast error:', txErrMsg);
               const userError = toUserFacingError(txErrMsg);
               dappConnectStore.setTxProgress('failed', undefined, userError);
-              dappConnectStore.sendRejectionResult(`Transaction failed: ${userError}`);
+              dappConnectStore.sendRejectionResultById(approvalSessionId, approvalId, `Transaction failed: ${userError}`);
               setPin('');
               setLoading(false);
               resolve();
@@ -395,7 +410,7 @@ const DAppApprovalModal = observer(() => {
         if (isDesktop) {
           try {
             const result = await desktopSigner.signMessage(messageHex, activeAddress, dappOrigin);
-            dappConnectStore.approveCurrentRequest({
+            dappConnectStore.approveRequestById(approvalSessionId, approvalId, {
               signature: result.signature,
               publicKey: result.publicKey,
               signer: result.signer,
@@ -405,7 +420,7 @@ const DAppApprovalModal = observer(() => {
           } catch (e) {
             const errMsg = e instanceof Error ? e.message : String(e);
             setError(`Message signing failed: ${errMsg}`);
-            dappConnectStore.rejectCurrentRequest(`Message signing failed: ${errMsg}`);
+            dappConnectStore.rejectRequestById(approvalSessionId, approvalId, `Message signing failed: ${errMsg}`);
           }
           setLoading(false);
           return;
@@ -420,14 +435,14 @@ const DAppApprovalModal = observer(() => {
         }
         try {
           const result = signMessage(messageHex, unlocked.hexSeed);
-          dappConnectStore.approveCurrentRequest(result);
+          dappConnectStore.approveRequestById(approvalSessionId, approvalId, result);
         } catch (e) {
           // Reject the dApp on a signing failure instead of relying on the
           // outer catch, so the error message is specific and the request is
           // always answered (never left hanging).
           const errMsg = e instanceof Error ? e.message : String(e);
           setError(`Message signing failed: ${errMsg}`);
-          dappConnectStore.rejectCurrentRequest(`Message signing failed: ${errMsg}`);
+          dappConnectStore.rejectRequestById(approvalSessionId, approvalId, `Message signing failed: ${errMsg}`);
           setLoading(false);
           return;
         }
@@ -461,7 +476,7 @@ const DAppApprovalModal = observer(() => {
         if (isDesktop) {
           try {
             const result = await desktopSigner.signTypedData(payload, activeAddress, dappOrigin);
-            dappConnectStore.approveCurrentRequest({
+            dappConnectStore.approveRequestById(approvalSessionId, approvalId, {
               signature: result.signature,
               publicKey: result.publicKey,
               signer: result.signer,
@@ -472,7 +487,7 @@ const DAppApprovalModal = observer(() => {
           } catch (e) {
             const errMsg = e instanceof Error ? e.message : String(e);
             setError('Typed-data signing not yet supported on desktop');
-            dappConnectStore.rejectCurrentRequest(
+            dappConnectStore.rejectRequestById(approvalSessionId, approvalId, 
               `Typed-data signing not yet supported on desktop: ${errMsg}`,
             );
           }
@@ -489,13 +504,13 @@ const DAppApprovalModal = observer(() => {
         }
         try {
           const result = signTypedData(payload, unlocked.hexSeed);
-          dappConnectStore.approveCurrentRequest(result);
+          dappConnectStore.approveRequestById(approvalSessionId, approvalId, result);
         } catch (e) {
           // Reject the dApp on encode/sign failure so its request is answered
           // rather than left hanging until its own timeout.
           const errMsg = e instanceof Error ? e.message : String(e);
           setError(`Typed data signing failed: ${errMsg}`);
-          dappConnectStore.rejectCurrentRequest(`Typed data signing failed: ${errMsg}`);
+          dappConnectStore.rejectRequestById(approvalSessionId, approvalId, `Typed data signing failed: ${errMsg}`);
           setLoading(false);
           return;
         }
@@ -504,7 +519,7 @@ const DAppApprovalModal = observer(() => {
       }
 
       // Default: approve with null
-      dappConnectStore.approveCurrentRequest(null);
+      dappConnectStore.approveRequestById(approvalSessionId, approvalId, null);
       setPin('');
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);
@@ -519,9 +534,9 @@ const DAppApprovalModal = observer(() => {
         if (isTxMethod && dappConnectStore.txProgress !== 'idle') {
           // Keep modal open to show failed state
           dappConnectStore.setTxProgress('failed', undefined, userError);
-          dappConnectStore.sendRejectionResult(userError);
+          dappConnectStore.sendRejectionResultById(approvalSessionId, approvalId, userError);
         } else {
-          dappConnectStore.rejectCurrentRequest(userError);
+          dappConnectStore.rejectRequestById(approvalSessionId, approvalId, userError);
         }
       }
     } finally {
@@ -616,6 +631,7 @@ const DAppApprovalModal = observer(() => {
         return;
       }
       if (isTxInProgress) return;
+      if (Date.now() - approvalShownAtRef.current < 350) return;
       // An explicit close (the X button) IS an answer: reject, so the dApp is
       // never left hanging on a dismissed card.
       handleReject();

--- a/src/components/Core/Body/DAppConnect/DAppApprovalModal.tsx
+++ b/src/components/Core/Body/DAppConnect/DAppApprovalModal.tsx
@@ -605,10 +605,30 @@ const DAppApprovalModal = observer(() => {
 
   return (
     <Dialog open={approvalModalOpen} onOpenChange={(open) => {
-      if (!open && !isTxInProgress) handleReject();
-      if (!open && isTxTerminal) handleDone();
+      if (open) return;
+      // Ignore any close while a signing/broadcast is in flight: the request
+      // must resolve first. Answering the dApp with a rejection here would
+      // race the desktop's trusted confirm, which can still approve and
+      // produce a signature for an already-rejected request.
+      if (loading) return;
+      if (isTxTerminal) {
+        handleDone();
+        return;
+      }
+      if (isTxInProgress) return;
+      // An explicit close (the X button) IS an answer: reject, so the dApp is
+      // never left hanging on a dismissed card.
+      handleReject();
     }}>
-      <DialogContent className="max-w-md p-0 gap-0 overflow-hidden">
+      {/* A pending approval demands an explicit answer (Approve / Reject / X).
+          Stray clicks elsewhere in the wallet and Escape must not dismiss the
+          card: silently swallowing the decision is how requests get answered
+          by accident or left dangling. */}
+      <DialogContent
+        className="max-w-md p-0 gap-0 overflow-hidden"
+        onInteractOutside={(e) => e.preventDefault()}
+        onEscapeKeyDown={(e) => e.preventDefault()}
+      >
         {/* dApp Identity Header */}
         <div className="bg-gradient-to-r from-secondary/5 to-transparent p-4">
           <div className="flex items-center gap-3">

--- a/src/components/Core/Body/DAppConnect/DAppApprovalModal.tsx
+++ b/src/components/Core/Body/DAppConnect/DAppApprovalModal.tsx
@@ -26,6 +26,8 @@ import {
   computeMessageDigest,
   computeTypedDataDigest,
   hexToBytes,
+  SCHEME_VERSION_MSG,
+  SCHEME_VERSION_TYPED,
   signMessage,
   signTypedData,
   SignMessageParamsSchema,
@@ -386,11 +388,20 @@ const DAppApprovalModal = observer(() => {
           return;
         }
         // Desktop: sign in the isolated signer (its own trusted modal); no PIN,
-        // no seed in the renderer.
+        // no seed in the renderer. The active address rides along so the
+        // signer can reject if its session diverged from renderer state, and
+        // the response is reshaped to the same rich object the web path
+        // returns (the dApp must not see the bridge-internal `kind`).
         if (isDesktop) {
           try {
-            const result = await desktopSigner.signMessage(messageHex, dappOrigin);
-            dappConnectStore.approveCurrentRequest(result);
+            const result = await desktopSigner.signMessage(messageHex, activeAddress, dappOrigin);
+            dappConnectStore.approveCurrentRequest({
+              signature: result.signature,
+              publicKey: result.publicKey,
+              signer: result.signer,
+              digest: result.digest,
+              schemeVersion: result.schemeVersion ?? SCHEME_VERSION_MSG,
+            });
           } catch (e) {
             const errMsg = e instanceof Error ? e.message : String(e);
             setError(`Message signing failed: ${errMsg}`);
@@ -445,11 +456,19 @@ const DAppApprovalModal = observer(() => {
         }
         // Desktop: typed-data signing is not yet supported in the signer (the
         // hasher has not been ported). Surface a clear error instead of any
-        // in-renderer fallback.
+        // in-renderer fallback. Same signer binding + response reshaping as
+        // the message arm, so this is already correct when the hasher lands.
         if (isDesktop) {
           try {
-            const result = await desktopSigner.signTypedData(payload, dappOrigin);
-            dappConnectStore.approveCurrentRequest(result);
+            const result = await desktopSigner.signTypedData(payload, activeAddress, dappOrigin);
+            dappConnectStore.approveCurrentRequest({
+              signature: result.signature,
+              publicKey: result.publicKey,
+              signer: result.signer,
+              digest: result.digest,
+              schemeVersion: result.schemeVersion ?? SCHEME_VERSION_TYPED,
+              domain: payload.domain,
+            });
           } catch (e) {
             const errMsg = e instanceof Error ? e.message : String(e);
             setError('Typed-data signing not yet supported on desktop');

--- a/src/desktop/__tests__/walletHydration.test.ts
+++ b/src/desktop/__tests__/walletHydration.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for the desktop wallet hydration helpers: merging the signer's
+ * wallet addresses into the renderer's account list, and choosing an active
+ * wallet to adopt. These back the fix for the "signer can unlock a wallet but
+ * the renderer shows 0 wallets" divergence.
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import { mergeSignerWalletsIntoList, pickActiveWallet } from '../walletHydration';
+import type { AccountListItem } from '@/utils/storage';
+
+const A = 'Q1111111111111111111111111111111111111111';
+const B = 'Q2222222222222222222222222222222222222222';
+const C = 'Q3333333333333333333333333333333333333333';
+
+describe('mergeSignerWalletsIntoList', () => {
+  it('adds a signer wallet missing from an empty list (the reported bug)', () => {
+    const { list, added } = mergeSignerWalletsIntoList([], [A]);
+    expect(added).toBe(true);
+    expect(list).toEqual([{ address: A, source: 'seed' }]);
+  });
+
+  it('reports nothing added when every signer wallet is already known', () => {
+    const stored: AccountListItem[] = [{ address: A, source: 'seed' }];
+    const { list, added } = mergeSignerWalletsIntoList(stored, [A]);
+    expect(added).toBe(false);
+    expect(list).toEqual(stored);
+  });
+
+  it('preserves existing entries and their source, appending only the new ones', () => {
+    const stored: AccountListItem[] = [{ address: A, source: 'extension' }];
+    const { list, added } = mergeSignerWalletsIntoList(stored, [A, B]);
+    expect(added).toBe(true);
+    expect(list).toEqual([
+      { address: A, source: 'extension' },
+      { address: B, source: 'seed' },
+    ]);
+  });
+
+  it('matches known addresses case-insensitively (no duplicate)', () => {
+    const stored: AccountListItem[] = [{ address: A, source: 'seed' }];
+    const { list, added } = mergeSignerWalletsIntoList(stored, [A.toLowerCase()]);
+    expect(added).toBe(false);
+    expect(list).toHaveLength(1);
+  });
+
+  it('dedupes repeats within the signer list', () => {
+    const { list, added } = mergeSignerWalletsIntoList([], [B, B, C]);
+    expect(added).toBe(true);
+    expect(list.map((a) => a.address)).toEqual([B, C]);
+  });
+
+  it('skips empty addresses', () => {
+    const { list, added } = mergeSignerWalletsIntoList([], ['']);
+    expect(added).toBe(false);
+    expect(list).toEqual([]);
+  });
+
+  it('does not mutate the input array', () => {
+    const stored: AccountListItem[] = [{ address: A, source: 'seed' }];
+    mergeSignerWalletsIntoList(stored, [B]);
+    expect(stored).toEqual([{ address: A, source: 'seed' }]);
+  });
+});
+
+describe('pickActiveWallet', () => {
+  it('prefers the signer active pointer when it is a real wallet', () => {
+    expect(pickActiveWallet([A, B], B)).toBe(B);
+  });
+
+  it('matches the active pointer case-insensitively', () => {
+    expect(pickActiveWallet([A, B], B.toLowerCase())).toBe(B.toLowerCase());
+  });
+
+  it('falls back to the first wallet when active is null', () => {
+    expect(pickActiveWallet([A, B], null)).toBe(A);
+  });
+
+  it('falls back to the first wallet when active is not among the wallets', () => {
+    expect(pickActiveWallet([A, B], C)).toBe(A);
+  });
+
+  it('returns undefined when there are no wallets', () => {
+    expect(pickActiveWallet([], null)).toBeUndefined();
+  });
+});

--- a/src/desktop/__tests__/walletHydration.test.ts
+++ b/src/desktop/__tests__/walletHydration.test.ts
@@ -61,6 +61,18 @@ describe('mergeSignerWalletsIntoList', () => {
     mergeSignerWalletsIntoList(stored, [B]);
     expect(stored).toEqual([{ address: A, source: 'seed' }]);
   });
+
+  it('tolerates a malformed stored entry (no throw) and still merges', () => {
+    // localStorage is unvalidated: an entry missing address must not blow up
+    // the whole reconcile. It is preserved verbatim; the new wallet is added.
+    // Built via JSON.parse so the malformed shape is a genuine runtime value
+    // (not a compile-time cast the hardened lint bans).
+    const stored = JSON.parse(`[{"source":"seed"},{"address":"${A}","source":"seed"}]`) as AccountListItem[];
+    const { list, added } = mergeSignerWalletsIntoList(stored, [B]);
+    expect(added).toBe(true);
+    expect(list).toHaveLength(3);
+    expect(list[2]).toEqual({ address: B, source: 'seed' });
+  });
 });
 
 describe('pickActiveWallet', () => {

--- a/src/desktop/bridge.ts
+++ b/src/desktop/bridge.ts
@@ -66,6 +66,8 @@ export interface SignatureResult {
   publicKey?: string;
   signer: string;
   digest?: string;
+  /** Scheme identifier for message/typedData (e.g. "QRL-SIGN-MSG-v1"). */
+  schemeVersion?: string;
   /** Present for `kind: 'transaction'`: the broadcast-ready signed payload. */
   rawTransaction?: string;
 }
@@ -85,11 +87,16 @@ export interface DAppOriginMeta {
   channelId: string;
 }
 
-/** Discriminated union of signature requests sent to the signer. */
+/**
+ * Discriminated union of signature requests sent to the signer. `signer` on
+ * the message/typedData arms names the account the caller intends to sign
+ * with; the desktop signer rejects the request when it differs from the
+ * unlocked session (transactions carry the same binding via tx.from).
+ */
 export type SignatureRequest =
   | { kind: 'transaction'; tx: UnsignedTransaction; origin?: DAppOriginMeta }
-  | { kind: 'message'; messageHex: string; origin?: DAppOriginMeta }
-  | { kind: 'typedData'; payload: unknown; origin?: DAppOriginMeta };
+  | { kind: 'message'; messageHex: string; signer: string; origin?: DAppOriginMeta }
+  | { kind: 'typedData'; payload: unknown; signer: string; origin?: DAppOriginMeta };
 
 export interface CreateWalletResult {
   status: WalletStatus;
@@ -350,18 +357,32 @@ export const desktopSigner = {
     return signed.rawTransaction;
   },
 
-  /** Sign a hex-encoded message via the signer's trusted modal. */
-  async signMessage(messageHex: string, origin?: DAppOriginMeta): Promise<SignatureResult> {
-    return qrlWallet().requestSignature({ kind: 'message', messageHex, origin });
+  /**
+   * Sign a hex-encoded message via the signer's trusted modal. `signer` is the
+   * account the caller intends to sign with; the desktop signer rejects the
+   * request when it differs from the unlocked session, so a renderer/signer
+   * account divergence can never yield a signature from the wrong key.
+   */
+  async signMessage(
+    messageHex: string,
+    signer: string,
+    origin?: DAppOriginMeta,
+  ): Promise<SignatureResult> {
+    return qrlWallet().requestSignature({ kind: 'message', messageHex, signer, origin });
   },
 
   /**
    * Sign typed data. The signer currently THROWS (hasher not yet ported), so
    * callers should surface a clear "not yet supported on desktop" error rather
-   * than falling back to an in-renderer signer.
+   * than falling back to an in-renderer signer. Carries the same signer
+   * binding as signMessage.
    */
-  async signTypedData(payload: unknown, origin?: DAppOriginMeta): Promise<SignatureResult> {
-    return qrlWallet().requestSignature({ kind: 'typedData', payload, origin });
+  async signTypedData(
+    payload: unknown,
+    signer: string,
+    origin?: DAppOriginMeta,
+  ): Promise<SignatureResult> {
+    return qrlWallet().requestSignature({ kind: 'typedData', payload, signer, origin });
   },
 
   /**

--- a/src/desktop/walletHydration.ts
+++ b/src/desktop/walletHydration.ts
@@ -1,0 +1,60 @@
+/**
+ * Desktop wallet hydration helpers.
+ *
+ * On desktop the SIGNER (its encrypted seed files on disk) is the source of
+ * truth for which wallets exist, not the renderer's localStorage account list.
+ * The list is only written during the in-renderer import/create flow, so any
+ * divergence (localStorage cleared, a wallet provisioned in another session,
+ * a per-network list mismatch) leaves the renderer showing "0 wallets" even
+ * though the signer can unlock one. qrlStore reconciles by merging the
+ * signer's wallet addresses into the account list on startup and on unlock.
+ *
+ * This module holds only the pure merge so it is trivially unit-testable; the
+ * bridge calls and storage writes live in qrlStore.
+ */
+
+import type { AccountListItem } from '@/utils/storage';
+
+/**
+ * Merge the signer's wallet addresses into the renderer's stored account list,
+ * preserving existing entries (and their source) and appending any signer
+ * wallet the list does not yet know, as a 'seed' account. Address comparison
+ * is case-insensitive. Returns the new list and whether anything was added, so
+ * the caller can skip the storage write when nothing changed.
+ */
+export function mergeSignerWalletsIntoList(
+  stored: AccountListItem[],
+  signerAddresses: string[],
+): { list: AccountListItem[]; added: boolean } {
+  const known = new Set(stored.map((a) => a.address.toLowerCase()));
+  const list = [...stored];
+  let added = false;
+  for (const address of signerAddresses) {
+    if (!address) continue;
+    const key = address.toLowerCase();
+    if (!known.has(key)) {
+      list.push({ address, source: 'seed' });
+      known.add(key);
+      added = true;
+    }
+  }
+  return { list, added };
+}
+
+/**
+ * Pick which wallet to adopt as active when the renderer has none stored:
+ * prefer the signer's own active pointer when it is a real wallet, else the
+ * first signer wallet. Returns undefined when there is nothing to adopt.
+ */
+export function pickActiveWallet(
+  signerAddresses: string[],
+  signerActive: string | null | undefined,
+): string | undefined {
+  if (
+    signerActive &&
+    signerAddresses.some((a) => a.toLowerCase() === signerActive.toLowerCase())
+  ) {
+    return signerActive;
+  }
+  return signerAddresses[0];
+}

--- a/src/desktop/walletHydration.ts
+++ b/src/desktop/walletHydration.ts
@@ -26,7 +26,14 @@ export function mergeSignerWalletsIntoList(
   stored: AccountListItem[],
   signerAddresses: string[],
 ): { list: AccountListItem[]; added: boolean } {
-  const known = new Set(stored.map((a) => a.address.toLowerCase()));
+  // stored comes from localStorage unvalidated; tolerate a malformed entry
+  // (missing/non-string address) rather than throwing out the whole reconcile.
+  // Such entries are preserved verbatim in the list, just not matched against.
+  const known = new Set(
+    stored
+      .map((a) => (typeof a?.address === 'string' ? a.address.toLowerCase() : null))
+      .filter((k): k is string => k !== null),
+  );
   const list = [...stored];
   let added = false;
   for (const address of signerAddresses) {

--- a/src/stores/__tests__/dappConnectStore.test.ts
+++ b/src/stores/__tests__/dappConnectStore.test.ts
@@ -243,18 +243,44 @@ describe('approval queue passthrough', () => {
     expect(mockService.rejectRequest).toHaveBeenCalledWith('session-1', 1, 'User rejected', undefined);
   });
 
-  it('sendApprovalResult keeps the modal open (progress UI)', () => {
+  it('sendApprovalResultById keeps the modal open (progress UI)', () => {
     const store = new DAppConnectStore();
     const req = makeRequest();
     store.pendingRequests = [req];
     store.currentApproval = req;
     store.approvalModalOpen = true;
 
-    store.sendApprovalResult('0xhash');
+    store.sendApprovalResultById(req.sessionId, req.id, '0xhash');
 
     expect(mockService.approveRequest).toHaveBeenCalledWith('session-1', 1, '0xhash');
     expect(store.currentApproval?.id).toBe(req.id);
     expect(store.approvalModalOpen).toBe(true);
+  });
+
+  it('approveRequestById answers the captured request, not the promoted one', () => {
+    // The wrong-request race: request A is approved, its async signing is in
+    // flight, A's session disconnects and request B becomes current. The
+    // resolution must answer A (already gone) and leave B untouched.
+    const store = new DAppConnectStore();
+    const reqA = makeRequest();
+    const reqB = { ...makeRequest(), id: 2, sessionId: 'session-2' };
+    store.pendingRequests = [reqA, reqB];
+    store.currentApproval = reqA;
+    store.approvalModalOpen = true;
+
+    // Captured before the await (what the modal does).
+    const { sessionId, id } = reqA;
+
+    // Session A dies mid-flight; B is promoted.
+    store.pendingRequests = [reqB];
+    store.currentApproval = reqB;
+
+    store.approveRequestById(sessionId, id, '0xsig');
+
+    expect(mockService.approveRequest).toHaveBeenCalledWith('session-1', 1, '0xsig');
+    expect(store.currentApproval?.id).toBe(reqB.id);
+    expect(store.approvalModalOpen).toBe(true);
+    expect(store.pendingRequests).toEqual([reqB]);
   });
 
   it('is a no-op with no current approval', () => {

--- a/src/stores/dappConnectStore.ts
+++ b/src/stores/dappConnectStore.ts
@@ -140,66 +140,62 @@ class DAppConnectStore {
   /** Approve the current request with a result */
   approveCurrentRequest(result: unknown): void {
     if (!this.currentApproval) return;
-
-    dappConnectService.approveRequest(
-      this.currentApproval.sessionId,
-      this.currentApproval.id,
-      result
-    );
-
-    this.removeCurrentApproval();
+    this.approveRequestById(this.currentApproval.sessionId, this.currentApproval.id, result);
   }
 
   /** Reject the current request */
   rejectCurrentRequest(message?: string, code?: number): void {
     if (!this.currentApproval) return;
+    this.rejectRequestById(this.currentApproval.sessionId, this.currentApproval.id, message, code);
+  }
 
-    dappConnectService.rejectRequest(
-      this.currentApproval.sessionId,
-      this.currentApproval.id,
-      message,
-      code
-    );
+  /**
+   * Answer a SPECIFIC request. Async approval flows resolve after awaits (PIN
+   * unlock, desktop trusted confirm, broadcast) during which currentApproval
+   * can change (a session disconnect promotes the next pending request), so
+   * answering "the current request" at resolution time can route a result to
+   * a different dApp request than the one the user approved. Callers that
+   * await MUST capture {sessionId, id} before the first await and answer
+   * through these.
+   */
+  approveRequestById(sessionId: string, id: string | number, result: unknown): void {
+    dappConnectService.approveRequest(sessionId, id, result);
+    this.removeApproval(sessionId, id);
+  }
 
-    this.removeCurrentApproval();
+  /** Reject a SPECIFIC request; see {@link approveRequestById}. */
+  rejectRequestById(sessionId: string, id: string | number, message?: string, code?: number): void {
+    dappConnectService.rejectRequest(sessionId, id, message, code);
+    this.removeApproval(sessionId, id);
   }
 
   /** Send approval result to dApp without closing the modal (for progress UI) */
-  sendApprovalResult(result: unknown): void {
-    if (!this.currentApproval) return;
-    dappConnectService.approveRequest(
-      this.currentApproval.sessionId,
-      this.currentApproval.id,
-      result
-    );
+  sendApprovalResultById(sessionId: string, id: string | number, result: unknown): void {
+    dappConnectService.approveRequest(sessionId, id, result);
   }
 
   /** Send rejection to dApp without closing the modal (for progress UI) */
-  sendRejectionResult(message?: string): void {
-    if (!this.currentApproval) return;
-    dappConnectService.rejectRequest(
-      this.currentApproval.sessionId,
-      this.currentApproval.id,
-      message
-    );
+  sendRejectionResultById(sessionId: string, id: string | number, message?: string): void {
+    dappConnectService.rejectRequest(sessionId, id, message);
   }
 
   /** Dismiss the current approval after tx progress is done (called from "Done"/"Close" button) */
   dismissCurrentApproval(): void {
-    this.removeCurrentApproval();
+    if (!this.currentApproval) return;
+    this.removeApproval(this.currentApproval.sessionId, this.currentApproval.id);
   }
 
-  /** Remove the current approval and show the next one if any */
-  private removeCurrentApproval(): void {
-    if (!this.currentApproval) return;
-
-    this.resetTxProgress();
-
-    const { id: currentId, sessionId: currentSessionId } = this.currentApproval;
+  /** Drop one request from the queue; promote the next when it was current. */
+  private removeApproval(sessionId: string, id: string | number): void {
     this.pendingRequests = this.pendingRequests.filter(
-      (r) => !(r.id === currentId && r.sessionId === currentSessionId)
+      (r) => !(r.id === id && r.sessionId === sessionId)
     );
 
+    const wasCurrent =
+      this.currentApproval?.id === id && this.currentApproval.sessionId === sessionId;
+    if (!wasCurrent) return;
+
+    this.resetTxProgress();
     if (this.pendingRequests.length > 0) {
       this.currentApproval = this.pendingRequests[0] ?? null;
     } else {
@@ -220,11 +216,6 @@ class DAppConnectStore {
     this.txProgress = 'idle';
     this.txHash = null;
     this.txError = null;
-  }
-
-  /** Close the approval modal without approving/rejecting */
-  closeApprovalModal(): void {
-    this.approvalModalOpen = false;
   }
 
   /** Disconnect a specific dApp session */

--- a/src/stores/qrlStore.ts
+++ b/src/stores/qrlStore.ts
@@ -408,18 +408,37 @@ class QrlStore {
 
     if (!this._desktopUnlockListenerBound) {
       this._desktopUnlockListenerBound = true;
-      desktopSigner.onLockStateChanged((locked) => {
-        if (locked) return;
-        // Re-run the FULL init sequence for the list: hydrate, refetch, then
-        // validateActiveAccount, which is the only thing that copies the
-        // stored active account into the activeAccount observable the Home
-        // screen gates on. Without it, a first hydration that found nothing
-        // (signer mid-restart at boot) would populate the list on unlock but
-        // still show the "Let's start" onboarding card until an app restart.
-        void this.hydrateDesktopWalletsFromSigner()
-          .then(() => this.fetchAccounts())
-          .then(() => this.validateActiveAccount());
-      });
+      try {
+        desktopSigner.onLockStateChanged((locked) => {
+          if (locked) return;
+          // Re-run the FULL init sequence for the list: hydrate, refetch, then
+          // validateActiveAccount, which is the only thing that copies the
+          // stored active account into the activeAccount observable the Home
+          // screen gates on. Without it, a first hydration that found nothing
+          // (signer mid-restart at boot) would populate the list on unlock but
+          // still show the "Let's start" onboarding card until an app restart.
+          void this.hydrateDesktopWalletsFromSigner()
+            .then(() => this.fetchAccounts())
+            .then(async () => {
+              const before = this.activeAccount.accountAddress;
+              await this.validateActiveAccount();
+              const after = this.activeAccount.accountAddress;
+              // Adoption on this path changes the active account outside
+              // setActiveAccount, and TokenStore/NftStore are purely
+              // hook-driven: fire the same hook so token/NFT state re-scopes
+              // to the adopted account instead of staying on the boot-time
+              // (possibly empty) scope.
+              if (after && after !== before) await this.onActiveAccountChanged?.(after);
+            })
+            .catch((error: unknown) => {
+              console.error('Desktop unlock re-hydration failed:', error);
+            });
+        });
+      } catch (error) {
+        // A shell predating onLockStateChanged must not abort blockchain init;
+        // the one-shot hydration below still runs.
+        console.error('Desktop lock-state listener unavailable:', error);
+      }
     }
 
     let signerAddresses: string[] = [];
@@ -463,8 +482,13 @@ class QrlStore {
           // Store the address exactly as it appears in the merged list, so the
           // strict-equality check in validateActiveAccount matches it (a
           // pre-existing entry may hold a different casing than the signer's).
+          // Same malformed-entry tolerance as mergeSignerWalletsIntoList: a
+          // stored entry without a string address must not throw here, or the
+          // adoption is silently lost on every run.
           const canonical =
-            list.find((a) => a.address.toLowerCase() === adopt.toLowerCase())?.address ?? adopt;
+            list.find(
+              (a) => typeof a?.address === 'string' && a.address.toLowerCase() === adopt.toLowerCase(),
+            )?.address ?? adopt;
           await StorageUtil.setActiveAccount(blockchain, canonical);
         }
       }

--- a/src/stores/qrlStore.ts
+++ b/src/stores/qrlStore.ts
@@ -410,7 +410,15 @@ class QrlStore {
       this._desktopUnlockListenerBound = true;
       desktopSigner.onLockStateChanged((locked) => {
         if (locked) return;
-        void this.hydrateDesktopWalletsFromSigner().then(() => this.fetchAccounts());
+        // Re-run the FULL init sequence for the list: hydrate, refetch, then
+        // validateActiveAccount, which is the only thing that copies the
+        // stored active account into the activeAccount observable the Home
+        // screen gates on. Without it, a first hydration that found nothing
+        // (signer mid-restart at boot) would populate the list on unlock but
+        // still show the "Let's start" onboarding card until an app restart.
+        void this.hydrateDesktopWalletsFromSigner()
+          .then(() => this.fetchAccounts())
+          .then(() => this.validateActiveAccount());
       });
     }
 
@@ -434,17 +442,34 @@ class QrlStore {
     }
     if (signerAddresses.length === 0) return;
 
-    const blockchain = this.qrlConnection.blockchain;
-    const stored = await StorageUtil.getAccountList(blockchain);
-    const { list, added } = mergeSignerWalletsIntoList(stored, signerAddresses);
-    if (added) await StorageUtil.setAccountList(blockchain, list);
+    // Storage reconcile is best-effort and MUST NOT throw: this method runs
+    // inside initializeBlockchain's try, so an uncaught throw here (e.g. a
+    // corrupt stored account list entry, or a localStorage quota error) would
+    // skip fetchAccounts, validateActiveAccount, and token/NFT init. Contain
+    // it so a hydration failure only loses the reconcile, never the rest of
+    // blockchain init.
+    try {
+      const blockchain = this.qrlConnection.blockchain;
+      const stored = await StorageUtil.getAccountList(blockchain);
+      const { list, added } = mergeSignerWalletsIntoList(stored, signerAddresses);
+      if (added) await StorageUtil.setAccountList(blockchain, list);
 
-    // Adopt an active wallet only when the renderer has none, so we never
-    // override a selection the user already made.
-    const storedActive = await StorageUtil.getActiveAccount(blockchain);
-    if (!storedActive) {
-      const adopt = pickActiveWallet(signerAddresses, signerActive);
-      if (adopt) await StorageUtil.setActiveAccount(blockchain, adopt);
+      // Adopt an active wallet only when the renderer has none, so we never
+      // override a selection the user already made.
+      const storedActive = await StorageUtil.getActiveAccount(blockchain);
+      if (!storedActive) {
+        const adopt = pickActiveWallet(signerAddresses, signerActive);
+        if (adopt) {
+          // Store the address exactly as it appears in the merged list, so the
+          // strict-equality check in validateActiveAccount matches it (a
+          // pre-existing entry may hold a different casing than the signer's).
+          const canonical =
+            list.find((a) => a.address.toLowerCase() === adopt.toLowerCase())?.address ?? adopt;
+          await StorageUtil.setActiveAccount(blockchain, canonical);
+        }
+      }
+    } catch (error) {
+      console.error('Desktop wallet hydration: storage reconcile failed:', error);
     }
   }
 

--- a/src/stores/qrlStore.ts
+++ b/src/stores/qrlStore.ts
@@ -1,6 +1,7 @@
 import { QRL_PROVIDER, EXPLORER_BASE, getPendingTxApiUrl } from "@/config";
 import { deriveHexSeedAsync } from "@/utils/crypto";
 import { isDesktop, desktopSigner } from "@/desktop/bridge";
+import { mergeSignerWalletsIntoList, pickActiveWallet } from "@/desktop/walletHydration";
 import type { AccountListItem, AccountSource } from "@/utils/storage";
 import { StorageUtil } from "@/utils/storage";
 import { log } from "@/utils";
@@ -106,6 +107,10 @@ class QrlStore {
   // makeAutoObservable below — it's a non-observable runtime handle.
   _receiptPollerIntervalId: ReturnType<typeof setInterval> | null = null;
 
+  // Desktop only: guards one-time registration of the signer lock-state
+  // listener that re-hydrates the wallet list on unlock. Non-observable.
+  _desktopUnlockListenerBound = false;
+
   // Callbacks wired by Store after construction so token/NFT init can run
   // *after* QrlStore has a live qrlInstance and network selection — and
   // without QrlStore taking a direct dependency on the other stores.
@@ -155,7 +160,9 @@ class QrlStore {
       _utils: false,
       _Web3: false,
       _receiptPollerIntervalId: false,
+      _desktopUnlockListenerBound: false,
       cancelReceiptPoller: false,
+      hydrateDesktopWalletsFromSigner: false,
       // Callback hooks injected by Store — not observable.
       onBlockchainReady: false,
       onActiveAccountChanged: false,
@@ -259,6 +266,10 @@ class QrlStore {
       });
 
       await this.fetchQrlConnection();
+      // Desktop: reconcile the account list against the signer (source of
+      // truth for which wallets exist) BEFORE fetchAccounts reads the list,
+      // so a wallet the signer can unlock is never shown as "0 wallets".
+      if (isDesktop) await this.hydrateDesktopWalletsFromSigner();
       await this.fetchAccounts();
       this.fetchQrlPrice(); // Fire-and-forget, non-blocking
       await this.validateActiveAccount();
@@ -373,6 +384,67 @@ class QrlStore {
       runInAction(() => {
         this.qrlConnection = { ...this.qrlConnection, isLoading: false };
       });
+    }
+  }
+
+  /**
+   * Desktop: reconcile the renderer's account list with the signer's wallets.
+   *
+   * The signer (encrypted seed files on disk) is the source of truth for which
+   * wallets exist; the renderer's localStorage list is only written during the
+   * in-renderer import/create flow, so the two can diverge (localStorage
+   * cleared, a wallet provisioned in another session, a per-network list
+   * mismatch), which would strand a real wallet behind the empty "Let's start"
+   * screen even though the native unlock window can open it.
+   *
+   * listWallets returns addresses only (no decryption), so this works even
+   * while the signer is locked at startup. Also registers, once, a lock-state
+   * listener that re-runs on unlock (covering wallets added/removed in-session
+   * and any main that gates listWallets behind an open session). Best-effort:
+   * any bridge failure leaves the localStorage list untouched.
+   */
+  async hydrateDesktopWalletsFromSigner(): Promise<void> {
+    if (!isDesktop) return;
+
+    if (!this._desktopUnlockListenerBound) {
+      this._desktopUnlockListenerBound = true;
+      desktopSigner.onLockStateChanged((locked) => {
+        if (locked) return;
+        void this.hydrateDesktopWalletsFromSigner().then(() => this.fetchAccounts());
+      });
+    }
+
+    let signerAddresses: string[] = [];
+    let signerActive: string | null = null;
+    try {
+      const { wallets, active } = await desktopSigner.listWallets();
+      signerAddresses = (wallets ?? []).map((w) => w.address);
+      signerActive = active;
+    } catch {
+      // Older mains may not implement listWallets: fall back to the single
+      // active address from getStatus.
+      try {
+        const status = await desktopSigner.getStatus();
+        if (status.address) signerAddresses = [status.address];
+        signerActive = status.activeAddress ?? status.address ?? null;
+      } catch (error) {
+        console.error('Desktop wallet hydration failed:', error);
+        return;
+      }
+    }
+    if (signerAddresses.length === 0) return;
+
+    const blockchain = this.qrlConnection.blockchain;
+    const stored = await StorageUtil.getAccountList(blockchain);
+    const { list, added } = mergeSignerWalletsIntoList(stored, signerAddresses);
+    if (added) await StorageUtil.setAccountList(blockchain, list);
+
+    // Adopt an active wallet only when the renderer has none, so we never
+    // override a selection the user already made.
+    const storedActive = await StorageUtil.getActiveAccount(blockchain);
+    if (!storedActive) {
+      const adopt = pickActiveWallet(signerAddresses, signerActive);
+      if (adopt) await StorageUtil.setActiveAccount(blockchain, adopt);
     }
   }
 


### PR DESCRIPTION
## What

Two field findings from the desktop dApp-connect e2e (2026-07-03, zondscan.com/dapp-example):

1. A dApp connected as account A received a valid signature from account B after the signer session moved to another wallet. Renderer account state and the isolated signer session are separate and nothing bound them.
2. The dApp-visible response carried `schemeVersion: undefined` (and leaked the bridge-internal `kind` field), diverging from the web wallet's response shape.

## Changes

- `desktopSigner.signMessage` / `signTypedData` now take the signing account and send it on the bridge request; the desktop signer (DigitalGuards/myqrlwallet-desktop PR #10, commit c5db9af) rejects any request whose account differs from the unlocked session, with main pre-checking before the trusted confirm and the confirm modal now displaying the account.
- `DAppApprovalModal` reshapes the desktop result to the exact rich object the web path returns: `{signature, publicKey, signer, digest, schemeVersion[, domain]}`.

## Notes

- Stacked on #210 (hydration); merge that first.
- Web (non-desktop) paths untouched.

## Gates

lint 0 warnings, 186/186 tests, build (tsc + vite) green.