### PR TITLE
feat: token transfers through the mobile-app pairing

### DIFF
--- a/src/components/Core/Body/Transfer/Transfer.tsx
+++ b/src/components/Core/Body/Transfer/Transfer.tsx
@@ -349,13 +349,10 @@ const Transfer = observer(() => {
     if (isNativeTransfer) {
       await handleNativeTransfer(formData);
     } else {
-      // Token transfers not supported for remote-signer wallets yet
-      if (isUsingRemoteSigner) {
-        control.setError("asset", {
-          message: isUsingMobile
-            ? "Token transfers are not yet supported with a connected mobile app wallet."
-            : "Token transfers are not yet supported with extension wallets.",
-        });
+      // Token transfers work through the mobile-app pairing (the relay
+      // carries contract calls) but not through extension wallets yet.
+      if (isUsingExtension) {
+        control.setError("asset", { message: "Token transfers are not yet supported with extension wallets." });
         return;
       }
       await handleTokenTransfer(formData);
@@ -421,6 +418,20 @@ const Transfer = observer(() => {
 
   async function handleTokenTransfer(formData: z.infer<typeof FormSchema>) {
     if (!selectedToken) return;
+
+    if (isUsingMobile) {
+      // Mobile pairing: no PIN, no seed. The store builds the transfer
+      // calldata and the phone signs after its own confirmation screen.
+      try {
+        const rawAmount = parseUnits(formData.amount.toString(), selectedToken.decimals).toString();
+        await sendTokenToStore(selectedToken, rawAmount, "", formData.receiverAddress);
+        resetForm();
+        window.scrollTo(0, 0);
+      } catch (error) {
+        control.setError("receiverAddress", { message: `Transfer failed: ${error instanceof Error ? error.message : String(error)}` });
+      }
+      return;
+    }
 
     if (isDesktop) {
       // Desktop: no PIN, no seed in the renderer. The store builds the transfer

--- a/src/components/Core/Body/Transfer/Transfer.tsx
+++ b/src/components/Core/Body/Transfer/Transfer.tsx
@@ -422,13 +422,14 @@ const Transfer = observer(() => {
     if (isUsingMobile) {
       // Mobile pairing: no PIN, no seed. The store builds the transfer
       // calldata and the phone signs after its own confirmation screen.
-      try {
-        const rawAmount = parseUnits(formData.amount.toString(), selectedToken.decimals).toString();
-        await sendTokenToStore(selectedToken, rawAmount, "", formData.receiverAddress);
+      // sendToken reports failure via its return value (the failed
+      // transactionStatus screen takes over), so only reset the form on
+      // success: Try Again then returns to the still-filled form.
+      const rawAmount = parseUnits(formData.amount.toString(), selectedToken.decimals).toString();
+      const sent = await sendTokenToStore(selectedToken, rawAmount, "", formData.receiverAddress);
+      if (sent) {
         resetForm();
         window.scrollTo(0, 0);
-      } catch (error) {
-        control.setError("receiverAddress", { message: `Transfer failed: ${error instanceof Error ? error.message : String(error)}` });
       }
       return;
     }

--- a/src/stores/tokenStore.ts
+++ b/src/stores/tokenStore.ts
@@ -3,7 +3,7 @@ import { deriveHexSeedAsync } from "@/utils/crypto";
 import { isDesktop, desktopSigner } from "@/desktop/bridge";
 import { StorageUtil } from "@/utils/storage";
 import { log } from "@/utils";
-import { getErrorMessage } from "@/utils/errors";
+import { getErrorMessage, isProviderRpcError } from "@/utils/errors";
 import type { TransactionReceipt } from "@theqrl/web3";
 import { getQrlWeb3 } from "@/utils/web3";
 import { action, computed, makeAutoObservable, observable, runInAction } from "mobx";
@@ -420,6 +420,74 @@ class TokenStore {
           };
         });
         log(`Desktop token transfer failed: ${message}`);
+        return false;
+      }
+    }
+
+    // Mobile-app pairing: build the transfer() calldata locally (no seed),
+    // then route through the relay provider. Minimal shape: the phone
+    // estimates its own gas and shows its own confirmation, so no gas
+    // fields; no value either (a token transfer moves no native QRL).
+    // `mnemonicPhrases` and `feeLevel` are intentionally unused here.
+    if (this.qrlStore.activeAccountSource === "mobile") {
+      try {
+        const provider = this.qrlStore.remoteProvider;
+        if (!provider) throw new Error("Mobile app wallet not connected.");
+        const selectedBlockChain = await StorageUtil.getBlockChain();
+        const { url } = QRL_PROVIDER[selectedBlockChain as keyof typeof QRL_PROVIDER];
+        const { default: Web3 } = await getQrlWeb3();
+        const web3 = new Web3(new Web3.providers.HttpProvider(url));
+        const from = this.qrlStore.activeAccount.accountAddress;
+        const contract = new web3.qrl.Contract(CustomERC20ABI, token.address);
+        const data = contract.methods.transfer(toAddress, amount).encodeABI();
+        // Pending (no hash yet) while the phone shows its approval screen.
+        runInAction(() => {
+          this.qrlStore.transactionStatus = {
+            state: "pending",
+            txHash: null,
+            receipt: null,
+            error: null,
+            pendingDetails: null,
+          };
+        });
+        const txHash = await provider.request<string>({
+          method: "qrl_sendTransaction",
+          params: [{ from, to: token.address, data }],
+        });
+        if (!txHash || typeof txHash !== "string") {
+          throw new Error("The mobile app did not return a valid transaction hash.");
+        }
+        runInAction(() => {
+          this.qrlStore.transactionStatus = {
+            state: "pending",
+            txHash,
+            receipt: null,
+            error: null,
+            pendingDetails: null,
+          };
+        });
+        log(`Mobile token transfer broadcast with hash: ${txHash}`);
+        this.qrlStore.fetchPendingTxDetails(txHash);
+        this.qrlStore.pollForReceipt(txHash);
+        // The receipt poller calls fetchAccounts on confirm; refresh token
+        // balances proactively too, matching the desktop path.
+        this.refreshTokenBalances();
+        return true;
+      } catch (error) {
+        const userRejected = isProviderRpcError(error) && error.code === 4001;
+        const message = getErrorMessage(error);
+        runInAction(() => {
+          this.qrlStore.transactionStatus = {
+            state: "failed",
+            txHash: null,
+            receipt: null,
+            error: userRejected
+              ? "Transaction rejected in mobile app."
+              : `Token transfer failed: ${message}`,
+            pendingDetails: null,
+          };
+        });
+        log(`Mobile token transfer failed: ${message}`);
         return false;
       }
     }


### PR DESCRIPTION
Follow-up to #231/#233: lifts the token-transfer block for mobile-paired accounts.

## How

- `tokenStore.sendToken` gains a mobile branch mirroring the desktop one: build `transfer()` calldata locally (no seed), send the minimal `{from, to, data}` shape through the relay provider (the phone estimates its own gas and shows its own confirmation), then reuse the shared pending/receipt-poll plumbing. EIP-1193 4001 maps to 'Transaction rejected in mobile app.'
- `Transfer.tsx`: mobile token sends route through the store with no PIN; the not-supported block now applies to extension wallets only (extension needs explicit gas fields, out of scope here).
- Token creation stays blocked for all connected wallets.

The relay protocol already carries contract calls in production (QuantaPool staking txs, QuantaSwap HTLC calls), so no wallet-side or protocol change is needed.

## Gates

lint clean, 244 tests passed, tsc + vite build green.

## Testing pending

Device test: QRC20 transfer from the web wallet approved on the phone (fixtures exist on testnet v2).