### PR TITLE
dApp-connect hardening: desync teardown, approval-aware grace, wake links

### DIFF
--- a/src/services/dappConnect/DAppConnectService.ts
+++ b/src/services/dappConnect/DAppConnectService.ts
@@ -11,7 +11,13 @@ import {
   type SynAckMessage,
   type AckMessage,
 } from './KeyExchange';
-import { parseConnectionURI, cidToString, computeFingerprint, fingerprintEquals } from './qrUri';
+import {
+  parseConnectionURI,
+  parseWakeURI,
+  cidToString,
+  computeFingerprint,
+  fingerprintEquals,
+} from './qrUri';
 import { fromBase64 } from './PQCrypto';
 import { SocketClient } from './SocketClient';
 import { RequestHandler } from './RequestHandler';
@@ -43,6 +49,16 @@ export const DEFAULT_RELAY_URL = 'https://qrlwallet.com';
 // back round trip and tore down recoverable sessions; 90s comfortably covers
 // it without leaving a genuinely-gone dApp "active" for long.
 const DAPP_REJOIN_GRACE_MS = 90000;
+// While an approval for the channel is still waiting on the user, the grace
+// period re-arms instead of reaping the session (approving can easily take
+// longer than 90s with FaceID + reading the request). Bounded so a session
+// whose approval is simply abandoned still gets cleaned up.
+const DAPP_LEAVE_APPROVAL_CAP_MS = 10 * 60 * 1000;
+// AEAD nonces derive from the recv counter with no gap tolerance, so a relay
+// buffer drop (5-min TTL / 50-msg cap) desyncs the stream unrecoverably and
+// every later open fails. Two consecutive failures cannot happen on a healthy
+// stream; requiring the second guards against one-off injected junk.
+const MAX_DECRYPT_FAILURES = 2;
 const TERMINATE_SEND_TIMEOUT_MS = 800;
 
 interface ActiveConnection {
@@ -82,6 +98,12 @@ type ServiceEventHandler = {
   onPendingRequest: (request: PendingDAppRequest) => void;
   onSessionConnected: (sessionId: string) => void;
   onSessionDisconnected: (sessionId: string) => void;
+  /**
+   * Whether an approval for this channel is still waiting on the user.
+   * Optional so existing wirings/mocks stay valid; when absent the
+   * stale-session grace behaves as before (no approval-aware extension).
+   */
+  hasPendingApprovalsForChannel?: (channelId: string) => boolean;
 };
 
 interface RpcRequestProvider {
@@ -104,6 +126,8 @@ export class DAppConnectService {
   // does not dedup across invocations). Value carries the effective `explicit`
   // so a racing user "forget" can upgrade a non-explicit teardown.
   private finalizing = new Map<string, { explicit: boolean }>();
+  // Consecutive post-handshake AEAD open failures per channel (desync detector).
+  private decryptFailures = new Map<string, number>();
   private handlers: ServiceEventHandler | null = null;
 
   setHandlers(handlers: ServiceEventHandler): void {
@@ -119,6 +143,16 @@ export class DAppConnectService {
     uri: string,
     origin: 'qr' | 'deeplink' = 'qr'
   ): Promise<{ success: boolean; error?: string }> {
+    // A wake link is an intentional "foreground the wallet" signal from the
+    // dApp SDK, not a pairing attempt: the session itself resumes via
+    // reconnectAll (APP_STATE active fires before this URI is forwarded).
+    // Recognize it so it does not read as a malformed pairing URI.
+    const wakeCid = parseWakeURI(uri);
+    if (wakeCid !== null) {
+      dlog(`Wake link received (cid ${wakeCid}); sessions resume via reconnectAll`);
+      return { success: true };
+    }
+
     let parsed;
     try {
       parsed = await parseConnectionURI(uri);
@@ -395,12 +429,30 @@ export class DAppConnectService {
     }
 
     if (typeof message === 'string' && conn.keyExchange.areKeysExchanged()) {
+      // The failure counter is scoped STRICTLY to the AEAD open. JSON.parse
+      // or dispatch errors happen after recvSeq advanced and say nothing
+      // about stream health, so they must never count toward a teardown.
+      let decrypted: string;
       try {
-        const decrypted = await conn.keyExchange.decryptMessage(message);
+        decrypted = await conn.keyExchange.decryptMessage(message);
+      } catch (err) {
+        console.error('[DAppConnect] Failed to decrypt message:', err);
+        const failures = (this.decryptFailures.get(channelId) ?? 0) + 1;
+        this.decryptFailures.set(channelId, failures);
+        if (failures >= MAX_DECRYPT_FAILURES) {
+          dlog(`AEAD stream desynced on ${channelId}; terminating session`);
+          // explicit=true tombstones the channel (close_channel): an
+          // encrypted TERMINATE would be undecipherable to a desynced dApp.
+          await this.disconnectSession(channelId, true);
+        }
+        return;
+      }
+      this.decryptFailures.delete(channelId);
+      try {
         const parsed = JSON.parse(decrypted);
         await this.handleDecryptedMessage(channelId, parsed);
       } catch (err) {
-        console.error('[DAppConnect] Failed to decrypt message:', err);
+        console.error('[DAppConnect] Failed to handle decrypted message:', err);
       }
     }
   }
@@ -597,6 +649,7 @@ export class DAppConnectService {
   async disconnectSession(channelId: string, explicit = true): Promise<void> {
     dlog(`disconnectSession called for ${channelId}`);
     this.clearDappLeaveTimeout(channelId);
+    this.decryptFailures.delete(channelId);
 
     // Collapse concurrent teardowns of the same channel to a single run. A
     // per-call flag cannot do this (each invocation has its own), so a user
@@ -886,11 +939,23 @@ export class DAppConnectService {
       });
   }
 
-  private scheduleDappLeaveTimeout(channelId: string): void {
+  private scheduleDappLeaveTimeout(channelId: string, graceStartedAt = Date.now()): void {
     this.clearDappLeaveTimeout(channelId);
     const timeout = setTimeout(() => {
       this.dappLeaveTimers.delete(channelId);
       if (!this.connections.has(channelId)) return;
+      // Don't reap a session whose approval modal the user is still looking
+      // at: FaceID + reading a request routinely outlasts one grace period,
+      // and the eventual response is relay-buffered for the absent dApp
+      // either way. Re-arm instead, bounded by the cumulative cap.
+      if (
+        Date.now() - graceStartedAt < DAPP_LEAVE_APPROVAL_CAP_MS &&
+        this.handlers?.hasPendingApprovalsForChannel?.(channelId)
+      ) {
+        dlog(`dApp absent but approval pending for ${channelId}; extending grace`);
+        this.scheduleDappLeaveTimeout(channelId, graceStartedAt);
+        return;
+      }
       dlog(`dApp absent for ${DAPP_REJOIN_GRACE_MS}ms; disconnecting`);
       // Fire-and-forget: this is a setTimeout callback, nothing to await into.
       void this.disconnectSession(channelId, false);

--- a/src/services/dappConnect/__tests__/qrUri.test.ts
+++ b/src/services/dappConnect/__tests__/qrUri.test.ts
@@ -11,6 +11,7 @@
 import { describe, it, expect } from '@jest/globals';
 import {
   parseConnectionURI,
+  parseWakeURI,
   computeFingerprint,
   fingerprintEquals,
   cidToString,
@@ -189,5 +190,23 @@ describe('cidToString / cidFromString', () => {
 
   it('cidFromString rejects non-128-bit-hex input', () => {
     expect(() => cidFromString('zz')).toThrow('not a 128-bit hex string');
+  });
+});
+
+describe('parseWakeURI', () => {
+  it('returns the cid from a wake link', () => {
+    expect(parseWakeURI('qrlconnect://?wake=abc-123')).toBe('abc-123');
+  });
+
+  it('returns null for a pairing URI (q present beats wake)', () => {
+    expect(parseWakeURI('qrlconnect://?q=SOMEBLOB')).toBeNull();
+    expect(parseWakeURI('qrlconnect://?q=SOMEBLOB&wake=abc')).toBeNull();
+  });
+
+  it('returns null for non-qrlconnect schemes and garbage', () => {
+    expect(parseWakeURI('https://qrlwallet.com/?wake=abc')).toBeNull();
+    expect(parseWakeURI('javascript:alert(1)')).toBeNull();
+    expect(parseWakeURI('')).toBeNull();
+    expect(parseWakeURI('qrlconnect://')).toBeNull();
   });
 });

--- a/src/services/dappConnect/qrUri.ts
+++ b/src/services/dappConnect/qrUri.ts
@@ -75,6 +75,25 @@ function startsWith(buf: Uint8Array, prefix: Uint8Array): boolean {
   return true;
 }
 
+/**
+ * Recognize a dApp "wake" link: `qrlconnect://?wake=<cid>`. The SDK deep-links
+ * it to foreground the wallet app when a request is waiting for a wallet whose
+ * socket is absent; it carries no pairing payload (sessions resume via
+ * reconnectAll on APP_STATE active). Returns the cid string, or null when the
+ * URI is not a wake link. A URI carrying `q` is always a pairing URI, never a
+ * wake link.
+ */
+export function parseWakeURI(uri: string): string | null {
+  if (typeof uri !== 'string' || !/^qrlconnect:/i.test(uri.trim())) return null;
+  try {
+    const swapped = new URL(uri.trim().replace(/^qrlconnect:\/?\/?/i, 'https://qrlconnect/'));
+    if (swapped.searchParams.get('q')) return null;
+    return swapped.searchParams.get('wake');
+  } catch {
+    return null;
+  }
+}
+
 export async function parseConnectionURI(uri: string): Promise<ParsedURI> {
   if (typeof uri !== 'string' || uri.length === 0) {
     throw new Error('qrUri: empty URI');

--- a/src/stores/__tests__/dappConnectStore.test.ts
+++ b/src/stores/__tests__/dappConnectStore.test.ts
@@ -321,6 +321,7 @@ describe('service handler callbacks', () => {
     return call[0] as {
       onPendingRequest: (r: PendingDAppRequest) => void;
       onSessionDisconnected: (sessionId: string) => void;
+      hasPendingApprovalsForChannel: (channelId: string) => boolean;
     };
   }
 
@@ -351,5 +352,19 @@ describe('service handler callbacks', () => {
     expect(store.pendingRequests.map((r) => r.id)).toEqual([other.id]);
     expect(store.currentApproval).toBeNull();
     expect(store.approvalModalOpen).toBe(false);
+  });
+
+  it('hasPendingApprovalsForChannel reflects per-channel pending state', () => {
+    const store = new DAppConnectStore();
+    const handlers = capturedHandlers();
+    expect(handlers.hasPendingApprovalsForChannel('session-1')).toBe(false);
+
+    handlers.onPendingRequest(makeRequest({ id: 1, sessionId: 'session-1' }));
+    expect(handlers.hasPendingApprovalsForChannel('session-1')).toBe(true);
+    expect(handlers.hasPendingApprovalsForChannel('session-2')).toBe(false);
+
+    handlers.onSessionDisconnected('session-1');
+    expect(handlers.hasPendingApprovalsForChannel('session-1')).toBe(false);
+    expect(store.pendingRequests).toHaveLength(0);
   });
 });

--- a/src/stores/dappConnectStore.ts
+++ b/src/stores/dappConnectStore.ts
@@ -90,6 +90,10 @@ class DAppConnectStore {
           }
         });
       },
+      // Lets the service's stale-session grace keep a channel alive while
+      // its approval modal is still waiting on the user.
+      hasPendingApprovalsForChannel: (channelId) =>
+        this.pendingRequests.some((r) => r.sessionId === channelId),
     });
 
     // Load existing sessions and reconnect


### PR DESCRIPTION
Wallet-mirror follow-ups to myqrlwallet-connect PR #32 (offline-wallet requests) and #34 (SDK desync teardown).

1. **AEAD desync teardown**: two consecutive post-handshake decrypt failures (strictly the AEAD open; JSON/dispatch errors never count) now disconnect the session with `explicit=true` (close_channel tombstone), instead of silently bricking the pairing when the relay buffer drops a message. Twin of the SDK change in connect PR #34.
2. **Approval-aware grace**: the 90s dApp-rejoin grace re-arms while `dappConnectStore` reports a pending approval for that channel (new optional `hasPendingApprovalsForChannel` service handler), capped at 10 minutes cumulative. Fixes the review finding that a user lingering in the approval modal >90s lost the session mid-approve.
3. **Wake links**: `qrlconnect://?wake=<cid>` is recognized as an intentional foreground signal (SDK 3.3.0 sends it for buffered requests) rather than logging 'missing q parameter'.

Gates: lint (zero warnings), jest 244/244 (new parseWakeURI + store-handler tests), build (tsc + vite) green.

Not covered by unit tests (no service-level harness exists): the grace re-arm timer path and the teardown's disconnectSession call: both are thin compositions over tested pieces; morning device pass on dev.qrlwallet.com recommended. Commits unsigned (gpg pinentry timed out overnight).