### PR TITLE
feat(address-book): saved recipients (Transfer picker + Contacts nav + management page)

### DIFF
--- a/src/components/Core/Body/AddressBook/AddressBook.tsx
+++ b/src/components/Core/Body/AddressBook/AddressBook.tsx
@@ -1,0 +1,258 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { BookUser, Copy, Pencil, Plus, Send, Trash2, Check } from "lucide-react";
+import { Button } from "@/components/UI/Button";
+import { Input } from "@/components/UI/Input";
+import { Label } from "@/components/UI/Label";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/UI/Card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/UI/Dialog";
+import { ROUTES } from "@/router/router";
+import { copyToClipboard } from "@/utils/nativeApp";
+import { formatAddressShort } from "@/utils/formatting";
+import type { AddressBookEntry } from "@/utils/addressBook";
+import { addEntry, loadAddressBook, removeEntry, renameEntry } from "@/utils/addressBook";
+
+export default function AddressBook() {
+  const navigate = useNavigate();
+  const [entries, setEntries] = useState<AddressBookEntry[]>(() => loadAddressBook());
+  const [addOpen, setAddOpen] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [newAddress, setNewAddress] = useState("");
+  const [addError, setAddError] = useState<string | null>(null);
+  const [renameTarget, setRenameTarget] = useState<AddressBookEntry | null>(null);
+  const [renameValue, setRenameValue] = useState("");
+  const [deleteTarget, setDeleteTarget] = useState<AddressBookEntry | null>(null);
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+
+  const refresh = () => setEntries(loadAddressBook());
+
+  const handleAdd = () => {
+    const result = addEntry(newName, newAddress);
+    if (typeof result === "string") {
+      setAddError(result);
+      return;
+    }
+    setAddOpen(false);
+    setNewName("");
+    setNewAddress("");
+    setAddError(null);
+    refresh();
+  };
+
+  const handleRename = () => {
+    if (renameTarget && renameEntry(renameTarget.id, renameValue)) {
+      setRenameTarget(null);
+      refresh();
+    }
+  };
+
+  const handleDelete = () => {
+    if (deleteTarget) {
+      removeEntry(deleteTarget.id);
+      setDeleteTarget(null);
+      refresh();
+    }
+  };
+
+  const handleCopy = (entry: AddressBookEntry) => {
+    copyToClipboard(entry.address);
+    setCopiedId(entry.id);
+    setTimeout(() => setCopiedId((current) => (current === entry.id ? null : current)), 1500);
+  };
+
+  const handleSend = (entry: AddressBookEntry) => {
+    navigate(ROUTES.TRANSFER, { state: { receiverAddress: entry.address } });
+  };
+
+  return (
+    <div className="flex flex-col gap-4 p-4 pb-20 max-w-2xl mx-auto w-full">
+      <Card className="border-l-4 border-l-orange-500">
+        <CardHeader className="bg-gradient-to-r from-orange-500/5 to-transparent">
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex items-center gap-3">
+              <BookUser className="h-7 w-7 text-secondary" />
+              <div>
+                <CardTitle className="text-2xl font-bold">Address Book</CardTitle>
+                <CardDescription>Saved recipients for quick transfers</CardDescription>
+              </div>
+            </div>
+            <Button size="sm" onClick={() => setAddOpen(true)}>
+              <Plus className="h-4 w-4 mr-1" />
+              Add
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent className="pt-4">
+          {entries.length === 0 ? (
+            <div className="text-center text-muted-foreground py-10 flex flex-col items-center gap-3">
+              <BookUser className="h-10 w-10 opacity-40" />
+              <p>No saved addresses yet.</p>
+              <p className="text-sm">
+                Add one here, or save a recipient from the Transfer page.
+              </p>
+            </div>
+          ) : (
+            <ul className="flex flex-col divide-y divide-border">
+              {entries.map((entry) => (
+                <li key={entry.id} className="flex items-center gap-3 py-3">
+                  <div className="min-w-0 flex-1">
+                    <p className="font-semibold truncate">{entry.name}</p>
+                    <p className="text-sm text-muted-foreground font-mono truncate">
+                      {formatAddressShort(entry.address)}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      title="Copy address"
+                      onClick={() => handleCopy(entry)}
+                    >
+                      {copiedId === entry.id ? (
+                        <Check className="h-4 w-4 text-green-500" />
+                      ) : (
+                        <Copy className="h-4 w-4" />
+                      )}
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      title="Send to this address"
+                      onClick={() => handleSend(entry)}
+                    >
+                      <Send className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      title="Rename"
+                      onClick={() => {
+                        setRenameTarget(entry);
+                        setRenameValue(entry.name);
+                      }}
+                    >
+                      <Pencil className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      title="Delete"
+                      onClick={() => setDeleteTarget(entry)}
+                    >
+                      <Trash2 className="h-4 w-4 text-destructive" />
+                    </Button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Add contact */}
+      <Dialog
+        open={addOpen}
+        onOpenChange={(open) => {
+          setAddOpen(open);
+          if (!open) setAddError(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Add Address</DialogTitle>
+            <DialogDescription>Save a recipient for quick transfers.</DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="ab-name">Name</Label>
+              <Input
+                id="ab-name"
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                placeholder="e.g. Cold storage"
+                maxLength={40}
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="ab-address">QRL address</Label>
+              <Input
+                id="ab-address"
+                value={newAddress}
+                onChange={(e) => setNewAddress(e.target.value)}
+                placeholder="Q..."
+                className="font-mono"
+              />
+            </div>
+            {addError ? <p className="text-sm text-destructive">{addError}</p> : null}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setAddOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleAdd}>Save</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Rename contact */}
+      <Dialog open={renameTarget !== null} onOpenChange={(open) => !open && setRenameTarget(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Rename Address</DialogTitle>
+            <DialogDescription className="font-mono">
+              {renameTarget ? formatAddressShort(renameTarget.address) : ""}
+            </DialogDescription>
+          </DialogHeader>
+          <Input
+            value={renameValue}
+            onChange={(e) => setRenameValue(e.target.value)}
+            maxLength={40}
+          />
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setRenameTarget(null)}>
+              Cancel
+            </Button>
+            <Button onClick={handleRename} disabled={!renameValue.trim()}>
+              Save
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete contact */}
+      <Dialog open={deleteTarget !== null} onOpenChange={(open) => !open && setDeleteTarget(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Address?</DialogTitle>
+            <DialogDescription>
+              {deleteTarget
+                ? `"${deleteTarget.name}" (${formatAddressShort(deleteTarget.address)}) will be removed from your address book.`
+                : ""}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteTarget(null)}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={handleDelete}>
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/components/Core/Body/AddressBook/AddressBookPicker.tsx
+++ b/src/components/Core/Body/AddressBook/AddressBookPicker.tsx
@@ -1,0 +1,144 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { BookUser, Plus } from "lucide-react";
+import { Button } from "@/components/UI/Button";
+import { Input } from "@/components/UI/Input";
+import { Label } from "@/components/UI/Label";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/UI/Dialog";
+import { ROUTES } from "@/router/router";
+import { formatAddressShort } from "@/utils/formatting";
+import {
+  addEntry,
+  findByAddress,
+  isValidQrlAddress,
+  loadAddressBook,
+} from "@/utils/addressBook";
+
+interface AddressBookPickerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Called with the picked address; the picker closes itself. */
+  onSelect: (address: string) => void;
+  /**
+   * The address currently typed in the form. When valid and not yet saved,
+   * the picker offers to save it under a name.
+   */
+  currentAddress?: string;
+}
+
+export function AddressBookPicker({
+  open,
+  onOpenChange,
+  onSelect,
+  currentAddress,
+}: AddressBookPickerProps) {
+  const navigate = useNavigate();
+  const [saveName, setSaveName] = useState("");
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  // The list is tiny; reading it during render keeps it fresh on every
+  // open and after an in-dialog save without effect/refresh plumbing.
+  const entries = open ? loadAddressBook() : [];
+
+  // Radix fires onOpenChange on close; resetting there makes each open fresh.
+  const handleOpenChange = (next: boolean) => {
+    if (!next) {
+      setSaveName("");
+      setSaveError(null);
+    }
+    onOpenChange(next);
+  };
+
+  const trimmedCurrent = (currentAddress ?? "").trim();
+  const offerSave =
+    isValidQrlAddress(trimmedCurrent) && findByAddress(trimmedCurrent) === undefined;
+
+  const handleSaveCurrent = () => {
+    const result = addEntry(saveName, trimmedCurrent);
+    if (typeof result === "string") {
+      setSaveError(result);
+      return;
+    }
+    setSaveName("");
+    setSaveError(null);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-h-[80vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <BookUser className="h-5 w-5 text-secondary" />
+            Address Book
+          </DialogTitle>
+          <DialogDescription>Pick a saved recipient.</DialogDescription>
+        </DialogHeader>
+
+        {entries.length === 0 ? (
+          <p className="text-sm text-muted-foreground text-center py-4">
+            No saved addresses yet.
+          </p>
+        ) : (
+          <ul className="flex flex-col divide-y divide-border -mx-2">
+            {entries.map((entry) => (
+              <li key={entry.id}>
+                <button
+                  type="button"
+                  className="w-full text-left px-2 py-3 hover:bg-accent rounded-md transition-colors"
+                  onClick={() => {
+                    onSelect(entry.address);
+                    onOpenChange(false);
+                  }}
+                >
+                  <p className="font-semibold truncate">{entry.name}</p>
+                  <p className="text-sm text-muted-foreground font-mono truncate">
+                    {formatAddressShort(entry.address)}
+                  </p>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {offerSave ? (
+          <div className="border-t border-border pt-3 flex flex-col gap-2">
+            <Label htmlFor="ab-save-name">
+              Save {formatAddressShort(trimmedCurrent)} as
+            </Label>
+            <div className="flex gap-2">
+              <Input
+                id="ab-save-name"
+                value={saveName}
+                onChange={(e) => setSaveName(e.target.value)}
+                placeholder="Name"
+                maxLength={40}
+              />
+              <Button onClick={handleSaveCurrent} disabled={!saveName.trim()}>
+                <Plus className="h-4 w-4 mr-1" />
+                Save
+              </Button>
+            </div>
+            {saveError ? <p className="text-sm text-destructive">{saveError}</p> : null}
+          </div>
+        ) : null}
+
+        <Button
+          variant="outline"
+          className="w-full"
+          onClick={() => {
+            onOpenChange(false);
+            navigate(ROUTES.ADDRESS_BOOK);
+          }}
+        >
+          Manage address book
+        </Button>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/Core/Body/Settings/Settings.tsx
+++ b/src/components/Core/Body/Settings/Settings.tsx
@@ -27,7 +27,9 @@ import { useState, useEffect, lazy } from "react";
 import { NetworkSettings } from "./NetworkSettings/NetworkSettings";
 import type { EncryptedSeedData } from "@/utils/storage";
 import { StorageUtil } from "@/utils/storage";
-import { Save, Shield } from "lucide-react";
+import { BookUser, ChevronRight, Save, Shield } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { ROUTES } from "@/router/router";
 import { SEO } from "@/components/SEO/SEO";
 import { PinInput } from "@/components/UI/PinInput/PinInput";
 import { decryptSeedAsync, reEncryptSeedAsync } from "@/utils/crypto";
@@ -73,6 +75,7 @@ const ChangePinSchema = z.object({
 type ChangePinFormValues = z.infer<typeof ChangePinSchema>;
 
 const Settings = observer(() => {
+    const navigate = useNavigate();
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [hasEncryptedSeeds, setHasEncryptedSeeds] = useState(false);
     const [isChangingPin, setIsChangingPin] = useState(false);
@@ -365,6 +368,29 @@ const Settings = observer(() => {
                         )}
 
                         <NetworkSettings />
+
+                        <Card className="border-l-4 border-l-orange-500">
+                            <button
+                                type="button"
+                                className="w-full text-left cursor-pointer"
+                                onClick={() => navigate(ROUTES.ADDRESS_BOOK)}
+                            >
+                                <CardHeader className="bg-gradient-to-r from-orange-500/5 to-transparent">
+                                    <div className="flex items-center justify-between gap-2">
+                                        <div className="flex items-center gap-3">
+                                            <BookUser className="h-6 w-6 text-secondary" />
+                                            <div>
+                                                <CardTitle className="text-2xl font-bold">Address Book</CardTitle>
+                                                <CardDescription>
+                                                    Manage saved recipients for quick transfers
+                                                </CardDescription>
+                                            </div>
+                                        </div>
+                                        <ChevronRight className="h-5 w-5 text-muted-foreground" />
+                                    </div>
+                                </CardHeader>
+                            </button>
+                        </Card>
 
                         <Card className="border-l-4 border-l-blue-accent">
                             <CardHeader className="bg-gradient-to-r from-blue-accent/5 to-transparent">

--- a/src/components/Core/Body/Transfer/Transfer.tsx
+++ b/src/components/Core/Body/Transfer/Transfer.tsx
@@ -31,13 +31,14 @@ import { useStore } from "@/stores/store";
 import { StorageUtil } from "@/utils/storage";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { utils } from "@theqrl/web3";
-import { Loader, Send, X, Copy, Coins, ExternalLink, ScanLine, Check } from "lucide-react";
+import { Loader, Send, X, Copy, Coins, ExternalLink, ScanLine, Check, BookUser } from "lucide-react";
 import { observer } from "mobx-react-lite";
 import { useEffect, useState, useMemo, useCallback } from "react";
 import { useForm } from "react-hook-form";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { z } from "zod";
 import { GasFeeNotice } from "./GasFeeNotice/GasFeeNotice";
+import { AddressBookPicker } from "../AddressBook/AddressBookPicker";
 import { TransactionSuccessful } from "./TransactionSuccessful/TransactionSuccessful";
 import { getExplorerAddressUrl, getExplorerTxUrl, QRL_PROVIDER } from "@/config";
 import { Slider } from "@/components/UI/Slider";
@@ -113,6 +114,13 @@ const Transfer = observer(() => {
   // Get initial asset from URL params (for token transfers from home page)
   const initialAsset = searchParams.get('asset') || 'native';
 
+  // Prefill from the address book page's Send action (navigation state).
+  const location = useLocation();
+  const prefilledReceiver =
+    typeof (location.state as { receiverAddress?: unknown } | null)?.receiverAddress === "string"
+      ? (location.state as { receiverAddress: string }).receiverAddress
+      : "";
+
   const [sliderValue, setSliderValue] = useState(0);
   const [feeLevel, setFeeLevel] = useState<FeeLevel>("medium");
   const [amountInputValue, setAmountInputValue] = useState("");
@@ -125,6 +133,9 @@ const Transfer = observer(() => {
   const [scanSuccess, setScanSuccess] = useState(false);
   const [scannedAddressPreview, setScannedAddressPreview] = useState<string | null>(null);
 
+  // Address book picker state
+  const [addressBookOpen, setAddressBookOpen] = useState(false);
+
   // Preserved across resetForm so the success screen can show the amount sent.
   const [submittedAmount, setSubmittedAmount] = useState<string>("");
   const [submittedAssetSymbol, setSubmittedAssetSymbol] = useState<string>("");
@@ -135,7 +146,7 @@ const Transfer = observer(() => {
     reValidateMode: "onChange",
     defaultValues: {
       asset: initialAsset,
-      receiverAddress: "",
+      receiverAddress: prefilledReceiver,
       amount: 0,
       pin: "",
     },
@@ -760,8 +771,17 @@ const Transfer = observer(() => {
                               value={field.value ?? ""}
                               disabled={isSubmitting || isScanning}
                               placeholder="Receiver address"
-                              className="pr-10"
+                              className={isInNativeApp() ? "pr-16" : "pr-10"}
                             />
+                            <button
+                              type="button"
+                              onClick={() => setAddressBookOpen(true)}
+                              disabled={isSubmitting || isScanning}
+                              className={`absolute ${isInNativeApp() ? "right-9" : "right-2"} top-1/2 -translate-y-1/2 p-1 rounded-md hover:bg-accent transition-colors disabled:opacity-50`}
+                              title="Address book"
+                            >
+                              <BookUser className="h-5 w-5 text-muted-foreground hover:text-foreground" />
+                            </button>
                             {isInNativeApp() && (
                               <button
                                 type="button"
@@ -794,12 +814,21 @@ const Transfer = observer(() => {
                         )}
                         {!isScanning && !scanSuccess && (
                           <FormDescription>
-                            Enter the receiver's account address{isInNativeApp() ? ' or scan QR' : ''}
+                            Enter the receiver's address, pick a contact{isInNativeApp() ? ', or scan QR' : ''}
                           </FormDescription>
                         )}
                         <FormMessage />
                       </FormItem>
                     )}
+                  />
+
+                  <AddressBookPicker
+                    open={addressBookOpen}
+                    onOpenChange={setAddressBookOpen}
+                    currentAddress={formValues.receiverAddress}
+                    onSelect={(address) =>
+                      setValue("receiverAddress", address, { shouldValidate: true })
+                    }
                   />
 
                   {/* Amount */}

--- a/src/components/Core/Layout/MobileNav.tsx
+++ b/src/components/Core/Layout/MobileNav.tsx
@@ -1,4 +1,4 @@
-import { Wallet, ArrowRight, Settings as SettingsIcon, LogOut } from "lucide-react"
+import { Wallet, ArrowRight, Settings as SettingsIcon, LogOut, BookUser } from "lucide-react"
 import { useNavigate, useLocation } from "react-router-dom";
 import { ROUTES } from "@/router/router";
 import { handleLogout } from "@/utils/logout";
@@ -16,6 +16,11 @@ const navItems = [
         icon: Wallet,
         label: "Wallets",
         path: ROUTES.ACCOUNT_LIST,
+    },
+    {
+        icon: BookUser,
+        label: "Contacts",
+        path: ROUTES.ADDRESS_BOOK,
     },
     {
         icon: SettingsIcon,

--- a/src/components/Core/Layout/app-sidebar.tsx
+++ b/src/components/Core/Layout/app-sidebar.tsx
@@ -1,4 +1,4 @@
-import { LogOut, Lock, Wallet, ArrowRight, Settings as SettingsIcon, Plug } from "lucide-react"
+import { LogOut, Lock, Wallet, ArrowRight, Settings as SettingsIcon, Plug, BookUser } from "lucide-react"
 import { observer } from "mobx-react-lite"
 import { useStore } from "@/stores/store"
 
@@ -35,6 +35,12 @@ const sidebarItems = [
         url: ROUTES.TRANSFER,
         label: "Send",
         icon: ArrowRight,
+    },
+    {
+        title: "Address Book",
+        url: ROUTES.ADDRESS_BOOK,
+        label: "Contacts",
+        icon: BookUser,
     },
     {
         title: "Settings",

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -24,6 +24,7 @@ const TransactionHistory = lazy(() => import("../components/Core/Body/Transactio
 const Transfer = lazy(() => import("../components/Core/Body/Transfer/Transfer.tsx"));
 const DAppSessionsPage = lazy(() => import("../components/Core/Body/DAppConnect/DAppSessionsPage.tsx"));
 const NftDetail = lazy(() => import("../components/Core/Body/Nfts/NftDetail.tsx"));
+const AddressBook = lazy(() => import("../components/Core/Body/AddressBook/AddressBook.tsx"));
 
 const ROUTES = {
   HOME: "/",
@@ -41,6 +42,7 @@ const ROUTES = {
   TOKEN_STATUS: "/token-status",
   TRANSACTION_HISTORY: "/tx-history",
   DAPP_SESSIONS: "/dapp-sessions",
+  ADDRESS_BOOK: "/address-book",
   NFT_DETAIL: "/nft/:contractAddress/:tokenId",
 } as const;
 
@@ -171,6 +173,14 @@ const router = createAppRouter([
         element: (
           <Suspense fallback={<Loading />}>
             <DAppSessionsPage />
+          </Suspense>
+        )
+      },
+      {
+        path: ROUTES.ADDRESS_BOOK,
+        element: (
+          <Suspense fallback={<Loading />}>
+            <AddressBook />
           </Suspense>
         )
       },

--- a/src/utils/addressBook.ts
+++ b/src/utils/addressBook.ts
@@ -1,0 +1,90 @@
+/**
+ * Address book: named QRL address contacts persisted in localStorage.
+ *
+ * Plain data (names + public Q-addresses), so it deliberately lives outside
+ * StorageUtil's expiring-item envelope: contacts must never silently expire.
+ */
+
+export interface AddressBookEntry {
+  id: string;
+  name: string;
+  address: string;
+  createdAt: number;
+}
+
+const STORAGE_KEY = "qrl:addressBook:v1";
+
+export const isValidQrlAddress = (address: string): boolean => {
+  const trimmed = address.trim();
+  return trimmed.startsWith("Q") && trimmed.length === 41;
+};
+
+const isEntry = (value: unknown): value is AddressBookEntry => {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v["id"] === "string" &&
+    typeof v["name"] === "string" &&
+    typeof v["address"] === "string" &&
+    typeof v["createdAt"] === "number"
+  );
+};
+
+export function loadAddressBook(): AddressBookEntry[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isEntry);
+  } catch {
+    return [];
+  }
+}
+
+function persist(entries: AddressBookEntry[]): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+}
+
+export function findByAddress(address: string): AddressBookEntry | undefined {
+  const needle = address.trim().toLowerCase();
+  return loadAddressBook().find((e) => e.address.toLowerCase() === needle);
+}
+
+/** Add a contact. Returns the new entry, or an error message string. */
+export function addEntry(name: string, address: string): AddressBookEntry | string {
+  const cleanName = name.trim();
+  const cleanAddress = address.trim();
+  if (!cleanName) return "Name is required";
+  if (!isValidQrlAddress(cleanAddress)) return "Not a valid QRL address (Q + 40 characters)";
+  if (findByAddress(cleanAddress)) return "This address is already saved";
+  const entry: AddressBookEntry = {
+    id: `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
+    name: cleanName,
+    address: cleanAddress,
+    createdAt: Date.now(),
+  };
+  persist([...loadAddressBook(), entry]);
+  return entry;
+}
+
+/** Rename a contact. Returns true when an entry was updated. */
+export function renameEntry(id: string, name: string): boolean {
+  const cleanName = name.trim();
+  if (!cleanName) return false;
+  const entries = loadAddressBook();
+  const target = entries.find((e) => e.id === id);
+  if (!target) return false;
+  target.name = cleanName;
+  persist(entries);
+  return true;
+}
+
+/** Delete a contact. Returns true when an entry was removed. */
+export function removeEntry(id: string): boolean {
+  const entries = loadAddressBook();
+  const next = entries.filter((e) => e.id !== id);
+  if (next.length === entries.length) return false;
+  persist(next);
+  return true;
+}


### PR DESCRIPTION
TestFlight feedback on build 25 asked for an address book on the Transfer page, the navbar, and Settings. All three circled surfaces turn out to be web-side (the in-app bottom bar is MobileNav rendered in the WebView), so this lands the whole feature here.

## What
- **Storage** (`src/utils/addressBook.ts`): localStorage contacts `{id, name, address, createdAt}` under versioned key `qrl:addressBook:v1`, shape-guarded load, Q-address validation (Q + 40 chars), duplicate detection. Plain public data, kept outside StorageUtil's expiring envelope on purpose (contacts must not expire).
- **/address-book page**: list (copy / send / rename / delete with confirm), add dialog, empty state. Send prefills Transfer via navigation state.
- **Transfer**: BookUser button inside the receiver field (sits left of the scan-QR button in the app), opens a picker dialog; the picker also offers "save the currently typed address" when it's valid and unknown. Field description updated.
- **Nav**: Contacts item in MobileNav + desktop sidebar; Address Book card on the web Settings page (native app settings row is a separate app-repo follow-up, navbar covers in-app access meanwhile).

## Gates
- `npm run lint` zero warnings, `npm run build` green, `npm test` 244/244.

## Test on staging (auto-deploys on merge)
dev.qrlwallet.com: add a contact, pick it on Transfer, save-from-Transfer flow, rename/delete, Contacts tab in the mobile navbar.