### PR TITLE
fix(scan): extract QRL address from explorer-URL QR payloads

### DIFF
--- a/src/components/Core/Body/Transfer/Transfer.tsx
+++ b/src/components/Core/Body/Transfer/Transfer.tsx
@@ -49,6 +49,7 @@ import type { FeeLevel } from "@/stores/qrlStore";
 import { SEO } from "@/components/SEO/SEO";
 import { getOptimalTokenBalance, formatAddressShort } from "@/utils/formatting";
 import { fetchBalance } from "@/utils/web3";
+import { extractQrlAddressFromQrPayload } from "@/utils/web3/address";
 import { formatUnits, parseUnits } from "@/utils/web3/units";
 import { BigNumber } from "bignumber.js";
 
@@ -223,12 +224,6 @@ const Transfer = observer(() => {
     return sendable.isPositive() ? sendable.toString() : "0";
   }, [accountBalance, nativeGasReserve, isNativeTransfer]);
 
-  // Validate QRL address format
-  const isValidQRLAddress = useCallback((address: string): boolean => {
-    const trimmed = address.trim();
-    return trimmed.startsWith('Q') && trimmed.length === 41;
-  }, []);
-
   // Handle QR scan request
   const handleScanQR = useCallback(() => {
     if (!isInNativeApp()) return;
@@ -244,11 +239,14 @@ const Transfer = observer(() => {
 
     const unsubscribe = subscribeToNativeMessages((message) => {
       if (message.type === 'QR_RESULT' && message.payload) {
-        const scannedAddress = (message.payload['address'] as string) || '';
+        const scannedPayload = (message.payload['address'] as string) || '';
         setIsScanning(false);
 
-        // Validate the scanned address
-        if (isValidQRLAddress(scannedAddress)) {
+        // Explorer QRs wrap the address in a URL (zondscan encodes
+        // https://zondscan.com/address/<addr>, lowercased), so extract the
+        // address from the payload instead of validating it raw.
+        const scannedAddress = extractQrlAddressFromQrPayload(scannedPayload);
+        if (scannedAddress) {
           // Success - trigger haptic, show success animation, set value
           triggerHaptic('success');
           setScanSuccess(true);
@@ -277,7 +275,7 @@ const Transfer = observer(() => {
     });
 
     return unsubscribe;
-  }, [isValidQRLAddress, setValue, control]);
+  }, [setValue, control]);
 
   if (!accountAddress) {
     return (

--- a/src/components/NativeAppBridge.tsx
+++ b/src/components/NativeAppBridge.tsx
@@ -25,6 +25,7 @@ import { DAppConnectService, dappConnectService } from '@/services/dappConnect/D
 import { WalletEncryptionUtil } from '@/utils/crypto/walletEncryption';
 import { reEncryptSeedAsync, CryptoOperationError, CryptoErrorCode } from '@/utils/crypto';
 import { ROUTES } from '@/router/router';
+import { extractQrlAddressFromQrPayload } from '@/utils/web3/address';
 import StorageUtil from '@/utils/storage/storage';
 import { QRL_PROVIDER } from '@/config';
 import { store } from '@/stores/store';
@@ -168,9 +169,17 @@ const NativeAppBridge: React.FC = () => {
             return;
           }
 
-          // Otherwise, navigate to transfer page with the address
+          // Otherwise, navigate to transfer page with the scanned address.
+          // Explorer QRs wrap it in a URL (zondscan encodes
+          // https://zondscan.com/address/<addr>), so extract rather than
+          // prefill the raw payload.
+          const scanned = extractQrlAddressFromQrPayload(address);
+          if (!scanned) {
+            logToNative(`QR payload has no QRL address: ${address.slice(0, 64)}`);
+            return;
+          }
           const searchParams = new URLSearchParams(location.search);
-          searchParams.set('to', address);
+          searchParams.set('to', scanned);
           navigate(`${ROUTES.TRANSFER}?${searchParams.toString()}`);
           break;
         }

--- a/src/utils/web3/__tests__/address.test.ts
+++ b/src/utils/web3/__tests__/address.test.ts
@@ -1,0 +1,53 @@
+import { extractQrlAddressFromQrPayload, isValidQrlAddress } from '../address';
+
+const ADDR = 'Q20b4fb2929cfBe8b002b8A0c572551F755e54aEF';
+const ADDR_LOWER = `q${ADDR.slice(1).toLowerCase()}`;
+
+describe('extractQrlAddressFromQrPayload', () => {
+  it('accepts a bare address (wallet receive QR)', () => {
+    expect(extractQrlAddressFromQrPayload(ADDR)).toBe(ADDR);
+    expect(extractQrlAddressFromQrPayload(`  ${ADDR}  `)).toBe(ADDR);
+  });
+
+  it('normalizes a bare lowercase-q address to a capital Q', () => {
+    const extracted = extractQrlAddressFromQrPayload(ADDR_LOWER);
+    expect(extracted).toBe(`Q${ADDR.slice(1).toLowerCase()}`);
+    expect(extracted !== null && isValidQrlAddress(extracted)).toBe(true);
+  });
+
+  it('extracts the address from a zondscan URL (whole address lowercased)', () => {
+    const url = `https://zondscan.com/address/${ADDR.toLowerCase()}`;
+    expect(extractQrlAddressFromQrPayload(url)).toBe(`Q${ADDR.slice(1).toLowerCase()}`);
+  });
+
+  it('extracts from a URL with a trailing path or query', () => {
+    expect(
+      extractQrlAddressFromQrPayload(`https://zondscan.com/address/${ADDR}?tab=tokens`)
+    ).toBe(ADDR);
+    expect(extractQrlAddressFromQrPayload(`https://zondscan.com/address/${ADDR}/tokens`)).toBe(
+      ADDR
+    );
+  });
+
+  it('rejects payloads without a QRL address', () => {
+    expect(extractQrlAddressFromQrPayload('')).toBeNull();
+    expect(extractQrlAddressFromQrPayload('hello world')).toBeNull();
+    expect(extractQrlAddressFromQrPayload('https://zondscan.com/blocks')).toBeNull();
+  });
+
+  it('rejects tx-hash URLs (64 hex chars, no Q token)', () => {
+    expect(
+      extractQrlAddressFromQrPayload(
+        'https://zondscan.com/tx/0x2b7a79306678b9a40a26a1871bfb468ac24977d9fc7d725df389df3397919c20'
+      )
+    ).toBeNull();
+  });
+
+  it('deliberately rejects bare 0x addresses (likely another EVM chain)', () => {
+    expect(extractQrlAddressFromQrPayload(`0x${ADDR.slice(1)}`)).toBeNull();
+  });
+
+  it('does not match a Q token embedded in longer hex', () => {
+    expect(extractQrlAddressFromQrPayload(`Q${'ab'.repeat(21)}`)).toBeNull();
+  });
+});

--- a/src/utils/web3/address.ts
+++ b/src/utils/web3/address.ts
@@ -55,6 +55,33 @@ export const normalizeQrlAddress = (address: string): string | null => {
 };
 
 /**
+ * Extracts a QRL address from an arbitrary scanned QR payload.
+ *
+ * Wallet receive QRs encode the bare address, but explorer QRs wrap it:
+ * zondscan encodes `https://zondscan.com/address/<addr>` with the whole
+ * address lowercased (including the `q`). Scan handling therefore extracts
+ * the first Q-prefixed 40-hex token, case-insensitively, instead of
+ * validating the raw payload. 0x-prefixed tokens are deliberately NOT
+ * accepted: a bare hex QR is most likely an address on another EVM chain.
+ *
+ * @param payload - Raw text decoded from the QR code
+ * @returns string | null - The address with a capital `Q`, or null
+ */
+export const extractQrlAddressFromQrPayload = (payload: string): string | null => {
+  if (!payload || typeof payload !== 'string') {
+    return null;
+  }
+
+  const trimmed = payload.trim();
+  if (isValidQrlAddress(trimmed)) {
+    return trimmed;
+  }
+
+  const match = /\b[Qq][0-9a-fA-F]{40}\b/.exec(trimmed);
+  return match ? `Q${match[0].slice(1)}` : null;
+};
+
+/**
  * Gets a user-friendly error message for invalid addresses
  * @param address - The address that failed validation
  * @returns string - Error message explaining the issue


### PR DESCRIPTION
## Problem

The mobile app scanner accepts a wallet receive QR (bare Q address) but rejects a zondscan address QR with 'Scanned QR does not contain a valid QRL address'.

Cause: zondscan's QR encodes the page URL, https://zondscan.com/address/<addr>, and lowercases the whole address including the q (ExplorerFrontend QRCodeModal.tsx). The wallet validated the raw payload as an address, so any wrapped or lowercased form failed.

## Fix

- New util extractQrlAddressFromQrPayload() in src/utils/web3/address.ts: accepts a bare address, otherwise extracts the first Q-prefixed 40-hex token (case-insensitive, word-bounded) and normalizes to a capital Q.
- Bare 0x tokens are deliberately rejected: most likely another EVM chain's address QR.
- Wired into the Transfer scan handler (replaces its inline prefix/length check) and the NativeAppBridge QR fallback, which previously navigated to the transfer page with the raw URL prefilled.

## Gates

lint (0 warnings), jest 212 pass (8 new in address.test.ts), build (tsc + vite) green.