### PR TITLE
fix: dApp tx account-binding + tx timeout state + hydration canonical/TOCTOU/watch-only

### DIFF
--- a/src/components/Core/Body/DAppConnect/DAppApprovalModal.tsx
+++ b/src/components/Core/Body/DAppConnect/DAppApprovalModal.tsx
@@ -200,6 +200,21 @@ const DAppApprovalModal = observer(() => {
           return;
         }
 
+        // Bind the request to the account it names, exactly like the
+        // signMessage / signTypedData paths above. The tx `from` is substituted
+        // with the LIVE active account at approve-click, and that active account
+        // can now flip automatically (e.g. an autolock + unlock of a different
+        // wallet while this approval sits open), so without this check the dApp
+        // could get a signature/spend from an account it never asked for. A dApp
+        // that omits `from` accepts the active account.
+        const requestedFrom = ((params?.[0] as Record<string, unknown> | undefined)?.['from'] ??
+          '') as string;
+        if (requestedFrom && requestedFrom.toLowerCase() !== activeAddress.toLowerCase()) {
+          setError('Signer mismatch: request is for a different account');
+          setLoading(false);
+          return;
+        }
+
         // Desktop: build + confirm + sign in the isolated signer (its own
         // trusted modal), then broadcast for send / return raw for sign. No
         // PIN, no seed in the renderer.

--- a/src/components/Core/Body/Transfer/Transfer.tsx
+++ b/src/components/Core/Body/Transfer/Transfer.tsx
@@ -578,6 +578,46 @@ const Transfer = observer(() => {
     );
   }
 
+  if (transactionStatus.state === 'timeout') {
+    return (
+      <div className="flex w-full items-start justify-center py-2 md:py-8 overflow-x-hidden">
+        <div className="relative w-full max-w-2xl px-2 md:px-4">
+          <Card className="w-full border-l-4 border-l-orange-500">
+            <CardHeader className="bg-gradient-to-r from-orange-500/10 to-transparent">
+              <CardTitle className="flex items-center gap-2">
+                <Loader className="h-5 w-5" />
+                Still Pending
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="py-8">
+              <div className="flex flex-col items-center gap-4 text-center">
+                <p className="text-muted-foreground">
+                  {transactionStatus.error ||
+                    "The transaction is taking longer than expected. It may still be mined; check the explorer."}
+                </p>
+                {transactionStatus.txHash && (
+                  <a
+                    href={getExplorerTxUrl(transactionStatus.txHash, blockchain)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-2 text-sm text-secondary hover:text-secondary/80"
+                  >
+                    View on Explorer <ExternalLink className="h-4 w-4" />
+                  </a>
+                )}
+              </div>
+            </CardContent>
+            <CardFooter>
+              <Button variant="outline" onClick={resetTransactionStatus} className="w-full">
+                Done
+              </Button>
+            </CardFooter>
+          </Card>
+        </div>
+      </div>
+    );
+  }
+
   if (transactionStatus.state === 'failed') {
     return (
       <div className="flex w-full items-start justify-center py-2 md:py-8 overflow-x-hidden">

--- a/src/desktop/__tests__/walletHydration.test.ts
+++ b/src/desktop/__tests__/walletHydration.test.ts
@@ -167,7 +167,9 @@ describe('decideActiveAccount', () => {
     expect(d).toEqual({ action: 'none' });
   });
 
-  it('matches the signer pointer case-insensitively and adopts canonical casing', () => {
+  it('rewrites a stored active that matches the signer wallet but differs only by case (canonical heal)', () => {
+    // Gemini HIGH: a case-only difference must still be rewritten to canonical,
+    // or validateActiveAccount's strict === find misses and clears the active.
     const d = decideActiveAccount({
       list,
       storedActive: B.toLowerCase(),
@@ -175,7 +177,17 @@ describe('decideActiveAccount', () => {
       signerAddresses: [A, B],
       authoritative: true,
     });
-    // storedActive lower-cases to the same key as the canonical B: no change.
+    expect(d).toEqual({ action: 'set', address: B });
+  });
+
+  it('is a true no-op only when the stored active is byte-identical to canonical', () => {
+    const d = decideActiveAccount({
+      list,
+      storedActive: B,
+      signerActive: B,
+      signerAddresses: [A, B],
+      authoritative: true,
+    });
     expect(d).toEqual({ action: 'none' });
   });
 
@@ -223,6 +235,21 @@ describe('decideActiveAccount', () => {
       authoritative: true,
     });
     expect(d).toEqual({ action: 'set', address: A });
+  });
+
+  it('does not force-flip a deliberately-selected extension/watch-only active account', () => {
+    const mixed: AccountListItem[] = [
+      { address: A, source: 'extension' },
+      { address: B, source: 'seed' },
+    ];
+    const d = decideActiveAccount({
+      list: mixed,
+      storedActive: A, // watch-only, deliberately selected
+      signerActive: B, // signer unlocked its own wallet
+      signerAddresses: [B],
+      authoritative: true,
+    });
+    expect(d).toEqual({ action: 'none' });
   });
 
   it('clears the active when the last wallet was removed', () => {

--- a/src/desktop/walletHydration.ts
+++ b/src/desktop/walletHydration.ts
@@ -144,11 +144,30 @@ export function decideActiveAccount(params: {
   authoritative: boolean;
 }): ActiveAccountDecision {
   const { list, storedActive, signerActive, signerAddresses, authoritative } = params;
-  const storedKey = (storedActive ?? '').toLowerCase();
 
-  if (signerActive && isAddressListed(list, signerActive)) {
+  // A deliberately-selected non-signer ('extension'/watch-only) active account
+  // is not the signer's to stomp: the signer can't sign for it anyway, and
+  // setActiveAccount supports selecting such addresses. Leave it as-is rather
+  // than force-flipping it to a signer wallet on every unlock.
+  const storedKey = (storedActive ?? '').toLowerCase();
+  const storedIsNonSigner =
+    storedKey.length > 0 &&
+    list.some(
+      (a) =>
+        typeof a?.address === 'string' &&
+        a.address.toLowerCase() === storedKey &&
+        a.source !== 'seed',
+    );
+
+  if (!storedIsNonSigner && signerActive && isAddressListed(list, signerActive)) {
     const canonical = canonicalOf(list, signerActive);
-    if (canonical.toLowerCase() !== storedKey) return { action: 'set', address: canonical };
+    // STRICT compare, not case-insensitive: when the stored active names the
+    // same wallet but in a different case than the list, it must still be
+    // rewritten to the canonical casing. Otherwise validateActiveAccount does
+    // a strict `===` find against the (canonical-cased) account list, fails to
+    // match, and CLEARS the active account (or shows a 0 balance). Only a
+    // byte-identical stored value is a true no-op.
+    if (canonical !== (storedActive ?? '')) return { action: 'set', address: canonical };
     return { action: 'none' };
   }
 

--- a/src/stores/qrlStore.ts
+++ b/src/stores/qrlStore.ts
@@ -42,7 +42,9 @@ type PendingTxInfo = {
 // Transaction status type — exported so token/NFT stores can write into
 // the shared `transactionStatus` slot on this store.
 export type TransactionStatus = {
-  state: 'idle' | 'pending' | 'confirmed' | 'failed';
+  // 'timeout' is distinct from 'failed': the tx was broadcast and may still be
+  // mined; the poller just stopped waiting. Never render it as a failure.
+  state: 'idle' | 'pending' | 'confirmed' | 'failed' | 'timeout';
   txHash: string | null;
   receipt: TransactionReceipt | null;
   error: string | null;
@@ -495,10 +497,21 @@ class QrlStore {
         signerAddresses,
         authoritative,
       });
-      if (decision.action === 'set') {
-        await StorageUtil.setActiveAccount(blockchain, decision.address);
-      } else if (decision.action === 'clear') {
-        await StorageUtil.clearActiveAccount(blockchain);
+      if (decision.action !== 'none') {
+        // Re-read immediately before applying: if a concurrent setActiveAccount
+        // (a user switch) landed during the awaits above, the stored pointer no
+        // longer equals what we based the decision on. The live user selection
+        // wins, so skip this write rather than clobbering it back to the
+        // (now stale) signer snapshot. The next lock/unlock re-hydration
+        // reconciles from a fresh snapshot.
+        const freshActive = await StorageUtil.getActiveAccount(blockchain);
+        if ((freshActive ?? '') !== (storedActive ?? '')) {
+          log('Desktop hydration: active account changed mid-reconcile; skipping adopt.');
+        } else if (decision.action === 'set') {
+          await StorageUtil.setActiveAccount(blockchain, decision.address);
+        } else {
+          await StorageUtil.clearActiveAccount(blockchain);
+        }
       }
     } catch (error) {
       console.error('Desktop wallet hydration: storage reconcile failed:', error);
@@ -939,9 +952,12 @@ class QrlStore {
         this.cancelReceiptPoller();
         runInAction(() => {
           if (this.transactionStatus.state === 'pending' && this.transactionStatus.txHash === txHash) {
+            // 'timeout', NOT 'failed': the tx is broadcast and may still mine.
+            // The UI shows a neutral "still pending" card with the explorer
+            // link, never a red failure.
             this.transactionStatus = {
               ...this.transactionStatus,
-              state: 'failed',
+              state: 'timeout',
               txHash: txHash,
               receipt: null,
               error:


### PR DESCRIPTION
Adversarial review + Gemini follow-ups on #213 / #214.

## Findings fixed
- **F1 (MEDIUM): dApp tx approval had no account binding.** `qrl_sendTransaction`/`qrl_signTransaction` substituted the live active account as `from` with no check against the account the request named, unlike `signMessage`/`signTypedData` which already reject a mismatch. Since #213 auto-flips the active account on unlock, a dApp could get a signature/spend from an account it never asked for. Added the same `Signer mismatch` guard (a dApp that omits `from` still accepts the active account).
- **Gemini HIGH (also a review test-gap): case-only active-account clear.** `decideActiveAccount` branch 1 compared case-insensitively, so a stored active differing from canonical only by case was left as-is and `validateActiveAccount`'s strict `===` find then cleared it (0 balance / lost active). Now a strict compare rewrites to canonical; only a byte-identical value is a no-op.
- **F5 (LOW): watch-only active force-flipped.** Branch 1 stomped a deliberately-selected `extension`/watch-only active account to a signer wallet on every unlock. Now a non-signer selection is left alone.
- **F2 (MEDIUM): hydration TOCTOU.** The adopt decision was made off a stale `signerActive` snapshot and could clobber a concurrent user `setActiveAccount` that landed during its awaits. It now re-reads the active pointer immediately before applying and skips the write if it changed (live selection wins).
- **F3 (MEDIUM): timeout shown as failure.** The 5-minute receipt-poll give-up set `state: 'failed'`, so a slow-but-mined tx was headlined "Transaction Failed". Added a distinct `timeout` state rendered as a neutral amber "Still Pending" card (explorer link + Done), never a red failure.

## Gates
lint clean, jest 204/204, build green.