### PR TITLE
feat(desktop): confirming state for dApp transactions (web parity)

### DIFF
--- a/src/components/Core/Body/DAppConnect/DAppApprovalModal.tsx
+++ b/src/components/Core/Body/DAppConnect/DAppApprovalModal.tsx
@@ -22,6 +22,11 @@ import StorageUtil from '@/utils/storage/storage';
 import { getExplorerTxUrl } from '@/config';
 import { formatAddressShort, formatQuantaValue } from '@/utils/formatting';
 import {
+  isReceiptStatusSuccess,
+  QRL_TX_POLLING_CONFIG,
+  waitForTransactionReceipt,
+} from '@/utils/web3/txPolling';
+import {
   bytesToHex,
   computeMessageDigest,
   computeTypedDataDigest,
@@ -225,6 +230,12 @@ const DAppApprovalModal = observer(() => {
           const valueD = txParamsD['value']
             ? BigInt(txParamsD['value'] as string).toString()
             : '0';
+          // The receipt wait below can outlive this approval being current (a
+          // session disconnect promotes the queue mid-poll); always answer the
+          // CAPTURED request, but only paint progress while it is still shown.
+          const isStillCurrent = () =>
+            dappConnectStore.currentApproval?.sessionId === approvalSessionId &&
+            dappConnectStore.currentApproval?.id === approvalId;
           try {
             dappConnectStore.setTxProgress('signing');
             if (method === 'qrl_signTransaction') {
@@ -252,14 +263,56 @@ const DAppApprovalModal = observer(() => {
               },
               dappOrigin,
             );
-            dappConnectStore.setTxProgress('confirmed', transactionHash);
-            dappConnectStore.sendApprovalResultById(approvalSessionId, approvalId, transactionHash);
-            setLoading(false);
+            // Broadcast succeeded; now wait for the on-chain receipt (web
+            // parity: the web path answers the dApp only on the `receipt`
+            // event). The desktop bridge exposes no receipt API, so poll the
+            // renderer's own provider, the same instance the web path uses.
+            dappConnectStore.setTxProgress('confirming', transactionHash);
+
+            const web3ForReceipt = qrlStore.qrlInstance;
+            if (!web3ForReceipt) {
+              // The tx IS broadcast; with no provider to poll, degrade to the
+              // legacy answer-at-broadcast rather than fake a rejection.
+              console.log('[DAppConnect] no web3 instance for receipt polling; answering at broadcast');
+              dappConnectStore.setTxProgress('confirmed', transactionHash);
+              dappConnectStore.sendApprovalResultById(approvalSessionId, approvalId, transactionHash);
+              setLoading(false);
+              return;
+            }
+
+            const outcome = await waitForTransactionReceipt(
+              (hash) => web3ForReceipt.getTransactionReceipt(hash),
+              transactionHash,
+            );
+
+            if (outcome.status === 'receipt' && isReceiptStatusSuccess(outcome.receipt.status)) {
+              if (isStillCurrent()) {
+                dappConnectStore.setTxProgress('confirmed', transactionHash);
+              }
+              // Answer even after a promotion: sending into a gone session is
+              // a logged no-op inside the connect service.
+              dappConnectStore.sendApprovalResultById(approvalSessionId, approvalId, transactionHash);
+              setLoading(false);
+              return;
+            }
+
+            // Reverted or polling window closed: reuse web3's error message
+            // shapes so the shared catch below produces the same user-facing
+            // copy the web path gets from its PromiEvent errors. Unlike web
+            // (which emits `receipt` then `error` for reverted txs and so
+            // double-answers the dApp), this sends a single rejection.
+            throw new Error(
+              outcome.status === 'receipt'
+                ? 'Transaction has been reverted by the QRVM'
+                : `Transaction was not mined within ${QRL_TX_POLLING_CONFIG.transactionPollingTimeout / 1000} seconds`,
+            );
           } catch (e) {
             const errMsg = e instanceof Error ? e.message : String(e);
             console.log('[DAppConnect] desktop tx error:', errMsg);
             const userError = toUserFacingError(errMsg);
-            dappConnectStore.setTxProgress('failed', undefined, userError);
+            if (isStillCurrent()) {
+              dappConnectStore.setTxProgress('failed', undefined, userError);
+            }
             dappConnectStore.sendRejectionResultById(approvalSessionId, approvalId, `Transaction failed: ${userError}`);
             setLoading(false);
           }

--- a/src/components/Core/Body/DAppConnect/DAppApprovalModal.tsx
+++ b/src/components/Core/Body/DAppConnect/DAppApprovalModal.tsx
@@ -276,7 +276,6 @@ const DAppApprovalModal = observer(() => {
               console.log('[DAppConnect] no web3 instance for receipt polling; answering at broadcast');
               dappConnectStore.setTxProgress('confirmed', transactionHash);
               dappConnectStore.sendApprovalResultById(approvalSessionId, approvalId, transactionHash);
-              setLoading(false);
               return;
             }
 
@@ -292,7 +291,6 @@ const DAppApprovalModal = observer(() => {
               // Answer even after a promotion: sending into a gone session is
               // a logged no-op inside the connect service.
               dappConnectStore.sendApprovalResultById(approvalSessionId, approvalId, transactionHash);
-              setLoading(false);
               return;
             }
 
@@ -314,7 +312,6 @@ const DAppApprovalModal = observer(() => {
               dappConnectStore.setTxProgress('failed', undefined, userError);
             }
             dappConnectStore.sendRejectionResultById(approvalSessionId, approvalId, `Transaction failed: ${userError}`);
-            setLoading(false);
           }
           return;
         }

--- a/src/stores/dappConnectStore.ts
+++ b/src/stores/dappConnectStore.ts
@@ -78,6 +78,10 @@ class DAppConnectStore {
           if (this.currentApproval?.sessionId === sessionId) {
             this.currentApproval = null;
             this.approvalModalOpen = false;
+            // A tx may be mid-flight for the dropped approval; without this,
+            // its progress ('confirming'/'failed') leaks onto the next
+            // promoted approval, which starts life in the terminal view.
+            this.resetTxProgress();
           }
         });
       },

--- a/src/utils/web3/__tests__/txPolling.test.ts
+++ b/src/utils/web3/__tests__/txPolling.test.ts
@@ -4,7 +4,11 @@
  * on a future web3 upgrade), and that it genuinely improves on the web3 defaults.
  */
 import Web3 from '@theqrl/web3';
-import { QRL_TX_POLLING_CONFIG } from '../txPolling';
+import {
+  isReceiptStatusSuccess,
+  QRL_TX_POLLING_CONFIG,
+  waitForTransactionReceipt,
+} from '../txPolling';
 
 const PROVIDER = () => new Web3.providers.HttpProvider('http://localhost:8545');
 
@@ -30,5 +34,123 @@ describe('QRL_TX_POLLING_CONFIG', () => {
     expect(qrl.transactionConfirmationBlocks).toBe(24);
     expect(QRL_TX_POLLING_CONFIG.transactionPollingInterval).toBeGreaterThan(qrl.transactionPollingInterval);
     expect(QRL_TX_POLLING_CONFIG.transactionConfirmationBlocks).toBeLessThan(qrl.transactionConfirmationBlocks);
+  });
+});
+
+describe('waitForTransactionReceipt', () => {
+  const HASH = '0x' + 'ab'.repeat(32);
+  const RECEIPT = { status: 1n, transactionHash: HASH };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('resolves with the receipt once getReceipt returns one', async () => {
+    const getReceipt = jest
+      .fn<Promise<typeof RECEIPT | null>, [string]>()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue(RECEIPT);
+
+    const resultPromise = waitForTransactionReceipt(getReceipt, HASH, {
+      intervalMs: 1000,
+      timeoutMs: 10_000,
+    });
+    await jest.advanceTimersByTimeAsync(3000);
+
+    await expect(resultPromise).resolves.toEqual({ status: 'receipt', receipt: RECEIPT });
+    expect(getReceipt).toHaveBeenCalledTimes(3);
+    expect(getReceipt).toHaveBeenCalledWith(HASH);
+  });
+
+  it('treats a thrown getReceipt as still-pending (v2 node throws "transaction not found")', async () => {
+    const getReceipt = jest
+      .fn<Promise<typeof RECEIPT | null>, [string]>()
+      .mockRejectedValueOnce(new Error('transaction not found'))
+      .mockRejectedValueOnce(new Error('transaction not found'))
+      .mockResolvedValue(RECEIPT);
+
+    const resultPromise = waitForTransactionReceipt(getReceipt, HASH, {
+      intervalMs: 1000,
+      timeoutMs: 10_000,
+    });
+    await jest.advanceTimersByTimeAsync(3000);
+
+    await expect(resultPromise).resolves.toEqual({ status: 'receipt', receipt: RECEIPT });
+  });
+
+  it('resolves {status: timeout} after exactly floor(timeout/interval) polls', async () => {
+    const getReceipt = jest.fn<Promise<null>, [string]>().mockResolvedValue(null);
+
+    const resultPromise = waitForTransactionReceipt(getReceipt, HASH, {
+      intervalMs: 1000,
+      timeoutMs: 5500,
+    });
+    await jest.advanceTimersByTimeAsync(6000);
+
+    await expect(resultPromise).resolves.toEqual({ status: 'timeout' });
+    expect(getReceipt).toHaveBeenCalledTimes(5);
+  });
+
+  it('defaults its cadence to QRL_TX_POLLING_CONFIG (waits a full interval before the first poll)', async () => {
+    const getReceipt = jest.fn<Promise<typeof RECEIPT>, [string]>().mockResolvedValue(RECEIPT);
+
+    const resultPromise = waitForTransactionReceipt(getReceipt, HASH);
+    await jest.advanceTimersByTimeAsync(QRL_TX_POLLING_CONFIG.transactionPollingInterval - 1);
+    expect(getReceipt).not.toHaveBeenCalled();
+
+    await jest.advanceTimersByTimeAsync(1);
+    await expect(resultPromise).resolves.toEqual({ status: 'receipt', receipt: RECEIPT });
+    expect(getReceipt).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops polling after resolution', async () => {
+    const getReceipt = jest.fn<Promise<typeof RECEIPT>, [string]>().mockResolvedValue(RECEIPT);
+
+    const resultPromise = waitForTransactionReceipt(getReceipt, HASH, {
+      intervalMs: 1000,
+      timeoutMs: 10_000,
+    });
+    await jest.advanceTimersByTimeAsync(1000);
+    await resultPromise;
+
+    await jest.advanceTimersByTimeAsync(10_000);
+    expect(getReceipt).toHaveBeenCalledTimes(1);
+  });
+
+  it('polls at least once even when timeoutMs < intervalMs', async () => {
+    const getReceipt = jest.fn<Promise<typeof RECEIPT>, [string]>().mockResolvedValue(RECEIPT);
+
+    const resultPromise = waitForTransactionReceipt(getReceipt, HASH, {
+      intervalMs: 1000,
+      timeoutMs: 500,
+    });
+    await jest.advanceTimersByTimeAsync(1000);
+
+    await expect(resultPromise).resolves.toEqual({ status: 'receipt', receipt: RECEIPT });
+    expect(getReceipt).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('isReceiptStatusSuccess', () => {
+  it.each([
+    [1n, true],
+    [0n, false], // web3's exact revert check: status === BigInt(0)
+    [1, true],
+    [0, false],
+    [true, true],
+    [false, false],
+    ['0x1', true],
+    ['0x0', false],
+    ['1', true],
+    ['0', false],
+    [undefined, true], // absent status counts as success, like web3
+    [null, true],
+  ])('%p -> %p', (status, expected) => {
+    expect(isReceiptStatusSuccess(status)).toBe(expected);
   });
 });

--- a/src/utils/web3/txPolling.ts
+++ b/src/utils/web3/txPolling.ts
@@ -10,17 +10,85 @@
  * These values poll every 7s and require a single confirmation, cutting it to
  * roughly ~10 RPC calls per tx. The user-facing "confirmed" state fires on the
  * `receipt` event (first inclusion), which is unaffected by
- * `transactionConfirmationBlocks` — that only controls how long web3 keeps
+ * `transactionConfirmationBlocks`: that only controls how long web3 keeps
  * watching for additional confirmations afterward.
  *
  * NOTE on units: in web3.js 4.x BOTH `transactionPollingInterval` and
  * `transactionPollingTimeout` are MILLISECONDS (the default timeout is
  * `750 * 1000`, and web3 divides it by 1000 only to render the seconds in its
- * timeout error). This differs from web3.js 1.x where the timeout was seconds —
+ * timeout error). This differs from web3.js 1.x where the timeout was seconds:
  * do not "convert" the timeout to seconds.
  */
 export const QRL_TX_POLLING_CONFIG = {
   transactionPollingInterval: 7000, // ms
   transactionConfirmationBlocks: 1,
-  transactionPollingTimeout: 7 * 60 * 1000, // ms (7 min, ~7 blocks) — NOT seconds
+  transactionPollingTimeout: 7 * 60 * 1000, // ms (7 min, ~7 blocks), NOT seconds
 };
+
+export interface WaitForReceiptOptions {
+  /** Poll cadence in ms. Default: QRL_TX_POLLING_CONFIG.transactionPollingInterval. */
+  intervalMs?: number;
+  /** Total polling window in ms. Default: QRL_TX_POLLING_CONFIG.transactionPollingTimeout. */
+  timeoutMs?: number;
+}
+
+export type WaitForReceiptResult<R> = { status: 'receipt'; receipt: R } | { status: 'timeout' };
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Poll for a transaction receipt by hash until it lands or the window closes.
+ *
+ * Hash-only counterpart to web3's PromiEvent receipt wait, for flows that get
+ * a bare hash back (e.g. the desktop signer broadcasts in the main process and
+ * returns only `transactionHash`). `getReceipt` is injected so callers choose
+ * the provider and tests need no web3 instance.
+ *
+ * A THROWN `getReceipt` is treated as "not yet mined", never a failure: the
+ * QRL v2 node throws "transaction not found" for pending transactions instead
+ * of returning null (see qrlStore.pollForReceipt for the same tolerance).
+ *
+ * Waits before the first poll: on a ~60s-block chain no receipt can exist the
+ * instant after broadcast.
+ */
+export async function waitForTransactionReceipt<R>(
+  getReceipt: (txHash: string) => Promise<R | null | undefined>,
+  txHash: string,
+  options: WaitForReceiptOptions = {},
+): Promise<WaitForReceiptResult<R>> {
+  const intervalMs = options.intervalMs ?? QRL_TX_POLLING_CONFIG.transactionPollingInterval;
+  const timeoutMs = options.timeoutMs ?? QRL_TX_POLLING_CONFIG.transactionPollingTimeout;
+  const attempts = Math.max(1, Math.floor(timeoutMs / intervalMs));
+
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    await sleep(intervalMs);
+    try {
+      const receipt = await getReceipt(txHash);
+      if (receipt) {
+        return { status: 'receipt', receipt };
+      }
+    } catch {
+      // still pending (v2 node throws instead of returning null)
+    }
+  }
+
+  return { status: 'timeout' };
+}
+
+/**
+ * Whether a receipt's `status` field indicates success. Mirrors web3's revert
+ * check (`transactionReceipt.status === BigInt(0)` means reverted; an absent
+ * status counts as success), tolerant of the bigint/number/boolean/hex-string
+ * shapes different return formats produce.
+ */
+export function isReceiptStatusSuccess(status: unknown): boolean {
+  if (status === undefined || status === null) return true;
+  if (typeof status === 'bigint') return status !== BigInt(0);
+  if (typeof status === 'number') return status !== 0;
+  if (typeof status === 'boolean') return status;
+  if (typeof status === 'string') {
+    const parsed = Number.parseInt(status, status.startsWith('0x') ? 16 : 10);
+    return Number.isNaN(parsed) ? true : parsed !== 0;
+  }
+  return true;
+}


### PR DESCRIPTION
## Problem

On desktop, a dApp qrl_sendTransaction goes sign -> broadcast -> instant green 'confirmed', and the dApp is answered at broadcast time. Web/mobile do this correctly: broadcast -> orange 'Awaiting confirmation...' -> 'confirmed' + dApp answered only when the on-chain receipt lands. Observed during QuantaSwap HTLC testing: desktop said done while the lock tx was still unmined (or reverting, pre desktop PR #18).

## Fix

- New hash-only receipt helper in src/utils/web3/txPolling.ts: waitForTransactionReceipt(getReceipt, hash, opts) with QRL_TX_POLLING_CONFIG cadence (7s x 60 = 420s), treating thrown getReceipt as still-pending (the v2 node throws 'transaction not found' for pending txs), plus isReceiptStatusSuccess mirroring web3's status === BigInt(0) revert check. getReceipt is injected; tests need no web3.
- Desktop branch of DAppApprovalModal: after desktopSigner.signAndSendTransaction returns the hash, set 'confirming' and poll qrlStore.qrlInstance (the same provider the web path uses; desktop CSP already allows it, the non-dApp Transfer flow polls with it today). Success receipt -> 'confirmed' + sendApprovalResultById (dApp gets its hash at receipt, web parity). Reverted/timeout -> throw into the existing catch with web3's message shapes -> 'failed' + rejection.
- Adjacent leak fix (affects web too): onSessionDisconnected cleared currentApproval without resetTxProgress(), so a mid-tx disconnect painted stale 'confirming'/'failed' onto the next promoted approval.

## Deliberate deviations, flagged

- Reverted txs: web's PromiEvent emits receipt THEN error, so the dApp gets an approve followed by a reject for the same request (web3 quirk). Desktop sends a single rejection with the same message shape ('Transaction has been reverted by the QRVM').
- qrlStore.pollForReceipt left untouched: it has external cancellation, transactionStatus gating, and soft 'timeout' semantics that the dApp path does not want.

## Gates

tsc --noEmit, lint (0 warnings), jest 230 pass (18 new in txPolling.test.ts), build: all green.

## Manual verification pending

Desktop run against QuantaSwap (with desktop PR #18's gas fix): expect signing -> broadcasting -> orange awaiting-confirmation (dismissal blocked, explorer link) -> green after ~1 block, dApp step advancing only at receipt.