### PR TITLE
feat(dapp-connect): in-browser pairing for the web wallet

### DIFF
--- a/src/components/Core/Body/DAppConnect/DAppConnectConsentModal.tsx
+++ b/src/components/Core/Body/DAppConnect/DAppConnectConsentModal.tsx
@@ -102,7 +102,9 @@ const DAppConnectConsentModal = observer(() => {
           <DialogDescription>
             {source === 'paste'
               ? 'You pasted a dApp connection code.'
-              : 'A dApp is requesting to connect to your wallet via QRL Connect.'}
+              : source === 'link'
+                ? 'You opened a dApp connection link. The dApp may be open in another tab or on another device.'
+                : 'A dApp is requesting to connect to your wallet via QRL Connect.'}
           </DialogDescription>
         </DialogHeader>
 
@@ -113,8 +115,8 @@ const DAppConnectConsentModal = observer(() => {
           <p>
             Connecting shares your active account address with the dApp. Its
             name and site are only verified after the encrypted channel is
-            established. Only continue if you just clicked Connect in a dApp
-            or pasted its connection code yourself.
+            established. Only continue if you just clicked Connect in a dApp,
+            opened its connection link, or pasted its connection code yourself.
           </p>
           {error && <p className="text-destructive">{error}</p>}
         </div>

--- a/src/components/Core/Body/DAppConnect/DAppSessionsList.tsx
+++ b/src/components/Core/Body/DAppConnect/DAppSessionsList.tsx
@@ -11,6 +11,7 @@ import { Input } from '@/components/UI/Input';
 import { SessionStatus } from '@/services/dappConnect/types';
 import { DAppConnectService } from '@/services/dappConnect/DAppConnectService';
 import { isDesktop } from '@/desktop/bridge';
+import { isInNativeApp } from '@/utils/nativeApp';
 
 const statusDotColors: Record<SessionStatus, string> = {
   [SessionStatus.CONNECTED]: '#3b82f6',     // blue-500
@@ -52,10 +53,11 @@ const DAppPulsingDot = ({ status }: { status: SessionStatus }) => {
 };
 
 /**
- * Desktop-only paste entry: the fallback ingress when the qrlconnect://
- * protocol handler is unavailable (unregistered, blocked, or the dApp is on
- * another machine so only its QR/URI text can travel). Feeds the exact same
- * consent modal as the deep link; no relay contact happens here.
+ * Paste entry (desktop + web): the fallback ingress when neither the
+ * qrlconnect:// protocol handler nor the web fragment link is available
+ * (unregistered, blocked, or the dApp is on another machine so only its
+ * QR/URI text can travel). Feeds the exact same consent modal as the other
+ * ingresses; no relay contact happens here.
  */
 const DesktopPasteConnect = observer(() => {
   const { dappConnectStore } = useStore();
@@ -145,13 +147,15 @@ const DAppSessionsList = observer(() => {
         )}
       </div>
 
-      {isDesktop && <DesktopPasteConnect />}
+      {(isDesktop || !isInNativeApp()) && <DesktopPasteConnect />}
 
       {activeSessions.length === 0 ? (
         <p className="text-sm text-muted-foreground">
           {isDesktop
             ? 'No dApps connected. Click "Open in MyQRLWallet" in a dApp, or paste its connection code above.'
-            : 'No dApps connected. Scan a QR code from a dApp to connect.'}
+            : isInNativeApp()
+              ? 'No dApps connected. Scan a QR code from a dApp to connect.'
+              : 'No dApps connected. Open a connection link from a dApp, or paste its connection code above.'}
         </p>
       ) : (
         <div className="space-y-3">

--- a/src/components/Core/MyQRLWallet.tsx
+++ b/src/components/Core/MyQRLWallet.tsx
@@ -6,17 +6,26 @@ import { useNavigate } from "react-router-dom";
 import { setupActivityTracking, startAutoLockTimer, clearAutoLockTimer } from "@/utils/storage";
 import NativeAppBridge from "@/components/NativeAppBridge";
 import { isDesktop } from "@/desktop/bridge";
+import { isInNativeApp } from "@/utils/nativeApp";
 import Layout from "./Layout/Layout";
 import Body from "./Body/Body";
 
-// DApp modals are only shown when an active dApp session sends a request —
+// DApp modals are only shown when an active dApp session sends a request;
 // lazy-load them so their @theqrl/web3 dependency doesn't block the
 // MyQRLWallet chunk from rendering on normal page loads.
 const DAppApprovalModal = withSuspense(lazy(() => import("./Body/DAppConnect/DAppApprovalModal")));
 const DAppConnectionBanner = withSuspense(lazy(() => import("./Body/DAppConnect/DAppConnectionBanner")));
-// Desktop-only: qrlconnect:// protocol-handler ingress + consent modal.
+// Desktop-only: qrlconnect:// protocol-handler ingress (subscription only).
 // Lazy so the web build never loads it (isDesktop is false there).
 const DesktopDAppBridge = withSuspense(lazy(() => import("@/components/DesktopDAppBridge")));
+// Web-only: #qrlconnect= fragment ingress ("Open web wallet" dApp handoff).
+const WebDAppIngress = withSuspense(lazy(() => import("@/components/WebDAppIngress")));
+// Consent gate for staged connect URIs (desktop deep link/paste, web
+// link/paste). Single global mount so the two ingresses can never
+// double-mount it; the native app consents via the physical QR scan instead.
+const DAppConnectConsentModal = withSuspense(
+  lazy(() => import("./Body/DAppConnect/DAppConnectConsentModal"))
+);
 
 const MyQRLWallet = observer(() => {
   const navigate = useNavigate();
@@ -39,6 +48,8 @@ const MyQRLWallet = observer(() => {
       <RouteMonitor />
       <NativeAppBridge />
       {isDesktop && <DesktopDAppBridge />}
+      {!isDesktop && !isInNativeApp() && <WebDAppIngress />}
+      {!isInNativeApp() && <DAppConnectConsentModal />}
       {/* Desktop surfaces connections via the sidebar dApps item + Settings
           instead of a strip floating over the wallet; web/mobile keep the
           banner as their always-visible affordance. */}

--- a/src/components/DesktopDAppBridge.tsx
+++ b/src/components/DesktopDAppBridge.tsx
@@ -6,17 +6,16 @@
  *    protocol handler, cold or warm start) and stages them behind the
  *    consent modal (dappConnectStore.requestDesktopConnect); the modal is
  *    the single gate before any relay contact.
- *  - renders that consent modal.
  *
- * Main already shape-validates and rate-limits the URIs; parsing and
- * fingerprint pinning happen in the audited dApp-connect stack only after
- * the user consents.
+ * The consent modal itself is mounted once, globally, in MyQRLWallet (it is
+ * shared with the web fragment/paste ingress). Main already shape-validates
+ * and rate-limits the URIs; parsing and fingerprint pinning happen in the
+ * audited dApp-connect stack only after the user consents.
  */
 
 import { useEffect } from 'react';
 import { useStore } from '@/stores/store';
 import { desktopSigner, isDesktop } from '@/desktop/bridge';
-import DAppConnectConsentModal from './Core/Body/DAppConnect/DAppConnectConsentModal';
 
 const DesktopDAppBridge = () => {
   const { dappConnectStore } = useStore();
@@ -29,8 +28,7 @@ const DesktopDAppBridge = () => {
     return unsubscribe;
   }, [dappConnectStore]);
 
-  if (!isDesktop) return null;
-  return <DAppConnectConsentModal />;
+  return null;
 };
 
 export default DesktopDAppBridge;

--- a/src/components/WebDAppIngress.tsx
+++ b/src/components/WebDAppIngress.tsx
@@ -26,15 +26,27 @@ const WebDAppIngress = () => {
 
   useEffect(() => {
     if (isDesktop || isInNativeApp()) return;
-    const hash = window.location.hash;
-    if (!fragmentHasPairingKey(hash)) return;
-    const uri = extractPairingUriFromFragment(hash);
-    window.history.replaceState(null, '', window.location.pathname + window.location.search);
-    if (uri !== null) {
-      dappConnectStore.requestDesktopConnect(uri, 'link');
-    } else {
-      console.warn('[DAppConnect] ignoring malformed qrlconnect fragment');
-    }
+
+    const consumeFragment = () => {
+      const hash = window.location.hash;
+      if (!fragmentHasPairingKey(hash)) return;
+      const uri = extractPairingUriFromFragment(hash);
+      window.history.replaceState(null, '', window.location.pathname + window.location.search);
+      if (uri !== null) {
+        dappConnectStore.requestDesktopConnect(uri, 'link');
+      } else {
+        console.warn('[DAppConnect] ignoring malformed qrlconnect fragment');
+      }
+    };
+
+    // On mount (fresh tab), and on hashchange: a link that navigates an
+    // ALREADY-open wallet tab to the same path with a new fragment does not
+    // reload the page, it only fires hashchange.
+    consumeFragment();
+    window.addEventListener('hashchange', consumeFragment);
+    return () => {
+      window.removeEventListener('hashchange', consumeFragment);
+    };
   }, [dappConnectStore]);
 
   return null;

--- a/src/components/WebDAppIngress.tsx
+++ b/src/components/WebDAppIngress.tsx
@@ -1,0 +1,43 @@
+/**
+ * Web dApp-connect ingress (analogue of DesktopDAppBridge for the plain
+ * browser build). Mounted only outside the desktop shell and the native app:
+ *
+ *  - reads a `#qrlconnect=<encoded uri>` fragment left by a dApp's
+ *    "Open web wallet" link, scrubs it from the address bar FIRST (the URI
+ *    is a bearer pairing offer; scrub-first also makes StrictMode's double
+ *    effect run a no-op), then stages it behind the consent modal
+ *    (dappConnectStore.requestDesktopConnect). The modal remains the single
+ *    gate before any relay contact.
+ *
+ * Desktop must never mount this: its hash router owns the fragment.
+ */
+
+import { useEffect } from 'react';
+import { useStore } from '@/stores/store';
+import { isDesktop } from '@/desktop/bridge';
+import { isInNativeApp } from '@/utils/nativeApp';
+import {
+  extractPairingUriFromFragment,
+  fragmentHasPairingKey,
+} from '@/services/dappConnect/fragmentIngress';
+
+const WebDAppIngress = () => {
+  const { dappConnectStore } = useStore();
+
+  useEffect(() => {
+    if (isDesktop || isInNativeApp()) return;
+    const hash = window.location.hash;
+    if (!fragmentHasPairingKey(hash)) return;
+    const uri = extractPairingUriFromFragment(hash);
+    window.history.replaceState(null, '', window.location.pathname + window.location.search);
+    if (uri !== null) {
+      dappConnectStore.requestDesktopConnect(uri, 'link');
+    } else {
+      console.warn('[DAppConnect] ignoring malformed qrlconnect fragment');
+    }
+  }, [dappConnectStore]);
+
+  return null;
+};
+
+export default WebDAppIngress;

--- a/src/components/WebDAppIngress.tsx
+++ b/src/components/WebDAppIngress.tsx
@@ -2,11 +2,15 @@
  * Web dApp-connect ingress (analogue of DesktopDAppBridge for the plain
  * browser build). Mounted only outside the desktop shell and the native app:
  *
- *  - reads a `#qrlconnect=<encoded uri>` fragment left by a dApp's
- *    "Open web wallet" link, scrubs it from the address bar FIRST (the URI
- *    is a bearer pairing offer; scrub-first also makes StrictMode's double
- *    effect run a no-op), then stages it behind the consent modal
- *    (dappConnectStore.requestDesktopConnect). The modal remains the single
+ *  - consumes the `#qrlconnect=<encoded uri>` fragment a dApp's
+ *    "Open web wallet" link left in the URL. The fresh-tab case is captured
+ *    and scrubbed synchronously at app entry (fragmentCapture.ts, before
+ *    RouteMonitor's restore-navigation can erase it); this component picks
+ *    up that stash on mount and additionally handles hashchange, because a
+ *    link that navigates an ALREADY-open wallet tab to the same path with a
+ *    new fragment does not reload the page.
+ *  - stages valid URIs behind the consent modal
+ *    (dappConnectStore.requestDesktopConnect); the modal remains the single
  *    gate before any relay contact.
  *
  * Desktop must never mount this: its hash router owns the fragment.
@@ -16,6 +20,10 @@ import { useEffect } from 'react';
 import { useStore } from '@/stores/store';
 import { isDesktop } from '@/desktop/bridge';
 import { isInNativeApp } from '@/utils/nativeApp';
+import {
+  rawLocationHash,
+  takeCapturedFragment,
+} from '@/services/dappConnect/fragmentCapture';
 import {
   extractPairingUriFromFragment,
   fragmentHasPairingKey,
@@ -27,11 +35,8 @@ const WebDAppIngress = () => {
   useEffect(() => {
     if (isDesktop || isInNativeApp()) return;
 
-    const consumeFragment = () => {
-      const hash = window.location.hash;
-      if (!fragmentHasPairingKey(hash)) return;
+    const stage = (hash: string) => {
       const uri = extractPairingUriFromFragment(hash);
-      window.history.replaceState(null, '', window.location.pathname + window.location.search);
       if (uri !== null) {
         dappConnectStore.requestDesktopConnect(uri, 'link');
       } else {
@@ -39,13 +44,28 @@ const WebDAppIngress = () => {
       }
     };
 
-    // On mount (fresh tab), and on hashchange: a link that navigates an
-    // ALREADY-open wallet tab to the same path with a new fragment does not
-    // reload the page, it only fires hashchange.
-    consumeFragment();
-    window.addEventListener('hashchange', consumeFragment);
+    // Fresh tab: the fragment was captured and scrubbed at app entry.
+    const captured = takeCapturedFragment();
+    if (captured !== null) stage(captured);
+
+    // Already-open tab: same-path navigation with a new fragment only fires
+    // hashchange. Scrub first (bearer offer; also makes re-entry a no-op),
+    // preserving the router's history state.
+    const onHashChange = () => {
+      const hash = rawLocationHash();
+      if (!fragmentHasPairingKey(hash)) return;
+      window.history.replaceState(
+        window.history.state,
+        '',
+        window.location.pathname + window.location.search
+      );
+      stage(hash);
+    };
+
+    onHashChange();
+    window.addEventListener('hashchange', onHashChange);
     return () => {
-      window.removeEventListener('hashchange', consumeFragment);
+      window.removeEventListener('hashchange', onHashChange);
     };
   }, [dappConnectStore]);
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,12 @@
 import { Buffer } from 'buffer';
 globalThis.Buffer = Buffer;
 
+// Must run before the router mounts: RouteMonitor's restore-navigation would
+// otherwise erase a #qrlconnect= pairing fragment (and leave the bearer URI
+// in history) before the lazy web ingress loads.
+import { captureQrlconnectFragment } from '@/services/dappConnect/fragmentCapture';
+captureQrlconnectFragment();
+
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { HelmetProvider } from 'react-helmet-async'

--- a/src/services/dappConnect/__tests__/fragmentIngress.test.ts
+++ b/src/services/dappConnect/__tests__/fragmentIngress.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Unit tests for the web fragment ingress parser: the #qrlconnect= handoff
+ * a dApp's "Open web wallet" link leaves in location.hash.
+ *
+ * DAppConnectService is mocked at the module seam for the same reason as in
+ * dappConnectStore.test.ts: its real module transitively imports the wallet
+ * store graph, which jest's node runtime cannot load. The mock mirrors the
+ * real one-line scheme regex.
+ */
+
+import { describe, it, expect, jest } from '@jest/globals';
+
+jest.mock('@/services/dappConnect/DAppConnectService', () => {
+  class DAppConnectService {
+    static isConnectionURI(uri: string): boolean {
+      return /^qrlconnect:/i.test(uri);
+    }
+  }
+  return { DAppConnectService };
+});
+
+import {
+  extractPairingUriFromFragment,
+  fragmentHasPairingKey,
+} from '@/services/dappConnect/fragmentIngress';
+
+// Payload with URI-hostile characters: its own query params (&), a literal
+// %25 / %26, and a + that must survive the round trip un-mangled.
+const URI = 'qrlconnect://?q=blob%25data&r=https://relay.example/path?a=1&b=2&plus=1+1&pct=%26';
+
+describe('extractPairingUriFromFragment', () => {
+  it('round-trips an encodeURIComponent-encoded URI without double-decoding', () => {
+    expect(extractPairingUriFromFragment(`#qrlconnect=${encodeURIComponent(URI)}`)).toBe(URI);
+  });
+
+  it('finds the key among other fragment params', () => {
+    const hash = `#foo=1&qrlconnect=${encodeURIComponent(URI)}&bar=2`;
+    expect(extractPairingUriFromFragment(hash)).toBe(URI);
+  });
+
+  it('accepts input without the leading #', () => {
+    expect(extractPairingUriFromFragment(`qrlconnect=${encodeURIComponent(URI)}`)).toBe(URI);
+  });
+
+  it.each([['', 'empty string'], ['#', 'bare hash'], ['#foo=1', 'no qrlconnect key']])(
+    'returns null for %s (%s)',
+    (hash) => {
+      expect(extractPairingUriFromFragment(hash)).toBeNull();
+    }
+  );
+
+  it('returns null for a non-qrlconnect value', () => {
+    const hash = `#qrlconnect=${encodeURIComponent('https://evil.example/?q=x')}`;
+    expect(extractPairingUriFromFragment(hash)).toBeNull();
+  });
+});
+
+describe('fragmentHasPairingKey', () => {
+  it('is true even when the value is invalid (so the caller still scrubs it)', () => {
+    expect(fragmentHasPairingKey('#qrlconnect=junk')).toBe(true);
+  });
+
+  it('is false when the key is absent', () => {
+    expect(fragmentHasPairingKey('#foo=1&bar=2')).toBe(false);
+    expect(fragmentHasPairingKey('')).toBe(false);
+  });
+});

--- a/src/services/dappConnect/fragmentCapture.ts
+++ b/src/services/dappConnect/fragmentCapture.ts
@@ -1,0 +1,53 @@
+/**
+ * Startup capture for the #qrlconnect= web pairing fragment.
+ *
+ * Must run synchronously at app entry, BEFORE the router mounts:
+ * RouteMonitor navigates on mount (restoring the last active page), which
+ * would otherwise discard the fragment before the lazy ingress chunk loads
+ * AND leave the bearer URI in an intact history entry. Capturing here
+ * scrubs the address bar immediately and stashes the raw hash for
+ * WebDAppIngress to validate and stage once React is up.
+ *
+ * Deliberately import-light (no dApp-connect service graph) so it is safe
+ * in the entry chunk. Reads the hash via new URL(href) rather than
+ * location.hash: Firefox percent-decodes the latter, which would corrupt
+ * encoded URIs before parsing.
+ */
+
+import { isDesktop } from '@/desktop/bridge';
+import { isInNativeApp } from '@/utils/nativeApp';
+
+export const FRAGMENT_KEY = 'qrlconnect';
+
+let capturedHash: string | null = null;
+
+/** The raw (undecoded) fragment of the current URL, without Firefox's
+ *  location.hash percent-decoding. */
+export const rawLocationHash = (): string => new URL(window.location.href).hash;
+
+const hasFragmentKey = (hash: string): boolean =>
+  new URLSearchParams(hash.startsWith('#') ? hash.slice(1) : hash).has(FRAGMENT_KEY);
+
+/**
+ * Web builds only: if the URL carries a qrlconnect fragment, stash it and
+ * scrub it from the address bar (preserving the history state object so
+ * the router's entry bookkeeping survives). Idempotent.
+ */
+export function captureQrlconnectFragment(): void {
+  if (typeof window === 'undefined' || isDesktop || isInNativeApp()) return;
+  const hash = rawLocationHash();
+  if (!hasFragmentKey(hash)) return;
+  capturedHash = hash;
+  window.history.replaceState(
+    window.history.state,
+    '',
+    window.location.pathname + window.location.search
+  );
+}
+
+/** Hand the stashed fragment to the ingress exactly once. */
+export function takeCapturedFragment(): string | null {
+  const hash = capturedHash;
+  capturedHash = null;
+  return hash;
+}

--- a/src/services/dappConnect/fragmentIngress.ts
+++ b/src/services/dappConnect/fragmentIngress.ts
@@ -1,0 +1,37 @@
+/**
+ * Web-only pairing ingress: parsing helpers for the URL-fragment handoff.
+ *
+ * A dApp opens `https://qrlwallet.com/dapp-sessions#qrlconnect=<enc(uri)>`.
+ * The pairing URI is a bearer offer, so it travels in the fragment (never
+ * sent to servers, absent from referrers) and the caller scrubs it from the
+ * address bar before staging it behind the consent modal.
+ */
+
+import { DAppConnectService } from './DAppConnectService';
+
+export const FRAGMENT_PARAM = 'qrlconnect';
+
+const paramsFromHash = (hash: string): URLSearchParams =>
+  new URLSearchParams(hash.startsWith('#') ? hash.slice(1) : hash);
+
+/**
+ * Extract a pairing URI from a location.hash-shaped string. Returns null
+ * when the key is absent or the value is not a qrlconnect:// URI.
+ *
+ * Note: URLSearchParams already percent-decodes; decoding again here would
+ * corrupt URIs whose payload contains literal %xx sequences.
+ */
+export function extractPairingUriFromFragment(hash: string): string | null {
+  const value = paramsFromHash(hash).get(FRAGMENT_PARAM);
+  if (value === null) return null;
+  return DAppConnectService.isConnectionURI(value) ? value : null;
+}
+
+/**
+ * Whether the fragment carries the pairing key at all (valid or not); the
+ * ingress scrubs the fragment whenever this is true, so even a malformed
+ * bearer-looking blob never lingers in the address bar.
+ */
+export function fragmentHasPairingKey(hash: string): boolean {
+  return paramsFromHash(hash).has(FRAGMENT_PARAM);
+}

--- a/src/stores/__tests__/dappConnectStore.test.ts
+++ b/src/stores/__tests__/dappConnectStore.test.ts
@@ -137,6 +137,21 @@ describe('requestDesktopConnect', () => {
     expect(store.desktopConnectUri).toBe(URI_B);
     expect(store.desktopConnectSource).toBe('paste');
   });
+
+  it('stages a web fragment-link URI with the link source', () => {
+    const store = new DAppConnectStore();
+    store.requestDesktopConnect(URI_A, 'link');
+    expect(store.desktopConnectUri).toBe(URI_A);
+    expect(store.desktopConnectSource).toBe('link');
+  });
+
+  it('latest request wins across web sources too (link then paste)', () => {
+    const store = new DAppConnectStore();
+    store.requestDesktopConnect(URI_A, 'link');
+    store.requestDesktopConnect(URI_B, 'paste');
+    expect(store.desktopConnectUri).toBe(URI_B);
+    expect(store.desktopConnectSource).toBe('paste');
+  });
 });
 
 describe('clearDesktopConnect', () => {
@@ -168,6 +183,13 @@ describe('confirmDesktopConnect', () => {
   it('maps a paste source to the qr origin (dApp may be on another device)', async () => {
     const store = new DAppConnectStore();
     store.requestDesktopConnect(URI_A, 'paste');
+    await store.confirmDesktopConnect();
+    expect(mockService.handleConnectionURI).toHaveBeenCalledWith(URI_A, 'qr');
+  });
+
+  it('maps a web link source to the qr origin (dApp may be in another tab)', async () => {
+    const store = new DAppConnectStore();
+    store.requestDesktopConnect(URI_A, 'link');
     await store.confirmDesktopConnect();
     expect(mockService.handleConnectionURI).toHaveBeenCalledWith(URI_A, 'qr');
   });

--- a/src/stores/dappConnectStore.ts
+++ b/src/stores/dappConnectStore.ts
@@ -10,8 +10,12 @@ import { isDesktop, desktopSigner } from '@/desktop/bridge';
 
 export type TxProgressState = 'idle' | 'signing' | 'broadcasting' | 'confirming' | 'confirmed' | 'failed';
 
-/** How a desktop connect URI reached the wallet (protocol handler vs paste). */
-export type DesktopConnectSource = 'deeplink' | 'paste';
+/**
+ * How a staged connect URI reached the wallet: the desktop OS protocol
+ * handler ('deeplink'), the paste field ('paste', desktop + web), or a web
+ * fragment link ('link', a dApp's "Open web wallet" handoff).
+ */
+export type DesktopConnectSource = 'deeplink' | 'paste' | 'link';
 
 class DAppConnectStore {
   activeSessions: DAppSession[] = [];
@@ -27,9 +31,10 @@ class DAppConnectStore {
   txHash: string | null = null;
   txError: string | null = null;
   /**
-   * Desktop only: a qrlconnect:// URI awaiting the user's consent (from the
-   * OS protocol handler or the paste field). The consent modal observes this;
-   * NO relay contact happens until the user confirms. Latest request wins.
+   * Desktop + web: a qrlconnect:// URI awaiting the user's consent (from the
+   * OS protocol handler, the paste field, or a web fragment link). The
+   * consent modal observes this; NO relay contact happens until the user
+   * confirms. Latest request wins.
    */
   desktopConnectUri: string | null = null;
   desktopConnectSource: DesktopConnectSource = 'deeplink';
@@ -101,9 +106,10 @@ class DAppConnectStore {
   }
 
   /**
-   * Desktop: stage a qrlconnect:// URI behind the consent modal. Called by
-   * the protocol-handler bridge and the paste field; the consent modal is the
-   * single gate before any relay contact.
+   * Stage a qrlconnect:// URI behind the consent modal. Called by the desktop
+   * protocol-handler bridge, the paste field (desktop + web), and the web
+   * fragment ingress; the consent modal is the single gate before any relay
+   * contact.
    */
   requestDesktopConnect(uri: string, source: DesktopConnectSource = 'deeplink'): void {
     if (!DAppConnectService.isConnectionURI(uri)) {
@@ -122,10 +128,11 @@ class DAppConnectStore {
   }
 
   /**
-   * Desktop: user consented in the modal. Runs the normal connect path; the
+   * User consented in the modal. Runs the normal connect path; the
    * 'deeplink' origin only ever gates the native return-to-dApp redirect,
-   * which is a no-op outside the mobile app, so paste + deeplink both map to
-   * their honest origin ('qr' for paste: the dApp may be on another device).
+   * which is a no-op outside the mobile app. Paste and web-link sources map
+   * to the honest 'qr' origin: the dApp may be in another tab or on another
+   * device.
    */
   async confirmDesktopConnect(): Promise<{ success: boolean; error?: string }> {
     const uri = this.desktopConnectUri;


### PR DESCRIPTION
## What

Gives the plain-browser web wallet an ingress for dApp pairing URIs (today only desktop and the mobile app have one), per the approved plan.

- **Fragment link (primary UX)**: a dApp opens `/dapp-sessions#qrlconnect=<encodeURIComponent(uri)>`. New `WebDAppIngress` (web-only mount) reads the fragment, scrubs it from the address bar with `history.replaceState` BEFORE staging (the URI is a bearer pairing offer: fragment never reaches servers, scrubbing keeps it out of history; scrub-first also makes React StrictMode double-runs no-ops), validates, and stages via the existing `requestDesktopConnect(uri, 'link')`.
- **Paste box on web**: the dApp Sessions paste entry is un-gated from desktop-only to desktop + web (still hidden inside the native app, where scanning is the flow).
- **Single consent-modal mount**: `DAppConnectConsentModal` moves from `DesktopDAppBridge` to one global mount in `MyQRLWallet` shared by all ingresses, so double-mounting is structurally impossible. Desktop behavior is unchanged (bridge is now subscription-only). New `'link'` source gets its own consent copy and maps to the honest `'qr'` origin.

No protocol changes: consent modal remains the single gate before any relay contact; web relay is same-origin and already CSP-allowed. Desktop's hash router owns the fragment, so the ingress never mounts there (`isDesktop` guard + web-only mount).

## Gates

- `npm run lint` (zero warnings) PASS
- `npm test`: 234 tests, 13 suites PASS (new `fragmentIngress` suite: encode round-trip, no-double-decode with `%`/`&`/`+` payloads, scheme rejection, scrub predicate; store suite extended for the `'link'` source and origin mapping)
- `npm run build` (tsc + vite) PASS

## Device test before promoting to prod (on dev.qrlwallet.com)

- Fragment-link connect from a dApp tab (URI must carry `r=` for the dev relay); address bar scrubbed before the modal shows; Back does not resurrect it
- Paste-box connect on web; cancel path = zero relay traffic; `#qrlconnect=junk` scrubbed with no modal
- Locked-wallet and no-wallet-imported profiles
- Two-wallet-tab scenario: tab 1 already open, fragment link opens tab 2, pair, refresh tab 1; watch for stranded sessions / reconnect spam
- CLAUDE.md 4.5 regressions: desktop QR connect, mobile deep link, stored-session reconnect, both-direction disconnects, duplicate-handshake idempotence

## Follow-up (separate PR, connect repo)

`@qrlwallet/connect-ui` gains an "Open web wallet" button building this fragment link; it must not publish to npm until this is live on prod qrlwallet.com.