### PR TITLE
feat: connect the mobile app as a remote signer via QRL Connect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@fontsource-variable/sora": "^5.2.8",
         "@hookform/resolvers": "^5.2.2",
         "@noble/post-quantum": "^0.5.4",
+        "@qrlwallet/connect": "^3.3.0",
         "@radix-ui/react-checkbox": "^1.1.3",
         "@radix-ui/react-dialog": "^1.1.6",
         "@radix-ui/react-dropdown-menu": "^2.1.1",
@@ -3478,6 +3479,34 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@qrlwallet/connect": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@qrlwallet/connect/-/connect-3.3.0.tgz",
+      "integrity": "sha512-Gsg4pXNLGu2uEFXBvqusBC0f90xwYGr5mnQXBjTWsVQvO1qXXHLMG7RlRbopf6jJ8aGefFtF7mdHwaMCdONm0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^2.2.0",
+        "@noble/post-quantum": "^0.5.4",
+        "@theqrl/mldsa87": "^2.1.1",
+        "eventemitter3": "^5.0.1",
+        "socket.io-client": "^4.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@qrlwallet/connect/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -8875,6 +8904,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/exit-x": {
       "version": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@fontsource-variable/sora": "^5.2.8",
     "@hookform/resolvers": "^5.2.2",
     "@noble/post-quantum": "^0.5.4",
+    "@qrlwallet/connect": "^3.3.0",
     "@radix-ui/react-checkbox": "^1.1.3",
     "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-dropdown-menu": "^2.1.1",

--- a/src/components/Core/Body/AccountList/ActiveAccount/ActiveAccount.tsx
+++ b/src/components/Core/Body/AccountList/ActiveAccount/ActiveAccount.tsx
@@ -42,9 +42,13 @@ export const ActiveAccount = observer(() => {
   // Mobile-app pairings get an explicit Disconnect: it ends the relay session
   // (notifying the phone) and removes the account from this wallet.
   const disconnectMobileAccount = async () => {
-    await disconnectMobile();
-    qrlStore.setMobileProvider(null);
-    await qrlStore.removeMobileAccounts();
+    try {
+      await disconnectMobile();
+      qrlStore.setMobileProvider(null);
+      await qrlStore.removeMobileAccounts();
+    } catch (error) {
+      console.error("Failed to disconnect mobile account:", error);
+    }
   };
 
   return (

--- a/src/components/Core/Body/AccountList/ActiveAccount/ActiveAccount.tsx
+++ b/src/components/Core/Body/AccountList/ActiveAccount/ActiveAccount.tsx
@@ -11,7 +11,7 @@ import { ROUTES } from "../../../../../router/router";
 import { useStore } from "../../../../../stores/store";
 import { getExplorerAddressUrl } from "@/config";
 import { openExternalUrl } from "@/utils/nativeApp";
-import { ExternalLink, SendHorizontal, History } from "lucide-react";
+import { ExternalLink, SendHorizontal, History, Unlink } from "lucide-react";
 import { observer } from "mobx-react-lite";
 import { Link } from "react-router-dom";
 import { AccountId } from "../AccountId/AccountId";
@@ -20,7 +20,9 @@ import { useState } from "react";
 import { QRCodeSVG } from "qrcode.react";
 import { TransactionHistoryPopup } from "./TransactionHistoryPopup";
 import { ExtensionBadge } from "../ExtensionBadge/ExtensionBadge";
+import { MobileBadge } from "../MobileBadge/MobileBadge";
 import { CopyAddressButton } from "../CopyAddressButton/CopyAddressButton";
+import { disconnectMobile } from "@/utils/mobileConnect/mobileConnection";
 
 export const ActiveAccount = observer(() => {
   const { qrlStore } = useStore();
@@ -37,6 +39,14 @@ export const ActiveAccount = observer(() => {
     openExternalUrl(getExplorerAddressUrl(accountAddress, blockchain));
   };
 
+  // Mobile-app pairings get an explicit Disconnect: it ends the relay session
+  // (notifying the phone) and removes the account from this wallet.
+  const disconnectMobileAccount = async () => {
+    await disconnectMobile();
+    qrlStore.setMobileProvider(null);
+    await qrlStore.removeMobileAccounts();
+  };
+
   return (
     !!accountAddress && (
       <>
@@ -47,6 +57,7 @@ export const ActiveAccount = observer(() => {
             <div className="flex flex-col gap-1">
               <AccountBalance className="m-auto md:m-0" accountAddress={accountAddress} />
               {activeAccountSource === 'extension' && <ExtensionBadge />}
+              {activeAccountSource === 'mobile' && <MobileBadge />}
             </div>
           </div>
           <div className="flex gap-4 items-center">
@@ -124,6 +135,27 @@ export const ActiveAccount = observer(() => {
                 </Tooltip>
               </TooltipProvider>
             </span>
+            {activeAccountSource === 'mobile' && (
+              <span>
+                <TooltipProvider>
+                  <Tooltip delayDuration={0}>
+                    <TooltipTrigger asChild>
+                      <Button
+                        className="hover:text-destructive"
+                        variant="outline"
+                        size="icon"
+                        onClick={() => void disconnectMobileAccount()}
+                      >
+                        <Unlink size={18} />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">
+                      <Label>Disconnect mobile app</Label>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              </span>
+            )}
           </div>
         </Card>
         <TransactionHistoryPopup 

--- a/src/components/Core/Body/AccountList/MobileBadge/MobileBadge.tsx
+++ b/src/components/Core/Body/AccountList/MobileBadge/MobileBadge.tsx
@@ -1,0 +1,5 @@
+export const MobileBadge = () => (
+  <span className="w-fit rounded px-2 py-0.5 text-[10px] font-semibold uppercase bg-emerald-800/30 text-emerald-400">
+    Mobile App
+  </span>
+);

--- a/src/components/Core/Body/AccountList/OtherAccounts/OtherAccounts.tsx
+++ b/src/components/Core/Body/AccountList/OtherAccounts/OtherAccounts.tsx
@@ -15,6 +15,7 @@ import { observer } from "mobx-react-lite";
 import { AccountId } from "../AccountId/AccountId";
 import { AccountBalance } from "../AccountBalance/AccountBalance";
 import { ExtensionBadge } from "../ExtensionBadge/ExtensionBadge";
+import { MobileBadge } from "../MobileBadge/MobileBadge";
 import { CopyAddressButton } from "../CopyAddressButton/CopyAddressButton";
 
 export const OtherAccounts = observer(() => {
@@ -50,6 +51,7 @@ export const OtherAccounts = observer(() => {
               <AccountId className="text-xs md:text-sm" account={accountAddress} />
               <AccountBalance className="m-auto md:m-0" accountAddress={accountAddress} />
               {source === 'extension' && <ExtensionBadge />}
+              {source === 'mobile' && <MobileBadge />}
             </div>
             <div className="flex gap-4 items-center">
               <CopyAddressButton accountAddress={accountAddress} />

--- a/src/components/Core/Body/CreateToken/TokenCreationForm/TokenCreationForm.tsx
+++ b/src/components/Core/Body/CreateToken/TokenCreationForm/TokenCreationForm.tsx
@@ -102,7 +102,10 @@ export const TokenCreationForm = observer(
             formState: { isSubmitting, isValid },
         } = form;
 
-        const isUsingExtension = activeAccountSource === 'extension';
+        // Extension and mobile-app accounts have no local seed; token
+        // creation needs one, so both are blocked below.
+        const isUsingRemoteSigner =
+            activeAccountSource === 'extension' || activeAccountSource === 'mobile';
 
         const formatRealValue = (supply: string, decimals: number) => {
             try {
@@ -123,9 +126,9 @@ export const TokenCreationForm = observer(
                     return;
                 }
 
-                // For extension wallets, we need to handle differently
-                if (isUsingExtension) {
-                    setFormError("Token creation with extension wallets is not yet supported. Please use an imported seed account.");
+                // Remote-signer wallets cannot create tokens yet
+                if (isUsingRemoteSigner) {
+                    setFormError("Token creation with connected wallets is not yet supported. Please use an imported seed account.");
                     return;
                 }
 
@@ -134,7 +137,7 @@ export const TokenCreationForm = observer(
                 // renderer: the store builds the calldata and routes through
                 // the signer, so we pass an empty mnemonic placeholder.
                 let mnemonicPhrase = "";
-                if (!isUsingExtension && !isDesktop) {
+                if (!isUsingRemoteSigner && !isDesktop) {
                     if (!pin) {
                         setPinError("PIN is required");
                         return;
@@ -512,7 +515,7 @@ export const TokenCreationForm = observer(
                                 />
                             )}
 
-                            {isUsingExtension ? (
+                            {isUsingRemoteSigner ? (
                                 <div className="flex flex-col p-4 bg-yellow-900/20 rounded-lg">
                                     <p className="text-sm text-yellow-200">
                                         Token creation is currently only supported for imported seed accounts.
@@ -541,7 +544,7 @@ export const TokenCreationForm = observer(
                         </CardContent>
                         <CardFooter>
                             <ShinyButton
-                                disabled={!isValid || (!isUsingExtension && !isDesktop && pin.length === 0) || isUsingExtension}
+                                disabled={!isValid || (!isUsingRemoteSigner && !isDesktop && pin.length === 0) || isUsingRemoteSigner}
                                 processing={isSubmitting}
                                 className="w-full"
                                 type="submit"

--- a/src/components/Core/Body/Home/AccountCreateImport/AccountCreateImport.tsx
+++ b/src/components/Core/Body/Home/AccountCreateImport/AccountCreateImport.tsx
@@ -9,16 +9,18 @@ import {
 import { ROUTES } from "../../../../../router/router";
 import { useStore } from "../../../../../stores/store";
 import { cva } from "class-variance-authority";
-import { Download, Plus, Link2 } from "lucide-react";
+import { Download, Plus, Link2, Smartphone } from "lucide-react";
 import { observer } from "mobx-react-lite";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import {
   connectWithProvider,
   discoverQrlProviders,
   type EIP6963ProviderDetail,
 } from "@/utils/extension";
+import { startMobilePairing } from "@/utils/mobileConnect/mobileConnection";
 import ExtensionPickerDialog from "./ExtensionPickerDialog";
+import MobilePairingDialog from "./MobilePairingDialog";
 import { isInNativeApp } from "@/utils/nativeApp";
 import { isDesktop } from "@/desktop/bridge";
 
@@ -43,13 +45,26 @@ const AccountCreateImport = observer(() => {
 
   const hasActiveAccount = !!accountAddress;
   const hasAccountCreationPreference = !!state?.hasAccountCreationPreference;
-  // The browser-extension connect option is web-only (hidden in the native app
-  // and the desktop app), so its mention is dropped from the copy there too.
+  // The connect options (browser extension, mobile app pairing) are web-only:
+  // hidden in the native app (it IS the mobile wallet) and the desktop app
+  // (the signer is the wallet). The copy drops their mention there too.
   const description = (isInNativeApp() || isDesktop)
     ? "You are connected to the blockchain. Create a new account or import an existing account."
-    : "You are connected to the blockchain. Create a new account, import an existing account, or connect using your browser extension.";
+    : "You are connected to the blockchain. Create a new account, import an existing account, or connect a wallet you already use: your browser extension or the MyQRLWallet mobile app.";
 
   const [pickerProviders, setPickerProviders] = useState<EIP6963ProviderDetail[] | null>(null);
+  const [mobilePairing, setMobilePairing] = useState<{ uri: string; installHint: string | null } | null>(null);
+  const [mobileConnectError, setMobileConnectError] = useState<string | null>(null);
+
+  // Close the pairing dialog once the store adopts the paired account (the
+  // mobileConnection event wiring sets the provider on 'connect').
+  const isMobileProviderSet = !!qrlStore.mobileProvider;
+  useEffect(() => {
+    if (mobilePairing && isMobileProviderSet) {
+      setMobilePairing(null);
+      navigate(ROUTES.HOME);
+    }
+  }, [mobilePairing, isMobileProviderSet, navigate]);
 
   const finishConnect = async (detail: EIP6963ProviderDetail) => {
     setPickerProviders(null);
@@ -81,6 +96,24 @@ const AccountCreateImport = observer(() => {
     setPickerProviders(providers);
   };
 
+  const openMobilePairing = async (fresh: boolean) => {
+    setMobileConnectError(null);
+    try {
+      const result = await startMobilePairing(qrlStore, fresh);
+      // On mobile browsers a successful deep link foregrounds the app; the
+      // relay events complete the pairing when the user returns.
+      if (result.redirected) return;
+      setMobilePairing({ uri: result.uri, installHint: result.installHint });
+    } catch (error) {
+      console.error("Mobile pairing failed to start:", error);
+      setMobileConnectError(
+        `Could not start mobile pairing: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  };
+
+  const handleConnectMobile = () => void openMobilePairing(false);
+
   return (
     <div
       className={accountCreateImportClasses({ hasAccountCreationPreference })}
@@ -107,13 +140,22 @@ const AccountCreateImport = observer(() => {
               Import an existing account
             </Button>
           </Link>
-          {/* Browser-extension connect is web-only. Hidden in the native app
-              and on desktop (the desktop signer is the wallet). */}
+          {/* The connect options are web-only. Hidden in the native app (it
+              IS the mobile wallet) and on desktop (the signer is the wallet). */}
           {!isInNativeApp() && !isDesktop && (
-            <Button className="w-full" type="button" variant="outline" onClick={handleConnectExtension}>
-              <Link2 className="mr-2 h-4 w-4" />
-              Connect Browser Extension
-            </Button>
+            <>
+              <Button className="w-full" type="button" variant="outline" onClick={handleConnectExtension}>
+                <Link2 className="mr-2 h-4 w-4" />
+                Connect Browser Extension
+              </Button>
+              <Button className="w-full" type="button" variant="outline" onClick={handleConnectMobile}>
+                <Smartphone className="mr-2 h-4 w-4" />
+                Connect Mobile App
+              </Button>
+              {mobileConnectError && (
+                <p className="text-sm text-destructive">{mobileConnectError}</p>
+              )}
+            </>
           )}
         </CardFooter>
       </Card>
@@ -123,6 +165,15 @@ const AccountCreateImport = observer(() => {
           providers={pickerProviders}
           onSelect={(detail) => void finishConnect(detail)}
           onClose={() => setPickerProviders(null)}
+        />
+      ) : null}
+
+      {mobilePairing ? (
+        <MobilePairingDialog
+          uri={mobilePairing.uri}
+          installHint={mobilePairing.installHint}
+          onClose={() => setMobilePairing(null)}
+          onNewCode={() => openMobilePairing(true)}
         />
       ) : null}
     </div>

--- a/src/components/Core/Body/Home/AccountCreateImport/MobilePairingDialog.tsx
+++ b/src/components/Core/Body/Home/AccountCreateImport/MobilePairingDialog.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useState } from "react";
+import { QRCodeSVG } from "qrcode.react";
+import { Copy, RefreshCw } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/UI/Dialog";
+import { Button } from "@/components/UI/Button";
+import { copyToClipboard } from "@/utils/nativeApp";
+import { subscribeMobileStatus } from "@/utils/mobileConnect/mobileConnection";
+
+interface Props {
+  uri: string;
+  /** Set on mobile browsers when the deep link into the app failed. */
+  installHint: string | null;
+  onClose: () => void;
+  /** Rotate to a fresh channel/keys and show the new code. */
+  onNewCode: () => Promise<void>;
+}
+
+/**
+ * Pairing dialog for connecting the MyQRLWallet mobile app as a remote
+ * signer: renders the qrlconnect:// URI as a QR for the phone to scan.
+ * The parent closes it when the store adopts the paired account.
+ */
+const MobilePairingDialog = ({ uri, installHint, onClose, onNewCode }: Props) => {
+  const [status, setStatus] = useState<string>("");
+  const [hasJustCopied, setHasJustCopied] = useState(false);
+  const [isRotating, setIsRotating] = useState(false);
+
+  useEffect(() => subscribeMobileStatus(setStatus), []);
+
+  const handleCopy = async () => {
+    const success = await copyToClipboard(uri);
+    if (success) {
+      setHasJustCopied(true);
+      setTimeout(() => setHasJustCopied(false), 1000);
+    }
+  };
+
+  const handleNewCode = async () => {
+    setIsRotating(true);
+    try {
+      await onNewCode();
+    } finally {
+      setIsRotating(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Connect Mobile App</DialogTitle>
+          <DialogDescription>
+            Open MyQRLWallet on your phone and scan this code to use the app
+            as the signer for this session.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col items-center gap-4">
+          <div className="rounded-lg bg-white p-3">
+            <QRCodeSVG value={uri} size={220} bgColor="#ffffff" fgColor="#000000" level="L" />
+          </div>
+          {installHint && (
+            <p className="text-center text-sm text-yellow-200">{installHint}</p>
+          )}
+          {status && (
+            <p className="text-center text-xs text-muted-foreground">{status}</p>
+          )}
+          <div className="flex w-full gap-4">
+            <Button className="w-full" type="button" variant="outline" onClick={handleCopy}>
+              <Copy className="mr-2 h-4 w-4" />
+              {hasJustCopied ? "Copied" : "Copy code"}
+            </Button>
+            <Button
+              className="w-full"
+              type="button"
+              variant="outline"
+              onClick={handleNewCode}
+              disabled={isRotating}
+            >
+              <RefreshCw className={`mr-2 h-4 w-4 ${isRotating ? "animate-spin" : ""}`} />
+              New code
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default MobilePairingDialog;

--- a/src/components/Core/Body/Home/AccountCreateImport/MobilePairingDialog.tsx
+++ b/src/components/Core/Body/Home/AccountCreateImport/MobilePairingDialog.tsx
@@ -45,6 +45,8 @@ const MobilePairingDialog = ({ uri, installHint, onClose, onNewCode }: Props) =>
     setIsRotating(true);
     try {
       await onNewCode();
+    } catch (error) {
+      console.error("Failed to rotate pairing code:", error);
     } finally {
       setIsRotating(false);
     }

--- a/src/components/Core/Body/Transfer/Transfer.tsx
+++ b/src/components/Core/Body/Transfer/Transfer.tsx
@@ -61,7 +61,7 @@ const Transfer = observer(() => {
     activeAccount,
     getAccountBalance,
     signAndSendTransaction,
-    sendTransactionViaExtension,
+    sendTransactionViaProvider,
     activeAccountSource,
     qrlConnection,
     transactionStatus,
@@ -73,8 +73,12 @@ const Transfer = observer(() => {
   const { accountAddress } = activeAccount;
 
   const isUsingExtension = activeAccountSource === 'extension';
+  const isUsingMobile = activeAccountSource === 'mobile';
+  // Remote signers (extension popup or paired mobile app) confirm in their
+  // own UI, so no local PIN is involved.
+  const isUsingRemoteSigner = isUsingExtension || isUsingMobile;
 
-  // Create FormSchema with PIN validation based on isUsingExtension
+  // Create FormSchema with PIN validation based on the signer type
   const FormSchema = useMemo(() => z
     .object({
       asset: z.string().min(1, "Please select an asset"),
@@ -97,10 +101,10 @@ const Transfer = observer(() => {
         }
       }
 
-      // Validate PIN for non-extension seed accounts. On desktop there is no
-      // PIN: the signer session is already unlocked, so the PIN field is
-      // hidden and not required.
-      if (!isUsingExtension && !isDesktop) {
+      // Validate PIN for seed accounts only. Remote signers confirm on their
+      // side, and on desktop there is no PIN: the signer session is already
+      // unlocked, so the PIN field is hidden and not required.
+      if (!isUsingRemoteSigner && !isDesktop) {
         if (!fields.pin || fields.pin.length < 4 || fields.pin.length > 6) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
@@ -109,7 +113,7 @@ const Transfer = observer(() => {
           });
         }
       }
-    }), [isUsingExtension]);
+    }), [isUsingRemoteSigner]);
 
   // Get initial asset from URL params (for token transfers from home page)
   const initialAsset = searchParams.get('asset') || 'native';
@@ -345,9 +349,13 @@ const Transfer = observer(() => {
     if (isNativeTransfer) {
       await handleNativeTransfer(formData);
     } else {
-      // Token transfers not supported for extension wallets
-      if (isUsingExtension) {
-        control.setError("asset", { message: "Token transfers are not yet supported with extension wallets." });
+      // Token transfers not supported for remote-signer wallets yet
+      if (isUsingRemoteSigner) {
+        control.setError("asset", {
+          message: isUsingMobile
+            ? "Token transfers are not yet supported with a connected mobile app wallet."
+            : "Token transfers are not yet supported with extension wallets.",
+        });
         return;
       }
       await handleTokenTransfer(formData);
@@ -367,8 +375,8 @@ const Transfer = observer(() => {
       } catch (error) {
         control.setError("receiverAddress", { message: `Transaction failed: ${error instanceof Error ? error.message : String(error)}` });
       }
-    } else if (isUsingExtension) {
-      await sendTransactionViaExtension(formData.receiverAddress, valueEther, feeLevel);
+    } else if (isUsingRemoteSigner) {
+      await sendTransactionViaProvider(formData.receiverAddress, valueEther, feeLevel);
       resetForm();
       window.scrollTo(0, 0);
     } else {
@@ -900,9 +908,10 @@ const Transfer = observer(() => {
                     )}
                   />
 
-                  {/* PIN Input. Hidden on desktop: the signer session is
+                  {/* PIN Input. Hidden for remote signers (they confirm in
+                      their own UI) and on desktop: the signer session is
                       already unlocked and signing does not re-prompt. */}
-                  {!isUsingExtension && !isDesktop && (
+                  {!isUsingRemoteSigner && !isDesktop && (
                     <FormField
                       control={control}
                       name="pin"
@@ -926,8 +935,15 @@ const Transfer = observer(() => {
                     />
                   )}
 
-                  {/* Gas Fee Notice (only for native transfers) */}
-                  {isNativeTransfer && (
+                  {/* Gas Fee Notice (only for native transfers). Hidden for
+                      mobile-app accounts: the phone estimates its own gas and
+                      presents the fee in its confirmation screen. */}
+                  {isNativeTransfer && isUsingMobile && (
+                    <p className="text-sm text-muted-foreground">
+                      The network fee is estimated and confirmed in the mobile app.
+                    </p>
+                  )}
+                  {isNativeTransfer && !isUsingMobile && (
                     <GasFeeNotice
                       from={accountAddress}
                       to={formValues.receiverAddress}

--- a/src/stores/qrlStore.ts
+++ b/src/stores/qrlStore.ts
@@ -92,6 +92,10 @@ class QrlStore {
   // Updated initial state
   transactionStatus: TransactionStatus = { state: 'idle', txHash: null, receipt: null, error: null, pendingDetails: null };
   extensionProvider: ExtensionProvider | null = null; // NEW: Store the extension provider
+  // Remote signer for accounts paired with the mobile app over the QRL
+  // Connect relay (source 'mobile'). Same request() surface as the extension
+  // provider; the live QRLConnect instance is owned by utils/mobileConnect.
+  mobileProvider: ExtensionProvider | null = null;
   qrlPrice: number = 0; // USD price from Explorer
   qrlPriceChange24h: number = 0; // 24h price change percentage
 
@@ -142,6 +146,16 @@ class QrlStore {
     );
   }
 
+  // Remote-signer provider for the ACTIVE account, or null for seed accounts.
+  // Extension and mobile accounts share one request() surface; only the
+  // transaction param shape differs (see sendTransactionViaProvider).
+  get remoteProvider(): ExtensionProvider | null {
+    const source = this.activeAccountSource;
+    if (source === 'extension') return this.extensionProvider;
+    if (source === 'mobile') return this.mobileProvider;
+    return null;
+  }
+
   // 3) Active account balance in USD
   get activeAccountBalanceUsd(): number {
     const balance = parseFloat(this.activeAccountBalance) || 0;
@@ -156,6 +170,7 @@ class QrlStore {
       activeAccount: observable.struct,
       transactionStatus: observable.struct,
       extensionProvider: observable.ref, // Use ref for complex objects like providers
+      mobileProvider: observable.ref,
       qrlPrice: observable,
       qrlPriceChange24h: observable,
       // Runtime handles + their cleanup helper — not observable.
@@ -170,6 +185,7 @@ class QrlStore {
       onActiveAccountChanged: false,
       activeAccountBalance: computed,
       activeAccountSource: computed,
+      remoteProvider: computed,
       activeAccountBalanceUsd: computed,
       fetchQrlPrice: action.bound,
       selectBlockchain: action.bound,
@@ -181,7 +197,10 @@ class QrlStore {
       resetTransactionStatus: action.bound,
       fetchPendingTxDetails: action.bound,
       setExtensionProvider: action.bound,
-      sendTransactionViaExtension: action.bound,
+      setMobileProvider: action.bound,
+      adoptMobileAccount: action.bound,
+      removeMobileAccounts: action.bound,
+      sendTransactionViaProvider: action.bound,
       estimateNativeTransferFee: action.bound,
     });
 
@@ -694,8 +713,10 @@ class QrlStore {
   }
 
   // Worst-case fee reserve for a native QRL transfer at the given fee level.
-  // gasLimit defaults to 21000 (matches signAndSendTransaction); callers using
-  // sendTransactionViaExtension must pass 53000 to match that path.
+  // gasLimit defaults to 21000 (matches signAndSendTransaction); extension
+  // sends via sendTransactionViaProvider use 53000, so callers on that path
+  // must pass it. Mobile-app sends estimate on the phone; 21000 is the
+  // native-transfer floor and serves as the reserve approximation there.
   // Returns the amount in QRL that must stay in the wallet to cover gas.
   async estimateNativeTransferFee(
     feeLevel: FeeLevel = 'medium',
@@ -879,6 +900,55 @@ class QrlStore {
     });
   }
 
+  // Set or clear the mobile-app relay provider (owned by utils/mobileConnect).
+  setMobileProvider(provider: ExtensionProvider | null) {
+    runInAction(() => {
+      this.mobileProvider = provider;
+      log(provider ? "Mobile provider set." : "Mobile provider cleared.");
+    });
+  }
+
+  // Make `address` the single mobile-sourced account: a pairing represents
+  // exactly one phone account, so an accountsChanged to a new address
+  // replaces the old entry rather than accumulating stale ones.
+  async adoptMobileAccount(address: string) {
+    const blockchain = this.qrlConnection.blockchain;
+    try {
+      const list = await StorageUtil.getAccountList(blockchain);
+      const filtered = list.filter(
+        (item) =>
+          item.source !== 'mobile' ||
+          item.address.toLowerCase() === address.toLowerCase(),
+      );
+      if (filtered.length !== list.length) {
+        await StorageUtil.setAccountList(blockchain, filtered);
+      }
+    } catch (error) {
+      console.error('Failed to prune stale mobile accounts:', error);
+    }
+    await this.setActiveAccount(address, 'mobile');
+  }
+
+  // Remove every mobile-sourced account (pairing ended, from either side).
+  async removeMobileAccounts() {
+    const blockchain = this.qrlConnection.blockchain;
+    const activeWasMobile = this.activeAccountSource === 'mobile';
+    try {
+      const list = await StorageUtil.getAccountList(blockchain);
+      const filtered = list.filter((item) => item.source !== 'mobile');
+      if (filtered.length !== list.length) {
+        await StorageUtil.setAccountList(blockchain, filtered);
+      }
+    } catch (error) {
+      console.error('Failed to remove mobile accounts:', error);
+    }
+    if (activeWasMobile) {
+      await this.setActiveAccount(undefined);
+    } else {
+      await this.fetchAccounts();
+    }
+  }
+
   // --- NEW: Function to poll for transaction receipt ---
   async pollForReceipt(txHash: string) {
     if (!txHash || !this.qrlInstance) return;
@@ -971,19 +1041,26 @@ class QrlStore {
   }
   // --- END NEW Function ---
 
-  // --- NEW: Send Transaction via Extension ---
-  async sendTransactionViaExtension(to: string, valueEther: string, feeLevel: FeeLevel = 'medium') {
-    if (!this.extensionProvider) {
-      console.error("sendTransactionViaExtension called but no provider is set.");
-      log("Error: sendTransactionViaExtension called without provider.");
+  // --- Send Transaction via a remote signer (extension or paired mobile app) ---
+  async sendTransactionViaProvider(to: string, valueEther: string, feeLevel: FeeLevel = 'medium') {
+    const source = this.activeAccountSource;
+    const walletName = source === 'mobile' ? 'mobile app' : 'extension';
+    const provider = this.remoteProvider;
+    if (!provider) {
+      console.error("sendTransactionViaProvider called but no provider is set.");
+      log("Error: sendTransactionViaProvider called without provider.");
       runInAction(() => {
-        this.transactionStatus = { ...this.transactionStatus, state: 'failed', error: 'Extension not connected.' };
+        this.transactionStatus = {
+          ...this.transactionStatus,
+          state: 'failed',
+          error: source === 'mobile' ? 'Mobile app wallet not connected.' : 'Extension not connected.',
+        };
       });
       return;
     }
     if (!this.activeAccount.accountAddress) {
-      console.error("sendTransactionViaExtension called but no active account.");
-      log("Error: sendTransactionViaExtension called without active account.");
+      console.error("sendTransactionViaProvider called but no active account.");
+      log("Error: sendTransactionViaProvider called without active account.");
       runInAction(() => {
         this.transactionStatus = { ...this.transactionStatus, state: 'failed', error: 'No active account selected.' };
       });
@@ -1008,36 +1085,49 @@ class QrlStore {
       }
       // --- End Wei Calculation ---
 
-      const gasLimit = 53000;
-
-      // Fetch current gas price and apply fee level multiplier
-      const baseGasPrice = (await this.qrlInstance?.getGasPrice()) ?? BigInt(1000000000);
-      const { maxFeePerGas, maxPriorityFeePerGas } = applyFeeLevel(baseGasPrice, feeLevel);
-
       const valueHex = "0x" + BigInt(valueBaseUnit).toString(16);
-      const gasHex = "0x" + gasLimit.toString(16);
-      const maxPriorityFeeHex = "0x" + maxPriorityFeePerGas.toString(16);
-      const maxFeeHex = "0x" + maxFeePerGas.toString(16);
 
-      const params = [{
-        from: this.activeAccount.accountAddress,
-        to: to,
-        value: valueHex, // Use manually hexed value from toPlanck("quanta")
-        gas: gasHex,
-        maxPriorityFeePerGas: maxPriorityFeeHex,
-        maxFeePerGas: maxFeeHex,
-        type: '0x2'
-      }];
+      let params: object[];
+      if (source === 'mobile') {
+        // The relay wallet estimates its own gas and shows its own fee UI, so
+        // it must receive the MINIMAL shape: dApp-supplied gas fields are
+        // ignored at best and shape-mismatched at worst.
+        params = [{
+          from: this.activeAccount.accountAddress,
+          to: to,
+          value: valueHex,
+        }];
+      } else {
+        const gasLimit = 53000;
 
-      log(`Requesting transaction via extension (18 Decimals): ${JSON.stringify(params)}`);
-      // Extension provider handles user confirmation popup
-      const txHash = await this.extensionProvider.request({
+        // Fetch current gas price and apply fee level multiplier
+        const baseGasPrice = (await this.qrlInstance?.getGasPrice()) ?? BigInt(1000000000);
+        const { maxFeePerGas, maxPriorityFeePerGas } = applyFeeLevel(baseGasPrice, feeLevel);
+
+        const gasHex = "0x" + gasLimit.toString(16);
+        const maxPriorityFeeHex = "0x" + maxPriorityFeePerGas.toString(16);
+        const maxFeeHex = "0x" + maxFeePerGas.toString(16);
+
+        params = [{
+          from: this.activeAccount.accountAddress,
+          to: to,
+          value: valueHex, // Use manually hexed value from toPlanck("quanta")
+          gas: gasHex,
+          maxPriorityFeePerGas: maxPriorityFeeHex,
+          maxFeePerGas: maxFeeHex,
+          type: '0x2'
+        }];
+      }
+
+      log(`Requesting transaction via ${walletName} (18 Decimals): ${JSON.stringify(params)}`);
+      // The remote wallet shows its own confirmation UI
+      const txHash = await provider.request({
         method: 'qrl_sendTransaction',
         params: params
       });
 
       if (txHash && typeof txHash === 'string') {
-        log(`Transaction sent via extension, hash: ${txHash}`);
+        log(`Transaction sent via ${walletName}, hash: ${txHash}`);
         runInAction(() => {
           // Still 'pending' until confirmed on-chain, but we have the hash
           this.transactionStatus = { ...this.transactionStatus, state: 'pending', txHash: txHash, error: null };
@@ -1046,14 +1136,14 @@ class QrlStore {
           this.pollForReceipt(txHash);
         });
       } else {
-        log(`Extension returned invalid txHash: ${txHash}`);
-        throw new Error("Extension did not return a valid transaction hash.");
+        log(`Wallet returned invalid txHash: ${txHash}`);
+        throw new Error(`The ${walletName} did not return a valid transaction hash.`);
       }
 
     } catch (error) {
-      console.error("Error sending transaction via extension:", error);
+      console.error(`Error sending transaction via ${walletName}:`, error);
       const message = getErrorMessage(error);
-      log(`Error sending via extension: ${message}`);
+      log(`Error sending via ${walletName}: ${message}`);
       runInAction(() => {
         // Check for user rejection code specifically if the provider follows EIP-1193 errors
         const userRejected = isProviderRpcError(error) && error.code === 4001;
@@ -1062,10 +1152,10 @@ class QrlStore {
           ...this.transactionStatus,
           state: 'failed',
           error: userRejected
-            ? 'Transaction rejected in extension.'
+            ? `Transaction rejected in ${walletName}.`
             : isCalcError
               ? message // Show calculation error
-              : (message || 'Transaction failed in extension.')
+              : (message || `Transaction failed in ${walletName}.`)
         };
       });
     }

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -3,6 +3,8 @@ import QrlStore from "./qrlStore";
 import TokenStore from "./tokenStore";
 import NftStore from "./nftStore";
 import DAppConnectStore from "./dappConnectStore";
+import { maybeRestoreMobileConnection } from "@/utils/mobileConnect/mobileConnection";
+import { StorageUtil } from "@/utils/storage";
 import { configure } from "mobx";
 
 // Configure MobX
@@ -29,6 +31,23 @@ class Store {
     this.qrlStore.onBlockchainReady = async () => {
       await this.tokenStore.initialize();
       await this.nftStore.initialize();
+
+      // Resume a mobile-app pairing (QRL Connect relay) if the SDK holds a
+      // stored session AND the account list still has a mobile-sourced
+      // account. Fire-and-forget: pairing restore must never block init.
+      try {
+        const list = await StorageUtil.getAccountList(
+          this.qrlStore.qrlConnection.blockchain,
+        );
+        const hasMobileAccount = list.some((item) => item.source === 'mobile');
+        void maybeRestoreMobileConnection(this.qrlStore, hasMobileAccount).catch(
+          (error: unknown) => {
+            console.error('Mobile pairing restore failed:', error);
+          },
+        );
+      } catch (error) {
+        console.error('Mobile pairing restore skipped:', error);
+      }
     };
     this.qrlStore.onActiveAccountChanged = async (newActiveAccount?: string) => {
       await this.tokenStore.handleActiveAccountChanged(newActiveAccount);

--- a/src/utils/logout.ts
+++ b/src/utils/logout.ts
@@ -4,6 +4,7 @@ import { QRL_PROVIDER } from "@/config";
 import { isInNativeApp } from "./nativeApp";
 import { clearAttemptTracker } from "./crypto/pinAttemptTracker";
 import { isDesktop, desktopSigner } from "@/desktop/bridge";
+import { disconnectMobile, hasMobileSession } from "./mobileConnect/mobileConnection";
 
 /**
  * A utility function to handle logout by clearing
@@ -33,6 +34,15 @@ export const handleLogout = async (navigate: (path: string) => void) => {
             navigate(ROUTES.HOME);
             window.location.reload();
             return;
+        }
+
+        // End any mobile-app pairing first (best-effort, notifies the phone
+        // when live) so the SDK session in localStorage cannot silently
+        // re-pair on the next load after the account list is wiped.
+        if (hasMobileSession()) {
+            await disconnectMobile().catch((err) =>
+                console.error("Logout: mobile pairing disconnect failed", err),
+            );
         }
 
         // Get all blockchain types

--- a/src/utils/mobileConnect/mobileConnection.ts
+++ b/src/utils/mobileConnect/mobileConnection.ts
@@ -79,9 +79,14 @@ async function createInstance(store: MobileConnectStore): Promise<QRLConnect> {
     const address = qrl.getAccounts()[0];
     if (!address) return;
     log(`Mobile connect: paired with ${address}`);
-    void store.adoptMobileAccount(address).then(() => {
-      store.setMobileProvider(asExtensionProvider(qrl));
-    });
+    void store
+      .adoptMobileAccount(address)
+      .then(() => {
+        store.setMobileProvider(asExtensionProvider(qrl));
+      })
+      .catch((error: unknown) => {
+        console.error("Mobile connect: failed to adopt paired account:", error);
+      });
   });
 
   qrl.on("accountsChanged", (accounts: string[]) => {
@@ -90,11 +95,15 @@ async function createInstance(store: MobileConnectStore): Promise<QRLConnect> {
       // Wallet revoked account access: same cleanup as a terminate.
       log("Mobile connect: accounts revoked");
       store.setMobileProvider(null);
-      void store.removeMobileAccounts();
+      void store.removeMobileAccounts().catch((error: unknown) => {
+        console.error("Mobile connect: failed to remove accounts:", error);
+      });
       return;
     }
     log(`Mobile connect: account changed to ${next}`);
-    void store.adoptMobileAccount(next);
+    void store.adoptMobileAccount(next).catch((error: unknown) => {
+      console.error("Mobile connect: failed to adopt changed account:", error);
+    });
   });
 
   qrl.on("disconnect", () => {
@@ -110,7 +119,9 @@ async function createInstance(store: MobileConnectStore): Promise<QRLConnect> {
     // startup reconnect gave up): drop the provider and the account.
     log("Mobile connect: session terminated");
     store.setMobileProvider(null);
-    void store.removeMobileAccounts();
+    void store.removeMobileAccounts().catch((error: unknown) => {
+      console.error("Mobile connect: failed to remove accounts:", error);
+    });
   });
 
   return qrl;

--- a/src/utils/mobileConnect/mobileConnection.ts
+++ b/src/utils/mobileConnect/mobileConnection.ts
@@ -1,0 +1,220 @@
+import type { QRLConnect } from "@qrlwallet/connect";
+import type { ExtensionProvider } from "@/stores/qrlStore";
+import type { AccountSource } from "@/utils/storage";
+import { log } from "@/utils";
+
+/**
+ * dApp-side QRL Connect client: pairs this web wallet with the MyQRLWallet
+ * mobile app over the relay, so the phone acts as a remote signer (the
+ * inverse of src/services/dappConnect/, which is the WALLET side answering
+ * incoming dApp sessions). Both roles run in the same page on separate relay
+ * channels and separate localStorage namespaces (wallet side:
+ * `qrlconnect:sessions`, this SDK: `@qrlwallet/connect:session`).
+ *
+ * The SDK is imported dynamically so its socket/ML-KEM weight stays out of
+ * the main bundle until a pairing exists or is requested.
+ */
+
+// Mirrors the SDK's default `${STORAGE_KEY_PREFIX}:session` key. Used for a
+// cheap "is there a stored pairing?" probe without loading the SDK chunk.
+const SDK_SESSION_KEY = "@qrlwallet/connect:session";
+const SDK_INFLIGHT_KEY = `${SDK_SESSION_KEY}:inflight`;
+
+/** The slice of qrlStore this module drives. Injected to avoid a dep cycle. */
+export interface MobileConnectStore {
+  setActiveAccount(newActiveAccount?: string, source?: AccountSource): Promise<void>;
+  setMobileProvider(provider: ExtensionProvider | null): void;
+  /** Make `address` the (single) mobile-sourced account, replacing any other. */
+  adoptMobileAccount(address: string): Promise<void>;
+  /** Remove all mobile-sourced accounts (pairing ended). */
+  removeMobileAccounts(): Promise<void>;
+}
+
+let instance: QRLConnect | null = null;
+let creating: Promise<QRLConnect> | null = null;
+
+// The SDK's request() returns Promise<unknown>; the store's ExtensionProvider
+// surface is generic. Adapt with a single assertion from unknown at the
+// boundary rather than pretending QRLConnect IS an ExtensionProvider.
+function asExtensionProvider(qrl: QRLConnect): ExtensionProvider {
+  return {
+    request: <T = unknown>(args: { method: string; params?: unknown[] | object }) => {
+      // The relay protocol takes positional (array) params only; wrap a bare
+      // object param the way EIP-1193 callers sometimes pass one.
+      const params =
+        args.params === undefined || Array.isArray(args.params)
+          ? args.params
+          : [args.params];
+      return qrl.request({ method: args.method, params }) as Promise<T>;
+    },
+  };
+}
+
+/** True when the SDK has a stored (unexpired at last write) pairing session. */
+export function hasMobileSession(): boolean {
+  try {
+    return localStorage.getItem(SDK_SESSION_KEY) !== null;
+  } catch {
+    return false;
+  }
+}
+
+async function createInstance(store: MobileConnectStore): Promise<QRLConnect> {
+  const { QRLConnect } = await import("@qrlwallet/connect");
+  const qrl = new QRLConnect({
+    dappMetadata: {
+      name: "MyQRLWallet Web",
+      url: window.location.origin,
+      // Peer redirect: after approving on the phone, return the user here.
+      redirectUrl: window.location.href,
+    },
+    autoReconnect: true,
+    // MANDATORY: the web wallet must never announce itself as an EIP-6963
+    // provider; it would show up in its own extension picker (and in every
+    // dApp's) as a wallet.
+    announceProvider: false,
+  });
+
+  qrl.on("connect", () => {
+    const address = qrl.getAccounts()[0];
+    if (!address) return;
+    log(`Mobile connect: paired with ${address}`);
+    void store.adoptMobileAccount(address).then(() => {
+      store.setMobileProvider(asExtensionProvider(qrl));
+    });
+  });
+
+  qrl.on("accountsChanged", (accounts: string[]) => {
+    const next = accounts[0];
+    if (!next) {
+      // Wallet revoked account access: same cleanup as a terminate.
+      log("Mobile connect: accounts revoked");
+      store.setMobileProvider(null);
+      void store.removeMobileAccounts();
+      return;
+    }
+    log(`Mobile connect: account changed to ${next}`);
+    void store.adoptMobileAccount(next);
+  });
+
+  qrl.on("disconnect", () => {
+    // The SDK also emits 'disconnect' when the phone is merely backgrounded
+    // (routine on mobile: the app loses its socket within seconds). The
+    // stored session survives that, and any request revives it: relay-
+    // buffered and, on SDK >= 3.3.0, deep-linked awake. Keep the account.
+    if (qrl.hasStoredSession()) {
+      log("Mobile connect: transient disconnect (session kept)");
+      return;
+    }
+    // Real terminate (phone-side disconnect, or a stale session whose
+    // startup reconnect gave up): drop the provider and the account.
+    log("Mobile connect: session terminated");
+    store.setMobileProvider(null);
+    void store.removeMobileAccounts();
+  });
+
+  return qrl;
+}
+
+/** Lazy singleton. The first caller's store gets wired into the events. */
+export async function getMobileConnect(store: MobileConnectStore): Promise<QRLConnect> {
+  if (instance) return instance;
+  creating ??= createInstance(store).then((qrl) => {
+    instance = qrl;
+    creating = null;
+    return qrl;
+  });
+  return creating;
+}
+
+/**
+ * Live pairing-status updates for the QR dialog. No-op unsubscribe when the
+ * SDK instance does not exist yet (callers subscribe after startMobilePairing,
+ * which guarantees creation).
+ */
+export function subscribeMobileStatus(cb: (status: string) => void): () => void {
+  const qrl = instance;
+  if (!qrl) return () => undefined;
+  const handler = (status: unknown) => cb(String(status));
+  qrl.on("statusChanged", handler);
+  return () => {
+    qrl.off("statusChanged", handler);
+  };
+}
+
+export interface MobilePairingStart {
+  uri: string;
+  /** True when a mobile-browser deep link into the app succeeded (no QR needed). */
+  redirected: boolean;
+  /** Set when the deep link failed: the app is likely not installed. */
+  installHint: string | null;
+}
+
+/**
+ * Begin (or resume) pairing: returns the qrlconnect:// URI for the QR dialog.
+ * On mobile browsers it first tries to deep-link straight into the app.
+ */
+export async function startMobilePairing(
+  store: MobileConnectStore,
+  fresh = false,
+): Promise<MobilePairingStart> {
+  const qrl = await getMobileConnect(store);
+  const { attemptWalletRedirect, getAppStoreUrl } = await import("@qrlwallet/connect");
+  const uri = fresh ? await qrl.newConnection() : await qrl.getConnectionURI();
+  if (qrl.isMobile()) {
+    const opened = await attemptWalletRedirect(uri);
+    if (opened) return { uri, redirected: true, installHint: null };
+    return {
+      uri,
+      redirected: false,
+      installHint: `MyQRLWallet app not detected. Install it (${getAppStoreUrl()}) or scan the code with the app on another device.`,
+    };
+  }
+  return { uri, redirected: false, installHint: null };
+}
+
+/**
+ * End the pairing from this side. Notifies the phone when a live instance
+ * exists; otherwise just drops the SDK's stored session so it cannot
+ * auto-reconnect on the next load.
+ */
+export async function disconnectMobile(): Promise<void> {
+  try {
+    if (instance) {
+      await instance.disconnect();
+    } else {
+      localStorage.removeItem(SDK_SESSION_KEY);
+      localStorage.removeItem(SDK_INFLIGHT_KEY);
+    }
+  } catch (error) {
+    console.error("Mobile connect: disconnect failed:", error);
+    try {
+      localStorage.removeItem(SDK_SESSION_KEY);
+      localStorage.removeItem(SDK_INFLIGHT_KEY);
+    } catch { /* storage unavailable */ }
+  }
+}
+
+/**
+ * Startup restore: if the SDK holds a stored pairing AND the account list
+ * still contains a mobile-sourced account, re-create the provider so
+ * autoReconnect resumes the session. A stored SDK session without a matching
+ * account (wallet was logged out / wiped) is discarded instead, so a wiped
+ * wallet never resurrects from SDK localStorage.
+ */
+export async function maybeRestoreMobileConnection(
+  store: MobileConnectStore,
+  hasMobileAccount: boolean,
+): Promise<void> {
+  if (!hasMobileSession()) return;
+  if (!hasMobileAccount) {
+    log("Mobile connect: stored SDK session without a mobile account; discarding");
+    await disconnectMobile();
+    return;
+  }
+  const qrl = await getMobileConnect(store);
+  // Provider is usable immediately; requests made before the socket resumes
+  // are buffered/relayed by the SDK. The 'connect' event re-confirms the
+  // account when the handshake completes.
+  store.setMobileProvider(asExtensionProvider(qrl));
+}

--- a/src/utils/storage/storage.ts
+++ b/src/utils/storage/storage.ts
@@ -59,8 +59,9 @@ export interface EncryptedSeedData {
   lastAccessed: number;
 }
 
-// New type to track the source (seed vs extension) for an account stored in ACCOUNT_LIST
-export type AccountSource = 'seed' | 'extension';
+// Tracks where an account in ACCOUNT_LIST is signed: a locally stored seed,
+// a browser extension, or the mobile app paired over the QRL Connect relay.
+export type AccountSource = 'seed' | 'extension' | 'mobile';
 
 export interface AccountListItem {
   address: string;


### PR DESCRIPTION
## What

Adds a **Connect Mobile App** option to the Let's start / Add accounts screen. The web wallet now runs the dApp side of the QRL Connect relay: it shows a `qrlconnect://` pairing QR (or deep-links on mobile browsers), and the paired MyQRLWallet app acts as the remote signer, exactly like the extension-account model.

## How

- New `'mobile'` account source alongside `'seed' | 'extension'` (`src/utils/storage/storage.ts`)
- `src/utils/mobileConnect/mobileConnection.ts`: lazy `@qrlwallet/connect@3.3.0` singleton with `announceProvider: false` (the wallet must never announce itself as an EIP-6963 provider), relay event wiring (connect / accountsChanged / disconnect with backgrounded-phone tolerance), startup session restore, disconnect. SDK is dynamically imported so its socket/ML-KEM weight stays out of the main bundle.
- `qrlStore`: `mobileProvider` slot, `remoteProvider` computed, `sendTransactionViaExtension` generalized to `sendTransactionViaProvider`. Mobile sends use the minimal `{from, to, value}` shape (the relay wallet estimates its own gas); extension keeps the explicit EIP-1559 shape.
- Transfer: no PIN field and no fee selector for mobile accounts (note: fee is confirmed in the app). Token transfer/creation stay blocked for connected wallets, matching extension behavior.
- Pairing survives refresh via the SDK stored session + `autoReconnect`, guarded so a wiped wallet cannot resurrect a pairing. Logout and the new Unlink action on the active-account card tear the session down (notifying the phone when live).
- Green **Mobile App** badge in the account list.

Web-only: hidden inside the native app WebView and the desktop build, same guard as the extension button. The wallet-side relay client (`src/services/dappConnect/`) is untouched; both roles coexist on separate channels and storage namespaces (`qrlconnect:sessions` vs `@qrlwallet/connect:session`).

## Gates

- `npm run lint` clean (zero warnings)
- `npm test` 244 passed
- `npm run build` (tsc + vite) green

## Testing done / pending

- Local dev server: button, QR dialog, copy/new-code verified visually
- Device test (pair, send, reject, refresh-restore, disconnect both ways) pending on dev after merge

## Risks

- npm audit shows only the known pre-existing elliptic lows upstream in @theqrl/web3, nothing new from @qrlwallet/connect
- Relay default is prod (`qrlwallet.com/relay`); the dev stack CSP already allowlists it