### PR TITLE
feat(dapp-connect): polish the sessions surface + block no-account pairing

### DIFF
--- a/src/components/Core/Body/DAppConnect/DAppConnectConsentModal.tsx
+++ b/src/components/Core/Body/DAppConnect/DAppConnectConsentModal.tsx
@@ -34,7 +34,10 @@ import { DEFAULT_RELAY_URL } from '@/services/dappConnect/DAppConnectService';
 const DEFAULT_RELAY_ORIGIN = new URL(DEFAULT_RELAY_URL).origin;
 
 const DAppConnectConsentModal = observer(() => {
-  const { dappConnectStore } = useStore();
+  const { dappConnectStore, qrlStore } = useStore();
+  // Pairing without an account is a ghost session: there is nothing to
+  // share, and the dApp just sees "no account". Gate Connect on having one.
+  const hasAccount = Boolean(qrlStore.activeAccount.accountAddress);
   const navigate = useNavigate();
   const [connecting, setConnecting] = useState(false);
   const [error, setError] = useState('');
@@ -118,6 +121,13 @@ const DAppConnectConsentModal = observer(() => {
             established. Only continue if you just clicked Connect in a dApp,
             opened its connection link, or pasted its connection code yourself.
           </p>
+          {!hasAccount && (
+            <p className="rounded-md border border-yellow-500/40 bg-yellow-500/10 p-2 text-yellow-500">
+              This wallet has no account yet, so there is nothing to share with
+              the dApp. Create or import an account first, then reconnect from
+              the dApp.
+            </p>
+          )}
           {error && <p className="text-destructive">{error}</p>}
         </div>
 
@@ -125,7 +135,7 @@ const DAppConnectConsentModal = observer(() => {
           <Button variant="outline" onClick={handleCancel} disabled={connecting}>
             Cancel
           </Button>
-          <Button onClick={() => void handleConnect()} disabled={connecting}>
+          <Button onClick={() => void handleConnect()} disabled={connecting || !hasAccount}>
             {connecting ? (
               <>
                 <Loader className="mr-2 h-4 w-4 animate-spin" />

--- a/src/components/Core/Body/DAppConnect/DAppConnectConsentModal.tsx
+++ b/src/components/Core/Body/DAppConnect/DAppConnectConsentModal.tsx
@@ -37,7 +37,11 @@ const DAppConnectConsentModal = observer(() => {
   const { dappConnectStore, qrlStore } = useStore();
   // Pairing without an account is a ghost session: there is nothing to
   // share, and the dApp just sees "no account". Gate Connect on having one.
+  // activeAccount hydrates asynchronously on boot, so suppress the warning
+  // (not the gate) until the store settles: a fragment-link cold load can
+  // stage this modal before hydration finishes.
   const hasAccount = Boolean(qrlStore.activeAccount.accountAddress);
+  const isInitializing = !qrlStore.qrlInstance || qrlStore.qrlAccounts.isLoading;
   const navigate = useNavigate();
   const [connecting, setConnecting] = useState(false);
   const [error, setError] = useState('');
@@ -121,7 +125,7 @@ const DAppConnectConsentModal = observer(() => {
             established. Only continue if you just clicked Connect in a dApp,
             opened its connection link, or pasted its connection code yourself.
           </p>
-          {!hasAccount && (
+          {!hasAccount && !isInitializing && (
             <p className="rounded-md border border-yellow-500/40 bg-yellow-500/10 p-2 text-yellow-500">
               This wallet has no account yet, so there is nothing to share with
               the dApp. Create or import an account first, then reconnect from

--- a/src/components/Core/Body/DAppConnect/DAppSessionsList.tsx
+++ b/src/components/Core/Body/DAppConnect/DAppSessionsList.tsx
@@ -1,13 +1,22 @@
 /**
- * DApp Sessions List - Management page for active dApp connections.
- * Accessible from Settings.
+ * DApp Sessions List - management surface for active dApp connections.
+ * Rendered inside a Card by both hosts: Settings embeds it, and the
+ * standalone /dapp-sessions route (the web fragment-link landing) wraps it
+ * in DAppSessionsPage.
  */
 
 import { useState } from 'react';
 import { observer } from 'mobx-react-lite';
+import { Plug, Unplug } from 'lucide-react';
 import { useStore } from '@/stores/store';
 import { Button } from '@/components/UI/Button';
 import { Input } from '@/components/UI/Input';
+import {
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/UI/Card';
 import { SessionStatus } from '@/services/dappConnect/types';
 import { DAppConnectService } from '@/services/dappConnect/DAppConnectService';
 import { isDesktop } from '@/desktop/bridge';
@@ -29,13 +38,21 @@ const statusLabels: Record<SessionStatus, string> = {
   [SessionStatus.DISCONNECTED]: 'Disconnected',
 };
 
+const statusPillClasses: Record<SessionStatus, string> = {
+  [SessionStatus.CONNECTED]: 'bg-blue-500/10 text-blue-400',
+  [SessionStatus.RECONNECTING]: 'bg-yellow-500/10 text-yellow-500',
+  [SessionStatus.CONNECTING]: 'bg-yellow-500/10 text-yellow-500',
+  [SessionStatus.KEY_EXCHANGE]: 'bg-yellow-500/10 text-yellow-500',
+  [SessionStatus.DISCONNECTED]: 'bg-red-500/10 text-red-400',
+};
+
 const DAppPulsingDot = ({ status }: { status: SessionStatus }) => {
   const color = statusDotColors[status];
   const isStable = status === SessionStatus.CONNECTED;
 
   return (
     <div
-      className="relative flex h-2.5 w-2.5 items-center justify-center rounded-full"
+      className="relative flex h-2.5 w-2.5 shrink-0 items-center justify-center rounded-full"
       style={{ backgroundColor: `${color}66` }}
     >
       <div
@@ -59,7 +76,7 @@ const DAppPulsingDot = ({ status }: { status: SessionStatus }) => {
  * QR/URI text can travel). Feeds the exact same consent modal as the other
  * ingresses; no relay contact happens here.
  */
-const DesktopPasteConnect = observer(() => {
+const PasteConnect = observer(() => {
   const { dappConnectStore } = useStore();
   const [open, setOpen] = useState(false);
   const [uri, setUri] = useState('');
@@ -79,9 +96,15 @@ const DesktopPasteConnect = observer(() => {
 
   if (!open) {
     return (
-      <Button variant="outline" size="sm" onClick={() => setOpen(true)}>
-        Connect a dApp
-      </Button>
+      <div className="flex flex-wrap items-center gap-3">
+        <Button variant="outline" size="sm" onClick={() => setOpen(true)}>
+          <Plug className="mr-2 h-4 w-4" />
+          Connect a dApp
+        </Button>
+        <p className="text-xs text-muted-foreground">
+          Paste a connection code from a dApp's pairing dialog.
+        </p>
+      </div>
     );
   }
 
@@ -120,12 +143,18 @@ const DesktopPasteConnect = observer(() => {
   );
 });
 
+const emptyStateHint = isDesktop
+  ? 'Click "Open in MyQRLWallet" in a dApp, or paste its connection code above.'
+  : isInNativeApp()
+    ? 'Scan a QR code from a dApp to connect.'
+    : 'Click "Open web wallet" in a dApp pairing dialog, or paste its connection code above.';
+
 const DAppSessionsList = observer(() => {
   const { dappConnectStore } = useStore();
   const { activeSessions } = dappConnectStore;
 
   return (
-    <div className="space-y-4 p-4">
+    <>
       <style>{`
         @keyframes slow-ping {
           75%, 100% {
@@ -134,66 +163,81 @@ const DAppSessionsList = observer(() => {
           }
         }
       `}</style>
-      <div className="flex items-center justify-between">
-        <h2 className="text-lg font-semibold">Connected dApps</h2>
-        {activeSessions.length > 0 && (
-          <Button
-            variant="destructive"
-            size="sm"
-            onClick={() => dappConnectStore.disconnectAll()}
-          >
-            Disconnect All
-          </Button>
-        )}
-      </div>
-
-      {(isDesktop || !isInNativeApp()) && <DesktopPasteConnect />}
-
-      {activeSessions.length === 0 ? (
-        <p className="text-sm text-muted-foreground">
-          {isDesktop
-            ? 'No dApps connected. Click "Open in MyQRLWallet" in a dApp, or paste its connection code above.'
-            : isInNativeApp()
-              ? 'No dApps connected. Scan a QR code from a dApp to connect.'
-              : 'No dApps connected. Open a connection link from a dApp, or paste its connection code above.'}
-        </p>
-      ) : (
-        <div className="space-y-3">
-          {activeSessions.map((session) => (
-            <div
-              key={session.id}
-              className="flex items-center justify-between rounded-lg border border-border p-4"
+      <CardHeader className="bg-gradient-to-r from-blue-accent/5 to-transparent">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="space-y-1">
+            <CardTitle className="text-xl font-bold">dApp connections</CardTitle>
+            <CardDescription>
+              dApps paired with this wallet over the end-to-end encrypted QRL Connect relay.
+            </CardDescription>
+          </div>
+          {activeSessions.length > 0 && (
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={() => dappConnectStore.disconnectAll()}
             >
-              <div className="space-y-1">
-                <div className="flex items-center gap-2">
-                  <DAppPulsingDot status={session.status} />
-                  <span className="font-semibold">{session.dappInfo.name}</span>
-                  <span className="text-xs text-muted-foreground">
-                    {statusLabels[session.status]}
-                  </span>
-                </div>
-                <p className="text-xs text-muted-foreground">{session.dappInfo.url}</p>
-                <p className="font-mono text-xs text-muted-foreground">
-                  Account: {session.connectedAccount
-                    ? `${session.connectedAccount.slice(0, 8)}...${session.connectedAccount.slice(-6)}`
-                    : 'None'}
-                </p>
-                <p className="text-xs text-muted-foreground">
-                  Connected {new Date(session.createdAt).toLocaleDateString()}
-                </p>
-              </div>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => dappConnectStore.disconnectSession(session.id)}
-              >
-                Disconnect
-              </Button>
-            </div>
-          ))}
+              Disconnect all
+            </Button>
+          )}
         </div>
-      )}
-    </div>
+      </CardHeader>
+      <CardContent className="space-y-4 pt-6">
+        {(isDesktop || !isInNativeApp()) && <PasteConnect />}
+
+        {activeSessions.length === 0 ? (
+          <div className="flex flex-col items-center gap-2 rounded-lg border border-dashed border-border py-10 text-center">
+            <Unplug className="h-8 w-8 text-muted-foreground/50" />
+            <p className="text-sm font-medium">No dApps connected</p>
+            <p className="max-w-sm px-4 text-xs leading-relaxed text-muted-foreground">
+              {emptyStateHint}
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {activeSessions.map((session) => (
+              <div
+                key={session.id}
+                className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border/80 bg-muted/20 p-4"
+              >
+                <div className="min-w-0 space-y-1.5">
+                  <div className="flex items-center gap-2.5">
+                    <DAppPulsingDot status={session.status} />
+                    <span className="truncate font-semibold">{session.dappInfo.name}</span>
+                    <span
+                      className={`rounded-full px-2 py-0.5 text-[11px] font-medium ${statusPillClasses[session.status]}`}
+                    >
+                      {statusLabels[session.status]}
+                    </span>
+                  </div>
+                  <p className="truncate text-xs text-muted-foreground">{session.dappInfo.url}</p>
+                  <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                    {session.connectedAccount ? (
+                      <span className="font-mono">
+                        {session.connectedAccount.slice(0, 8)}...{session.connectedAccount.slice(-6)}
+                      </span>
+                    ) : (
+                      <span className="italic">No account shared</span>
+                    )}
+                    <span>
+                      Connected {new Date(session.createdAt).toLocaleDateString()}
+                    </span>
+                  </div>
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="hover:border-destructive hover:bg-destructive/10 hover:text-destructive"
+                  onClick={() => dappConnectStore.disconnectSession(session.id)}
+                >
+                  Disconnect
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </>
   );
 });
 

--- a/src/components/Core/Body/DAppConnect/DAppSessionsPage.tsx
+++ b/src/components/Core/Body/DAppConnect/DAppSessionsPage.tsx
@@ -1,0 +1,18 @@
+/**
+ * Standalone /dapp-sessions route: where web fragment-link handoffs land and
+ * the consent modal navigates after a successful connect. Settings embeds
+ * the same list in its own card instead.
+ */
+
+import { Card } from '@/components/UI/Card';
+import DAppSessionsList from './DAppSessionsList';
+
+const DAppSessionsPage = () => (
+  <div className="mx-auto w-full max-w-3xl px-4 py-8">
+    <Card className="border-l-4 border-l-blue-accent">
+      <DAppSessionsList />
+    </Card>
+  </div>
+);
+
+export default DAppSessionsPage;

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -22,7 +22,7 @@ const Privacy = lazy(() => import("../components/Core/Body/Privacy/Privacy.tsx")
 const TokenStatus = lazy(() => import("../components/Core/Body/CreateToken/TokenStatus.tsx"));
 const TransactionHistory = lazy(() => import("../components/Core/Body/TransactionHistory/TransactionHistory.tsx"));
 const Transfer = lazy(() => import("../components/Core/Body/Transfer/Transfer.tsx"));
-const DAppSessionsList = lazy(() => import("../components/Core/Body/DAppConnect/DAppSessionsList.tsx"));
+const DAppSessionsPage = lazy(() => import("../components/Core/Body/DAppConnect/DAppSessionsPage.tsx"));
 const NftDetail = lazy(() => import("../components/Core/Body/Nfts/NftDetail.tsx"));
 
 const ROUTES = {
@@ -170,7 +170,7 @@ const router = createAppRouter([
         path: ROUTES.DAPP_SESSIONS,
         element: (
           <Suspense fallback={<Loading />}>
-            <DAppSessionsList />
+            <DAppSessionsPage />
           </Suspense>
         )
       },


### PR DESCRIPTION
Follow-ups from live prod testing of the pairing flow:

- **Sessions UI**: the standalone /dapp-sessions page (where fragment handoffs land) was a bare list on an empty page. Restyled to the wallet's card language (gradient header, status pills, meta rows, dashed empty state, page container via new DAppSessionsPage; Settings keeps embedding the list in its own card).
- **No-account pairing blocked**: a wallet with zero accounts could pair, producing ghost 'Account: None' sessions. The consent modal now disables Connect with an inline 'create or import an account first' note (applies to desktop deep-link/paste and web link/paste; the mobile scan path is store-driven and unaffected for now).

Gates: lint (zero warnings), jest 240, tsc+vite build: PASS. Visual check on dev.qrlwallet.com before the next prod promotion.