### PR TITLE
fix(address-book): native-backed persistence + full-wipe clearing + #227 review follow-ups

### DIFF
--- a/src/components/Core/Body/AddressBook/AddressBookPicker.tsx
+++ b/src/components/Core/Body/AddressBook/AddressBookPicker.tsx
@@ -13,12 +13,7 @@ import {
 } from "@/components/UI/Dialog";
 import { ROUTES } from "@/router/router";
 import { formatAddressShort } from "@/utils/formatting";
-import {
-  addEntry,
-  findByAddress,
-  isValidQrlAddress,
-  loadAddressBook,
-} from "@/utils/addressBook";
+import { addEntry, isValidQrlAddress, loadAddressBook } from "@/utils/addressBook";
 
 interface AddressBookPickerProps {
   open: boolean;
@@ -56,8 +51,12 @@ export function AddressBookPicker({
   };
 
   const trimmedCurrent = (currentAddress ?? "").trim();
+  // Gated on open and derived from the in-memory list so a closed picker
+  // costs the parent's renders nothing (PR #227 review feedback).
   const offerSave =
-    isValidQrlAddress(trimmedCurrent) && findByAddress(trimmedCurrent) === undefined;
+    open &&
+    isValidQrlAddress(trimmedCurrent) &&
+    !entries.some((e) => e.address.toLowerCase() === trimmedCurrent.toLowerCase());
 
   const handleSaveCurrent = () => {
     const result = addEntry(saveName, trimmedCurrent);

--- a/src/components/NativeAppBridge.tsx
+++ b/src/components/NativeAppBridge.tsx
@@ -26,6 +26,7 @@ import { WalletEncryptionUtil } from '@/utils/crypto/walletEncryption';
 import { reEncryptSeedAsync, CryptoOperationError, CryptoErrorCode } from '@/utils/crypto';
 import { ROUTES } from '@/router/router';
 import StorageUtil from '@/utils/storage/storage';
+import { clearAddressBook, mergeContacts } from '@/utils/addressBook';
 import { QRL_PROVIDER } from '@/config';
 import { store } from '@/stores/store';
 
@@ -257,6 +258,32 @@ const NativeAppBridge: React.FC = () => {
           break;
         }
 
+        case 'RESTORE_CONTACTS' as NativeToWebMessageType: {
+          // Native pushes its address-book backup on boot; merge it in
+          // (union by address, local wins) so contacts survive WebView
+          // data loss. mergeContacts syncs the union back to native.
+          try {
+            const { contacts } = (payload || {}) as Record<string, unknown>;
+            mergeContacts(contacts);
+          } catch (error) {
+            console.error('[Bridge] Error restoring contacts:', error);
+            logToNative(`Error restoring contacts: ${error instanceof Error ? error.message : String(error)}`);
+          }
+          break;
+        }
+
+        case 'NAVIGATE' as NativeToWebMessageType: {
+          // Native settings rows deep-link into web routes (e.g. the
+          // Address Book). Only plain in-app paths are accepted.
+          const { path } = (payload || {}) as Record<string, unknown>;
+          if (typeof path === 'string' && path.startsWith('/') && !path.startsWith('//')) {
+            navigate(path);
+          } else {
+            console.warn('[Bridge] Ignored NAVIGATE with invalid path:', path);
+          }
+          break;
+        }
+
         case 'CLIPBOARD_SUCCESS':
           // Could show a toast notification
           console.log('[Bridge] Clipboard success');
@@ -333,6 +360,7 @@ const NativeAppBridge: React.FC = () => {
           // an explicit "erase everything" request from native settings.
           StorageUtil.clearAllTokenData();
           StorageUtil.clearAllNftData();
+          clearAddressBook();
 
           // Confirm to native that web cleared its data
           confirmWalletCleared();

--- a/src/utils/addressBook.ts
+++ b/src/utils/addressBook.ts
@@ -14,10 +14,10 @@ export interface AddressBookEntry {
 
 const STORAGE_KEY = "qrl:addressBook:v1";
 
-export const isValidQrlAddress = (address: string): boolean => {
-  const trimmed = address.trim();
-  return trimmed.startsWith("Q") && trimmed.length === 41;
-};
+// Shared validator (Q + 40 hex chars), re-exported for address-book UIs.
+export { isValidQrlAddress } from "./web3/address";
+import { isValidQrlAddress } from "./web3/address";
+import { isInNativeApp, notifyContactsUpdated } from "./nativeApp";
 
 const isEntry = (value: unknown): value is AddressBookEntry => {
   if (typeof value !== "object" || value === null) return false;
@@ -44,6 +44,12 @@ export function loadAddressBook(): AddressBookEntry[] {
 
 function persist(entries: AddressBookEntry[]): void {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+  // In the app, native AsyncStorage is the durable copy: iOS may evict
+  // WebView website data under storage pressure. Native restores it on
+  // boot (RESTORE_CONTACTS) and deletes it on Remove All Wallets.
+  if (isInNativeApp()) {
+    notifyContactsUpdated(entries);
+  }
 }
 
 export function findByAddress(address: string): AddressBookEntry | undefined {
@@ -87,4 +93,30 @@ export function removeEntry(id: string): boolean {
   if (next.length === entries.length) return false;
   persist(next);
   return true;
+}
+
+/**
+ * Erase the whole address book. Part of the CLEAR_WALLET full wipe;
+ * deliberately NOT called on logout, which (like token/NFT lists)
+ * preserves public curated data so re-importing restores it. The native
+ * side deletes its own backup in the same wipe flow.
+ */
+export function clearAddressBook(): void {
+  localStorage.removeItem(STORAGE_KEY);
+}
+
+/**
+ * Merge the native backup into the local book (union by address; local
+ * entries win). Called from the RESTORE_CONTACTS bridge message; the
+ * resulting union syncs back to native via persist().
+ */
+export function mergeContacts(incoming: unknown): void {
+  if (!Array.isArray(incoming)) return;
+  const valid = incoming.filter(isEntry).filter((e) => isValidQrlAddress(e.address));
+  if (valid.length === 0) return;
+  const existing = loadAddressBook();
+  const known = new Set(existing.map((e) => e.address.toLowerCase()));
+  const additions = valid.filter((e) => !known.has(e.address.toLowerCase()));
+  if (additions.length === 0) return;
+  persist([...existing, ...additions]);
 }

--- a/src/utils/nativeApp.ts
+++ b/src/utils/nativeApp.ts
@@ -23,6 +23,7 @@ export type WebToNativeMessageType =
   | 'WEB_APP_READY'         // Web app is fully initialized and ready to receive data
   | 'PIN_VERIFIED'          // Web responds to PIN verification request
   | 'PIN_CHANGED'           // Web responds to PIN change request
+  | 'CONTACTS_UPDATED'      // Web address book changed, native should back it up
   // Navigation messages
   | 'OPEN_NATIVE_SETTINGS'  // Request native app to open its settings screen
   // DApp Connect messages
@@ -54,7 +55,9 @@ export type NativeToWebMessageType =
   | 'DAPP_URI'              // Deep link URI received by native, forwarded to WebView
   | 'DAPP_DISCONNECT'       // Native requests web to disconnect a specific dApp session
   // Display preferences (native settings drives the Home card toggles)
-  | 'SET_DISPLAY_PREFS';    // Native sets showTokensCard / showNftsCard in wallet settings
+  | 'SET_DISPLAY_PREFS'     // Native sets showTokensCard / showNftsCard in wallet settings
+  | 'RESTORE_CONTACTS'      // Native sends the backed-up address book on boot
+  | 'NAVIGATE';             // Native asks the web app to navigate to an in-app route
 
 export interface NativeMessage {
   type: NativeToWebMessageType;
@@ -258,6 +261,14 @@ export const notifySeedStored = (options: {
   blockchain: string;
 }): boolean => {
   return sendToNative('SEED_STORED', options);
+};
+
+/**
+ * Mirror the address book to native storage so contacts survive WebView
+ * data loss; native persists them until an explicit Remove All Wallets.
+ */
+export const notifyContactsUpdated = (contacts: unknown[]): boolean => {
+  return sendToNative('CONTACTS_UPDATED', { contacts });
 };
 
 /**


### PR DESCRIPTION
Answers "where is it stored and why didn't logout clear it", implements the decided policy (contacts persist unless wallets are wiped), and addresses the gemini comments on #227.

## Storage policy
- Contacts live in web localStorage (`qrl:addressBook:v1`). Logout intentionally keeps them, same documented precedent as token/NFT lists in `logout.ts` (public curated data restored on re-import; secrets are what logout wipes).
- **Fixed gap:** the CLEAR_WALLET full wipe (native Remove All Wallets) now clears the address book; it previously left contacts behind.

## In-app durability (pairs with app PR)
- iOS can evict WebView website data, so every persist mirrors contacts to native via new `CONTACTS_UPDATED`; the app stores them in AsyncStorage and pushes them back on boot via `RESTORE_CONTACTS`; web merges (union by address, local wins, shape-guarded + validated). Old app builds ignore the unknown message; no compatibility break.
- New `NAVIGATE` message so native settings rows can deep-link web routes (validated, in-app paths only).

## Review follow-ups from #227
- Adopted: shared strict validator `utils/web3/address.ts` (adds the 40-hex check); picker's save-offer computed from in-memory entries and gated on `open` (closed picker = zero localStorage reads during Transfer renders).
- Declined with reason: both useEffect-load suggestions collide with this repo's `react-hooks/set-state-in-effect` lint error (the pattern was removed during #227 for exactly that rule).

Gates: lint 0 warnings, build green, 244/244 tests.