### PR TITLE
fix(desktop): renderer active account follows the signer's unlocked wallet (send account-mismatch)

### DIFF
--- a/src/desktop/__tests__/walletHydration.test.ts
+++ b/src/desktop/__tests__/walletHydration.test.ts
@@ -8,7 +8,12 @@
  */
 
 import { describe, it, expect } from '@jest/globals';
-import { isAddressListed, pickActiveWallet, reconcileSignerWallets } from '../walletHydration';
+import {
+  decideActiveAccount,
+  isAddressListed,
+  pickActiveWallet,
+  reconcileSignerWallets,
+} from '../walletHydration';
 import type { AccountListItem } from '@/utils/storage';
 
 const A = 'Q1111111111111111111111111111111111111111';
@@ -129,6 +134,117 @@ describe('isAddressListed', () => {
     const list = JSON.parse(`[{"source":"seed"},{"address":"${A}","source":"seed"}]`) as AccountListItem[];
     expect(isAddressListed(list, B)).toBe(false);
     expect(isAddressListed(list, A)).toBe(true);
+  });
+});
+
+describe('decideActiveAccount', () => {
+  const list: AccountListItem[] = [
+    { address: A, source: 'seed' },
+    { address: B, source: 'seed' },
+  ];
+
+  it('adopts the signer active pointer when the renderer active is a different listed wallet (the send-mismatch bug)', () => {
+    // Signer unlocked B; renderer still points at A. Sending would build
+    // from=A against session=B and the signer rejects it. Adopt B.
+    const d = decideActiveAccount({
+      list,
+      storedActive: A,
+      signerActive: B,
+      signerAddresses: [A, B],
+      authoritative: true,
+    });
+    expect(d).toEqual({ action: 'set', address: B });
+  });
+
+  it('leaves the active account alone when it already matches the signer', () => {
+    const d = decideActiveAccount({
+      list,
+      storedActive: B,
+      signerActive: B,
+      signerAddresses: [A, B],
+      authoritative: true,
+    });
+    expect(d).toEqual({ action: 'none' });
+  });
+
+  it('matches the signer pointer case-insensitively and adopts canonical casing', () => {
+    const d = decideActiveAccount({
+      list,
+      storedActive: B.toLowerCase(),
+      signerActive: B.toLowerCase(),
+      signerAddresses: [A, B],
+      authoritative: true,
+    });
+    // storedActive lower-cases to the same key as the canonical B: no change.
+    expect(d).toEqual({ action: 'none' });
+  });
+
+  it('adopts canonical-cased signer active even when stored differs only by case', () => {
+    const d = decideActiveAccount({
+      list,
+      storedActive: A,
+      signerActive: B.toLowerCase(),
+      signerAddresses: [A, B],
+      authoritative: true,
+    });
+    expect(d).toEqual({ action: 'set', address: B });
+  });
+
+  it('adopts when the renderer has no active account', () => {
+    const d = decideActiveAccount({
+      list,
+      storedActive: null,
+      signerActive: A,
+      signerAddresses: [A, B],
+      authoritative: true,
+    });
+    expect(d).toEqual({ action: 'set', address: A });
+  });
+
+  it('does not adopt a signer pointer that is not a listed wallet (non-authoritative fallback keeps a valid active)', () => {
+    // getStatus fallback: signerActive is some address not in the list; the
+    // renderer active is valid and listed, so leave it.
+    const d = decideActiveAccount({
+      list,
+      storedActive: A,
+      signerActive: C,
+      signerAddresses: [C],
+      authoritative: false,
+    });
+    expect(d).toEqual({ action: 'none' });
+  });
+
+  it('heals a stored active that was removed (authoritative), falling back to a remaining wallet', () => {
+    const d = decideActiveAccount({
+      list: [{ address: A, source: 'seed' }],
+      storedActive: B, // B was removed; not in list
+      signerActive: null,
+      signerAddresses: [A],
+      authoritative: true,
+    });
+    expect(d).toEqual({ action: 'set', address: A });
+  });
+
+  it('clears the active when the last wallet was removed', () => {
+    const d = decideActiveAccount({
+      list: [],
+      storedActive: A,
+      signerActive: null,
+      signerAddresses: [],
+      authoritative: true,
+    });
+    expect(d).toEqual({ action: 'clear' });
+  });
+
+  it('does not drop a stored active on the non-authoritative fallback when signer reports nothing usable', () => {
+    const d = decideActiveAccount({
+      list,
+      storedActive: A,
+      signerActive: null,
+      signerAddresses: [],
+      authoritative: false,
+    });
+    expect(d).toEqual({ action: 'none' });
   });
 });
 

--- a/src/desktop/walletHydration.ts
+++ b/src/desktop/walletHydration.ts
@@ -100,3 +100,62 @@ export function pickActiveWallet(
   }
   return signerAddresses[0];
 }
+
+/** Canonical-case an address as it appears in the reconciled list (so a strict
+ * equality lookup elsewhere matches); returns the input if not listed.
+ * Malformed-entry tolerant. */
+function canonicalOf(list: AccountListItem[], addr: string): string {
+  const key = addr.toLowerCase();
+  return (
+    list.find((a) => typeof a?.address === 'string' && a.address.toLowerCase() === key)?.address ??
+    addr
+  );
+}
+
+/** What the renderer should do with its active-account pointer after a
+ * reconcile. `set` adopts `address`; `clear` wipes it; `none` leaves it. */
+export type ActiveAccountDecision =
+  | { action: 'set'; address: string }
+  | { action: 'clear' }
+  | { action: 'none' };
+
+/**
+ * Decide the renderer's active account after hydrating against the signer.
+ *
+ * On desktop the signer's active pointer IS the account that is unlocked
+ * (every unlock and setActiveWallet calls setActiveAddress) and the ONLY
+ * account that can sign. The renderer active account MUST mirror it, or a send
+ * builds `from` from a stale renderer active that differs from the unlocked
+ * session and the signer rejects it ("signing account mismatch"). So:
+ *
+ *  1. If the signer's active pointer names a real listed wallet and the
+ *     renderer differs, adopt it (the load-bearing sync).
+ *  2. Else, when the renderer has no active or its stored one is no longer
+ *     listed (authoritative removals only), adopt any wallet, or clear if the
+ *     last wallet is gone.
+ *  3. Else leave the renderer active as-is.
+ */
+export function decideActiveAccount(params: {
+  list: AccountListItem[];
+  storedActive: string | null | undefined;
+  signerActive: string | null | undefined;
+  signerAddresses: string[];
+  /** True only when signerAddresses came from an authoritative listWallets. */
+  authoritative: boolean;
+}): ActiveAccountDecision {
+  const { list, storedActive, signerActive, signerAddresses, authoritative } = params;
+  const storedKey = (storedActive ?? '').toLowerCase();
+
+  if (signerActive && isAddressListed(list, signerActive)) {
+    const canonical = canonicalOf(list, signerActive);
+    if (canonical.toLowerCase() !== storedKey) return { action: 'set', address: canonical };
+    return { action: 'none' };
+  }
+
+  if (!storedActive || (authoritative && !isAddressListed(list, storedActive))) {
+    const adopt = pickActiveWallet(signerAddresses, signerActive);
+    if (adopt) return { action: 'set', address: canonicalOf(list, adopt) };
+    if (storedActive) return { action: 'clear' };
+  }
+  return { action: 'none' };
+}

--- a/src/stores/qrlStore.ts
+++ b/src/stores/qrlStore.ts
@@ -1,7 +1,7 @@
 import { QRL_PROVIDER, EXPLORER_BASE, getPendingTxApiUrl } from "@/config";
 import { deriveHexSeedAsync } from "@/utils/crypto";
 import { isDesktop, desktopSigner } from "@/desktop/bridge";
-import { isAddressListed, pickActiveWallet, reconcileSignerWallets } from "@/desktop/walletHydration";
+import { decideActiveAccount, reconcileSignerWallets } from "@/desktop/walletHydration";
 import type { AccountListItem, AccountSource } from "@/utils/storage";
 import { StorageUtil } from "@/utils/storage";
 import { log } from "@/utils";
@@ -482,31 +482,23 @@ class QrlStore {
       const { list, changed } = reconcileSignerWallets(stored, signerAddresses, authoritative);
       if (changed) await StorageUtil.setAccountList(blockchain, list);
 
-      // Adopt an active wallet when the renderer has none, or heal it when the
-      // stored one no longer exists (its wallet was removed from the native
-      // settings window; authoritative-only, same reasoning as the drop side).
-      // Never override a live selection the user made.
+      // Decide the renderer's active account. On desktop it MUST mirror the
+      // signer's unlocked/selected account (see decideActiveAccount): a send
+      // builds `from` from the renderer active, so a stale one that differs
+      // from the unlocked session is rejected by the signer ("signing account
+      // mismatch"). The decision is a pure, unit-tested helper.
       const storedActive = await StorageUtil.getActiveAccount(blockchain);
-      if (!storedActive || (authoritative && !isAddressListed(list, storedActive))) {
-        const adopt = pickActiveWallet(signerAddresses, signerActive);
-        if (adopt) {
-          // Store the address exactly as it appears in the reconciled list, so
-          // the strict-equality check in validateActiveAccount matches it (a
-          // pre-existing entry may hold a different casing than the signer's).
-          // Same malformed-entry tolerance as reconcileSignerWallets: a stored
-          // entry without a string address must not throw here, or the
-          // adoption is silently lost on every run.
-          const canonical =
-            list.find(
-              (a) => typeof a?.address === 'string' && a.address.toLowerCase() === adopt.toLowerCase(),
-            )?.address ?? adopt;
-          await StorageUtil.setActiveAccount(blockchain, canonical);
-        } else if (storedActive) {
-          // The active wallet is gone and nothing remains to adopt (last
-          // wallet removed): clear the pointer so the UI lands on onboarding
-          // instead of a ghost account.
-          await StorageUtil.clearActiveAccount(blockchain);
-        }
+      const decision = decideActiveAccount({
+        list,
+        storedActive,
+        signerActive,
+        signerAddresses,
+        authoritative,
+      });
+      if (decision.action === 'set') {
+        await StorageUtil.setActiveAccount(blockchain, decision.address);
+      } else if (decision.action === 'clear') {
+        await StorageUtil.clearActiveAccount(blockchain);
       }
     } catch (error) {
       console.error('Desktop wallet hydration: storage reconcile failed:', error);


### PR DESCRIPTION
## Bug
Desktop sends failed with `signing account mismatch: request targets a different account than the unlocked session` in any multi-wallet setup: unlock wallet B in the native picker, but the renderer's active account was still wallet A, so the send built `from=A` against `session=B` and the signer (correctly) rejected it. Diagnosed from the on-device state: signer had 2 wallets (picker showed both), renderer active pointed at the other one.

## Root cause
`qrlStore.hydrateDesktopWalletsFromSigner` only adopted the signer's active pointer when the renderer had **no** active account (or an unlisted one). A stale-but-listed active survived every hydration, so the renderer active and the signer's unlocked session drifted apart and never reconverged.

## Fix
On desktop the signer's active pointer **is** the unlocked/selected account (every unlock and `setActiveWallet` calls `setActiveAddress`) and the only account that can sign, so the renderer active must mirror it. Lifted the decision into a pure, unit-tested helper `decideActiveAccount`:
- adopt the signer's active pointer whenever it names a real listed wallet and the renderer differs (the load-bearing sync);
- keep the missing/removed-active heal + last-wallet clear as fallbacks;
- never drop off the non-authoritative `getStatus` fallback.

Self-heals the diverged state on the next unlock (the `onLockStateChanged` re-hydration adopts whatever account you unlock). The stale ghost accounts in the renderer list are separately dropped by the authoritative reconcile on next boot.

## Verification
- Reproduced the crypto happy-path end-to-end from a testnet seed with no GUI (import -> unlock -> build -> sign a 14.5KB type-2 tx); confirmed the mismatch is state-only, not crypto.
- 10 new `decideActiveAccount` unit tests incl. the exact send-mismatch case (unlock B, renderer active A -> adopt B).
- Gates: lint clean, jest 202/202, build green.