### PR TITLE
release: NFT metadata refresh (gallery TTL re-fetch + hardening)

### DIFF
--- a/src/components/Core/Body/Nfts/AddNftModal.tsx
+++ b/src/components/Core/Body/Nfts/AddNftModal.tsx
@@ -200,7 +200,7 @@ export const AddNftModal = observer(({ isOpen, onClose }: AddNftModalProps) => {
           setIsAdding(false);
           return;
         } else {
-          // Non-enumerable — fall back to user-supplied tokenId.
+          // Non-enumerable: fall back to user-supplied tokenId.
           if (!tokenId.trim()) {
             setError(
               "This contract doesn't expose ownership enumeration. Please enter a Token ID.",
@@ -249,6 +249,10 @@ export const AddNftModal = observer(({ isOpen, onClose }: AddNftModalProps) => {
         let metaName: string | undefined;
         let metaImage: string | undefined;
         let metaDescription: string | undefined;
+        // Only stamped when the metadata JSON actually resolved. A failed
+        // fetch leaves it undefined so nftStore.refreshNftMetadata retries
+        // on the next gallery visit instead of waiting out the TTL.
+        let metaFetchedAt: number | undefined;
         try {
           const uri = await fetchTokenUri(
             contractAddress,
@@ -258,9 +262,12 @@ export const AddNftModal = observer(({ isOpen, onClose }: AddNftModalProps) => {
           );
           if (uri) {
             const meta = await fetchNftMetadata(uri);
-            metaName = meta?.name;
-            metaImage = meta?.image;
-            metaDescription = meta?.description;
+            if (meta) {
+              metaName = meta.name;
+              metaImage = meta.image;
+              metaDescription = meta.description;
+              metaFetchedAt = Date.now();
+            }
           }
         } catch (err) {
           console.error(`fetchTokenUri/Metadata failed for ${id}:`, err);
@@ -287,7 +294,7 @@ export const AddNftModal = observer(({ isOpen, onClose }: AddNftModalProps) => {
                   ))
                 ).toString()
               : undefined,
-          fetchedAt: Date.now(),
+          fetchedAt: metaFetchedAt,
         };
         await nftStore.addNft(nft);
       }

--- a/src/components/Core/Body/Nfts/NftGallery.tsx
+++ b/src/components/Core/Body/Nfts/NftGallery.tsx
@@ -25,14 +25,20 @@ const NftGallery = observer(() => {
   const [isRefreshing, setIsRefreshing] = useState(false);
 
   // Refresh ownership/balances on mount so a stale list gets corrected
-  // when the wallet has been used elsewhere since the last visit.
+  // when the wallet has been used elsewhere since the last visit, then
+  // re-resolve metadata for entries that never fetched or aged past the
+  // TTL, so on-chain tokenURI changes (and first-fetch IPFS failures)
+  // heal without a remove/re-add.
   useEffect(() => {
-    void nftStore.refreshNftBalances();
+    void (async () => {
+      await nftStore.refreshNftBalances();
+      await nftStore.refreshNftMetadata();
+    })();
   }, [nftStore]);
 
   // Populate the discovery cache so the empty-state can say "Explorer
   // found N NFTs" and the AddNftModal can offer a picker. Does NOT
-  // auto-merge into nftList — the user has to explicitly pick.
+  // auto-merge into nftList: the user has to explicitly pick.
   useEffect(() => {
     if (!activeAccountAddress) return;
     void nftStore.discoverNftsForReview(activeAccountAddress);
@@ -41,7 +47,10 @@ const NftGallery = observer(() => {
   const onRefresh = async () => {
     setIsRefreshing(true);
     try {
+      // Ownership first (may drop entries), then force-refresh metadata
+      // for whatever survived.
       await nftStore.refreshNftBalances();
+      await nftStore.refreshNftMetadata(true);
     } finally {
       setIsRefreshing(false);
     }
@@ -79,7 +88,7 @@ const NftGallery = observer(() => {
                 </Button>
               </TooltipTrigger>
               <TooltipContent>
-                <p>Refresh ownership and balances</p>
+                <p>Refresh ownership, balances, and metadata</p>
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>

--- a/src/components/Core/Body/Nfts/NftGallery.tsx
+++ b/src/components/Core/Body/Nfts/NftGallery.tsx
@@ -78,7 +78,7 @@ const NftGallery = observer(() => {
                   size="sm"
                   onClick={onRefresh}
                   disabled={isRefreshing}
-                  aria-label="Refresh NFT ownership"
+                  aria-label="Refresh ownership, balances, and metadata"
                 >
                   {isRefreshing ? (
                     <Loader2 className="h-4 w-4 animate-spin" />

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -5,4 +5,10 @@ export {
   type TokenInterface,
 } from './tokens';
 
-export { type NFTInterface, NFT_METADATA_TTL_MS } from './nft';
+export {
+  type NFTInterface,
+  NFT_METADATA_TTL_MS,
+  NFT_METADATA_RETRY_BASE_MS,
+  NFT_METADATA_RETRY_MAX_MS,
+  NFT_METADATA_MAX_PER_RUN,
+} from './nft';

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -5,4 +5,4 @@ export {
   type TokenInterface,
 } from './tokens';
 
-export { type NFTInterface } from './nft';
+export { type NFTInterface, NFT_METADATA_TTL_MS } from './nft';

--- a/src/constants/nft.ts
+++ b/src/constants/nft.ts
@@ -1,5 +1,11 @@
 import type { NftStandard } from "@/utils/web3/nft";
 
+// Re-resolve tokenURI + metadata JSON for a gallery entry when its last
+// successful fetch is older than this. Mirrors the explorer backend's
+// METADATA_REFRESH_TTL_MS default so both surfaces pick up on-chain
+// tokenURI changes on the same cadence.
+export const NFT_METADATA_TTL_MS = 24 * 60 * 60 * 1000;
+
 export interface NFTInterface {
   contractAddress: string;
   standard: NftStandard;
@@ -12,6 +18,8 @@ export interface NFTInterface {
   // ERC-1155 holdings can be > 1 of the same id; stored as a decimal
   // string so it survives serialization. Undefined for ERC-721 (always 1).
   balance?: string;
-  // Snapshot of when we last fetched metadata, for cache-warming UI.
+  // Timestamp (ms) of the last SUCCESSFUL metadata fetch. Absent when
+  // metadata has never resolved, which makes the entry eligible for a
+  // refresh on the next gallery visit instead of waiting out the TTL.
   fetchedAt?: number;
 }

--- a/src/constants/nft.ts
+++ b/src/constants/nft.ts
@@ -6,6 +6,19 @@ import type { NftStandard } from "@/utils/web3/nft";
 // tokenURI changes on the same cadence.
 export const NFT_METADATA_TTL_MS = 24 * 60 * 60 * 1000;
 
+// Failure backoff for metadata refreshes: after N consecutive failures a
+// non-forced refresh waits base * 2^(N-1), capped at max, before retrying.
+// Without this a permanently dead tokenURI would re-fetch on every gallery
+// mount forever. The gallery Refresh button bypasses the backoff.
+export const NFT_METADATA_RETRY_BASE_MS = 5 * 60 * 1000;
+export const NFT_METADATA_RETRY_MAX_MS = 24 * 60 * 60 * 1000;
+
+// Cap on metadata fetches per refresh run. Each eligible entry costs one
+// tokenURI RPC plus one /api/ipfs proxy fetch, and the proxy rate-limits
+// 60 req/min/IP shared with the gallery's own thumbnail loads; a large
+// gallery drains the rest of its backlog on subsequent visits.
+export const NFT_METADATA_MAX_PER_RUN = 12;
+
 export interface NFTInterface {
   contractAddress: string;
   standard: NftStandard;
@@ -22,4 +35,9 @@ export interface NFTInterface {
   // metadata has never resolved, which makes the entry eligible for a
   // refresh on the next gallery visit instead of waiting out the TTL.
   fetchedAt?: number;
+  // Failure bookkeeping for metadata refreshes: consecutive failure count
+  // and the timestamp of the last failure. Drive the exponential backoff
+  // in nftStore.refreshNftMetadata; cleared on success.
+  fetchRetryCount?: number;
+  fetchFailedAt?: number;
 }

--- a/src/stores/nftStore.ts
+++ b/src/stores/nftStore.ts
@@ -58,12 +58,20 @@ class NftStore {
   // account alone is not enough.)
   private nftListScope: { blockchain: string; account: string } | null = null;
 
-  // Single-flight guards: React StrictMode double-mounts the gallery
-  // effect and the Refresh button can overlap the invisible mount chain;
-  // a second concurrent loop would double RPC/proxy traffic and its
-  // wholesale setNftList could resurrect an entry the first loop dropped.
-  private balancesRefreshInFlight = false;
-  private metadataRefreshInFlight = false;
+  // Single-flight refresh tracking. A call made while a run for the SAME
+  // scope is in flight coalesces into it (React StrictMode double-mounts
+  // the gallery effect; a second concurrent loop would double RPC/proxy
+  // traffic). A call for a DIFFERENT scope (account/network switch) or a
+  // forced metadata refresh chains behind the in-flight run instead, so
+  // it actually executes against the new state.
+  private balancesRefresh: {
+    scope: { blockchain: string; account: string };
+    done: Promise<void>;
+  } | null = null;
+  private metadataRefresh: {
+    scope: { blockchain: string; account: string };
+    done: Promise<void>;
+  } | null = null;
 
   constructor(
     private qrlStore: QrlStore,
@@ -183,6 +191,16 @@ class NftStore {
       // after the switch can't leak the prior account's results.
       this.discoveredNfts = [];
     });
+    // Kick a refresh for the freshly loaded scope so an already-mounted
+    // gallery is current after the switch (its mount effect only fires
+    // once). Fire-and-forget: the account switch must not block on
+    // per-NFT RPC. A run still draining for the previous scope is
+    // chained behind, and its own write is dropped by the scope guard.
+    void this.refreshNftBalances()
+      .then(() => this.refreshNftMetadata())
+      .catch((err: unknown) => {
+        console.error("post-switch NFT refresh failed:", err);
+      });
   }
 
   async setNftList(list: NFTInterface[]) {
@@ -255,65 +273,91 @@ class NftStore {
    * balance. Drops NFTs the wallet no longer owns (e.g. transferred
    * out from another client) so the gallery stays honest.
    *
-   * Single-flight: a run that starts while another is in flight returns
-   * immediately. Scope-guarded: bails when the nftList is not settled
-   * for the live scope, before iterating and again before persisting.
+   * Same-scope calls coalesce into the in-flight run; cross-scope calls
+   * (account/network switch) chain behind it. Scope-guarded: bails when
+   * the nftList is not settled for the live scope.
    */
-  async refreshNftBalances() {
-    if (this.balancesRefreshInFlight) return;
+  async refreshNftBalances(): Promise<void> {
+    const scope = this.scope;
+    const current = this.balancesRefresh;
+    if (current && NftStore.scopesEqual(current.scope, scope)) {
+      return current.done;
+    }
+    const done = (async () => {
+      if (current) await current.done.catch(() => undefined);
+      await this.runBalancesRefresh();
+    })();
+    const entry = {
+      scope,
+      done: done.finally(() => {
+        if (this.balancesRefresh === entry) this.balancesRefresh = null;
+      }),
+    };
+    this.balancesRefresh = entry;
+    return entry.done;
+  }
+
+  private async runBalancesRefresh(): Promise<void> {
     const scope = this.scope;
     if (!scope.account || this.nftList.length === 0) return;
     if (!this.nftListSettledFor(scope)) return;
-    this.balancesRefreshInFlight = true;
-    try {
-      const selectedBlockChain = await StorageUtil.getBlockChain();
-      const rpcUrl =
-        QRL_PROVIDER[selectedBlockChain as keyof typeof QRL_PROVIDER].url;
+    const selectedBlockChain = await StorageUtil.getBlockChain();
+    const rpcUrl =
+      QRL_PROVIDER[selectedBlockChain as keyof typeof QRL_PROVIDER].url;
 
-      const updated: NFTInterface[] = [];
-      for (const nft of this.nftList) {
-        try {
-          if (nft.standard === "ERC721") {
-            const stillOwner = await isErc721Owner(
-              nft.contractAddress,
-              scope.account,
-              nft.tokenId,
-              rpcUrl,
-            );
-            if (stillOwner) {
-              updated.push(nft);
-            }
-            // dropped if no longer owner
-          } else {
-            const bal = await fetchErc1155Balance(
-              nft.contractAddress,
-              scope.account,
-              nft.tokenId,
-              rpcUrl,
-            );
-            if (bal > 0n) {
-              updated.push({ ...nft, balance: bal.toString() });
-            }
-            // dropped if balance == 0
-          }
-        } catch (err) {
-          // Keep stale entries on transient errors so a flaky RPC doesn't
-          // wipe the gallery; log + carry on.
-          console.error(
-            `refreshNftBalances: ${nft.contractAddress}#${nft.tokenId}`,
-            err,
+    // Decide per-entry from a snapshot, then merge the decisions into
+    // the CURRENT list. A wholesale overwrite of this.nftList would
+    // silently wipe NFTs the user adds (and resurrect ones they remove)
+    // while the ownership checks are in flight.
+    const drops = new Set<string>();
+    const balances = new Map<string, string>();
+    for (const nft of this.nftList) {
+      const key = nftKey(nft.contractAddress, nft.tokenId);
+      try {
+        if (nft.standard === "ERC721") {
+          const stillOwner = await isErc721Owner(
+            nft.contractAddress,
+            scope.account,
+            nft.tokenId,
+            rpcUrl,
           );
-          updated.push(nft);
+          if (!stillOwner) drops.add(key);
+        } else {
+          const bal = await fetchErc1155Balance(
+            nft.contractAddress,
+            scope.account,
+            nft.tokenId,
+            rpcUrl,
+          );
+          if (bal > 0n) {
+            balances.set(key, bal.toString());
+          } else {
+            drops.add(key);
+          }
         }
+      } catch (err) {
+        // Keep entries on transient errors so a flaky RPC doesn't wipe
+        // the gallery; log + carry on.
+        console.error(
+          `refreshNftBalances: ${nft.contractAddress}#${nft.tokenId}`,
+          err,
+        );
       }
-      if (!this.nftListSettledFor(scope)) {
-        log("refreshNftBalances: scope changed mid-refresh, dropping result");
-        return;
-      }
-      await this.setNftList(updated);
-    } finally {
-      this.balancesRefreshInFlight = false;
     }
+    if (drops.size === 0 && balances.size === 0) return;
+    if (!this.nftListSettledFor(scope)) {
+      log("refreshNftBalances: scope changed mid-refresh, dropping result");
+      return;
+    }
+    const merged = this.nftList
+      .filter((n) => !drops.has(nftKey(n.contractAddress, n.tokenId)))
+      .map((n) => {
+        const bal = balances.get(nftKey(n.contractAddress, n.tokenId));
+        return bal !== undefined && bal !== n.balance
+          ? { ...n, balance: bal }
+          : n;
+      });
+    await this.setNftList(merged);
   }
 
   /**
@@ -335,104 +379,121 @@ class NftStore {
    * failure bookkeeping is written), and a successful fetch only
    * overwrites fields the new document provides, so a temporarily
    * broken tokenURI can't blank out a working card.
+   *
+   * Same-scope non-forced calls coalesce into the in-flight run; forced
+   * and cross-scope calls chain behind it so they actually execute.
    */
-  async refreshNftMetadata(force = false) {
-    if (this.metadataRefreshInFlight) return;
+  async refreshNftMetadata(force = false): Promise<void> {
+    const scope = this.scope;
+    const current = this.metadataRefresh;
+    if (current && !force && NftStore.scopesEqual(current.scope, scope)) {
+      return current.done;
+    }
+    const done = (async () => {
+      if (current) await current.done.catch(() => undefined);
+      await this.runMetadataRefresh(force);
+    })();
+    const entry = {
+      scope,
+      done: done.finally(() => {
+        if (this.metadataRefresh === entry) this.metadataRefresh = null;
+      }),
+    };
+    this.metadataRefresh = entry;
+    return entry.done;
+  }
+
+  private async runMetadataRefresh(force: boolean): Promise<void> {
     const scope = this.scope;
     if (!scope.account || this.nftList.length === 0) return;
     if (!this.nftListSettledFor(scope)) return;
-    this.metadataRefreshInFlight = true;
-    try {
-      const selectedBlockChain = await StorageUtil.getBlockChain();
-      const rpcUrl =
-        QRL_PROVIDER[selectedBlockChain as keyof typeof QRL_PROVIDER].url;
+    const selectedBlockChain = await StorageUtil.getBlockChain();
+    const rpcUrl =
+      QRL_PROVIDER[selectedBlockChain as keyof typeof QRL_PROVIDER].url;
 
-      const now = Date.now();
-      const updates = new Map<string, NFTInterface>();
-      const markFailed = (nft: NFTInterface) => {
+    const now = Date.now();
+    const updates = new Map<string, NFTInterface>();
+    const markFailed = (nft: NFTInterface) => {
+      updates.set(nftKey(nft.contractAddress, nft.tokenId), {
+        ...nft,
+        fetchRetryCount: (nft.fetchRetryCount ?? 0) + 1,
+        fetchFailedAt: Date.now(),
+      });
+    };
+    let attempts = 0;
+    for (const nft of this.nftList) {
+      if (attempts >= NFT_METADATA_MAX_PER_RUN) break;
+      const stale =
+        !nft.fetchedAt || now - nft.fetchedAt > NFT_METADATA_TTL_MS;
+      if (!force && !stale) continue;
+      if (!force && nft.fetchFailedAt) {
+        const backoff = Math.min(
+          NFT_METADATA_RETRY_BASE_MS *
+            2 ** Math.max((nft.fetchRetryCount ?? 1) - 1, 0),
+          NFT_METADATA_RETRY_MAX_MS,
+        );
+        if (now - nft.fetchFailedAt < backoff) continue;
+      }
+      attempts++;
+      try {
+        const uri = await fetchTokenUri(
+          nft.contractAddress,
+          nft.tokenId,
+          rpcUrl,
+          nft.standard,
+        );
+        if (!uri) {
+          markFailed(nft);
+          continue;
+        }
+        const meta = await fetchNftMetadata(uri);
+        if (!meta) {
+          markFailed(nft);
+          continue;
+        }
         updates.set(nftKey(nft.contractAddress, nft.tokenId), {
           ...nft,
-          fetchRetryCount: (nft.fetchRetryCount ?? 0) + 1,
-          fetchFailedAt: Date.now(),
+          name: meta.name ?? nft.name,
+          description: meta.description ?? nft.description,
+          image: meta.image ?? nft.image,
+          fetchedAt: Date.now(),
+          fetchRetryCount: undefined,
+          fetchFailedAt: undefined,
         });
-      };
-      let attempts = 0;
-      for (const nft of this.nftList) {
-        if (attempts >= NFT_METADATA_MAX_PER_RUN) break;
-        const stale =
-          !nft.fetchedAt || now - nft.fetchedAt > NFT_METADATA_TTL_MS;
-        if (!force && !stale) continue;
-        if (!force && nft.fetchFailedAt) {
-          const backoff = Math.min(
-            NFT_METADATA_RETRY_BASE_MS *
-              2 ** Math.max((nft.fetchRetryCount ?? 1) - 1, 0),
-            NFT_METADATA_RETRY_MAX_MS,
-          );
-          if (now - nft.fetchFailedAt < backoff) continue;
-        }
-        attempts++;
-        try {
-          const uri = await fetchTokenUri(
-            nft.contractAddress,
-            nft.tokenId,
-            rpcUrl,
-            nft.standard,
-          );
-          if (!uri) {
-            markFailed(nft);
-            continue;
-          }
-          const meta = await fetchNftMetadata(uri);
-          if (!meta) {
-            markFailed(nft);
-            continue;
-          }
-          updates.set(nftKey(nft.contractAddress, nft.tokenId), {
-            ...nft,
-            name: meta.name ?? nft.name,
-            description: meta.description ?? nft.description,
-            image: meta.image ?? nft.image,
-            fetchedAt: Date.now(),
-            fetchRetryCount: undefined,
-            fetchFailedAt: undefined,
-          });
-        } catch (err) {
-          markFailed(nft);
-          console.error(
-            `refreshNftMetadata: ${nft.contractAddress}#${nft.tokenId}`,
-            err,
-          );
-        }
+      } catch (err) {
+        markFailed(nft);
+        console.error(
+          `refreshNftMetadata: ${nft.contractAddress}#${nft.tokenId}`,
+          err,
+        );
       }
-      if (updates.size === 0) return;
-      // Scope guard: if the account or network switched while we awaited
-      // RPC, this.nftList belongs to another scope now and these updates
-      // must be dropped.
-      if (!this.nftListSettledFor(scope)) {
-        log("refreshNftMetadata: scope changed mid-refresh, dropping");
-        return;
-      }
-      // Merge into the CURRENT list rather than the snapshot we iterated:
-      // refreshNftBalances may have dropped or re-balanced entries while
-      // the metadata fetches were in flight, and ownership state wins.
-      const merged = this.nftList.map((n) => {
-        const u = updates.get(nftKey(n.contractAddress, n.tokenId));
-        if (!u) return n;
-        return {
-          ...n,
-          name: u.name,
-          description: u.description,
-          image: u.image,
-          fetchedAt: u.fetchedAt,
-          fetchRetryCount: u.fetchRetryCount,
-          fetchFailedAt: u.fetchFailedAt,
-        };
-      });
-      await this.setNftList(merged);
-      log(`refreshNftMetadata: refreshed ${updates.size} entries`);
-    } finally {
-      this.metadataRefreshInFlight = false;
     }
+    if (updates.size === 0) return;
+    // Scope guard: if the account or network switched while we awaited
+    // RPC, this.nftList belongs to another scope now and these updates
+    // must be dropped.
+    if (!this.nftListSettledFor(scope)) {
+      log("refreshNftMetadata: scope changed mid-refresh, dropping");
+      return;
+    }
+    // Merge into the CURRENT list rather than the snapshot we iterated:
+    // entries added/removed while fetches were in flight stay untouched,
+    // and refreshNftBalances ownership decisions win.
+    const merged = this.nftList.map((n) => {
+      const u = updates.get(nftKey(n.contractAddress, n.tokenId));
+      if (!u) return n;
+      return {
+        ...n,
+        name: u.name,
+        description: u.description,
+        image: u.image,
+        fetchedAt: u.fetchedAt,
+        fetchRetryCount: u.fetchRetryCount,
+        fetchFailedAt: u.fetchFailedAt,
+      };
+    });
+    await this.setNftList(merged);
+    log(`refreshNftMetadata: refreshed ${updates.size} entries`);
   }
 
   /**

--- a/src/stores/nftStore.ts
+++ b/src/stores/nftStore.ts
@@ -13,7 +13,13 @@ import { QRL_PROVIDER } from "@/config";
 import { StorageUtil } from "@/utils/storage";
 import { deriveHexSeedAsync } from "@/utils/crypto";
 import { isDesktop, desktopSigner } from "@/desktop/bridge";
-import { NFT_METADATA_TTL_MS, type NFTInterface } from "@/constants";
+import {
+  NFT_METADATA_MAX_PER_RUN,
+  NFT_METADATA_RETRY_BASE_MS,
+  NFT_METADATA_RETRY_MAX_MS,
+  NFT_METADATA_TTL_MS,
+  type NFTInterface,
+} from "@/constants";
 import { erc721ABI } from "@/abi/ERC721ABI";
 import { erc1155ABI } from "@/abi/ERC1155ABI";
 import {
@@ -42,6 +48,22 @@ class NftStore {
   // spam-airdropped NFT can't land in the gallery without an explicit
   // user pick.
   discoveredNfts: NFTInterface[] = [];
+
+  // Scope that the CURRENT nftList belongs to. Written wherever the list
+  // is (re)loaded or persisted. The refresh loops compare it against the
+  // live scope before starting AND before writing, so a refresh that
+  // straddles an account or network switch can never persist one scope's
+  // list under another scope's storage key. (activeAccount flips before
+  // handleActiveAccountChanged swaps the list, so comparing the live
+  // account alone is not enough.)
+  private nftListScope: { blockchain: string; account: string } | null = null;
+
+  // Single-flight guards: React StrictMode double-mounts the gallery
+  // effect and the Refresh button can overlap the invisible mount chain;
+  // a second concurrent loop would double RPC/proxy traffic and its
+  // wholesale setNftList could resurrect an entry the first loop dropped.
+  private balancesRefreshInFlight = false;
+  private metadataRefreshInFlight = false;
 
   constructor(
     private qrlStore: QrlStore,
@@ -111,11 +133,33 @@ class NftStore {
     };
   }
 
+  private static scopesEqual(
+    a: { blockchain: string; account: string },
+    b: { blockchain: string; account: string },
+  ): boolean {
+    return a.blockchain === b.blockchain && a.account === b.account;
+  }
+
+  // True when the in-memory nftList is settled for `scope`: loaded from
+  // that scope's storage key and not superseded since. Refresh loops must
+  // check this before iterating AND before persisting.
+  private nftListSettledFor(scope: {
+    blockchain: string;
+    account: string;
+  }): boolean {
+    return (
+      this.nftListScope !== null &&
+      NftStore.scopesEqual(this.nftListScope, scope) &&
+      NftStore.scopesEqual(this.scope, scope)
+    );
+  }
+
   async initialize() {
     const { blockchain, account } = this.scope;
     const persisted = await StorageUtil.getNftList(blockchain, account);
     runInAction(() => {
       this.nftList = persisted;
+      this.nftListScope = { blockchain, account };
     });
     await this.loadHiddenNfts();
   }
@@ -133,6 +177,7 @@ class NftStore {
     const hidden = await StorageUtil.getHiddenNfts(blockchain, newActiveAccount);
     runInAction(() => {
       this.nftList = persisted;
+      this.nftListScope = { blockchain, account: newActiveAccount };
       this.hiddenNfts = hidden;
       // Discovered list is per-address; drop it so a picker opened
       // after the switch can't leak the prior account's results.
@@ -145,6 +190,7 @@ class NftStore {
     await StorageUtil.updateNftList(blockchain, account, list);
     runInAction(() => {
       this.nftList = list;
+      this.nftListScope = { blockchain, account };
     });
   }
 
@@ -208,126 +254,185 @@ class NftStore {
    * For each NFT in the list: confirm 721 ownership / refresh 1155
    * balance. Drops NFTs the wallet no longer owns (e.g. transferred
    * out from another client) so the gallery stays honest.
+   *
+   * Single-flight: a run that starts while another is in flight returns
+   * immediately. Scope-guarded: bails when the nftList is not settled
+   * for the live scope, before iterating and again before persisting.
    */
   async refreshNftBalances() {
-    const owner = this.qrlStore.activeAccount.accountAddress;
-    if (!owner || this.nftList.length === 0) return;
-    const selectedBlockChain = await StorageUtil.getBlockChain();
-    const rpcUrl =
-      QRL_PROVIDER[selectedBlockChain as keyof typeof QRL_PROVIDER].url;
+    if (this.balancesRefreshInFlight) return;
+    const scope = this.scope;
+    if (!scope.account || this.nftList.length === 0) return;
+    if (!this.nftListSettledFor(scope)) return;
+    this.balancesRefreshInFlight = true;
+    try {
+      const selectedBlockChain = await StorageUtil.getBlockChain();
+      const rpcUrl =
+        QRL_PROVIDER[selectedBlockChain as keyof typeof QRL_PROVIDER].url;
 
-    const updated: NFTInterface[] = [];
-    for (const nft of this.nftList) {
-      try {
-        if (nft.standard === "ERC721") {
-          const stillOwner = await isErc721Owner(
-            nft.contractAddress,
-            owner,
-            nft.tokenId,
-            rpcUrl,
-          );
-          if (stillOwner) {
-            updated.push(nft);
+      const updated: NFTInterface[] = [];
+      for (const nft of this.nftList) {
+        try {
+          if (nft.standard === "ERC721") {
+            const stillOwner = await isErc721Owner(
+              nft.contractAddress,
+              scope.account,
+              nft.tokenId,
+              rpcUrl,
+            );
+            if (stillOwner) {
+              updated.push(nft);
+            }
+            // dropped if no longer owner
+          } else {
+            const bal = await fetchErc1155Balance(
+              nft.contractAddress,
+              scope.account,
+              nft.tokenId,
+              rpcUrl,
+            );
+            if (bal > 0n) {
+              updated.push({ ...nft, balance: bal.toString() });
+            }
+            // dropped if balance == 0
           }
-          // dropped if no longer owner
-        } else {
-          const bal = await fetchErc1155Balance(
-            nft.contractAddress,
-            owner,
-            nft.tokenId,
-            rpcUrl,
+        } catch (err) {
+          // Keep stale entries on transient errors so a flaky RPC doesn't
+          // wipe the gallery; log + carry on.
+          console.error(
+            `refreshNftBalances: ${nft.contractAddress}#${nft.tokenId}`,
+            err,
           );
-          if (bal > 0n) {
-            updated.push({ ...nft, balance: bal.toString() });
-          }
-          // dropped if balance == 0
+          updated.push(nft);
         }
-      } catch (err) {
-        // Keep stale entries on transient errors so a flaky RPC doesn't
-        // wipe the gallery; log + carry on.
-        console.error(
-          `refreshNftBalances: ${nft.contractAddress}#${nft.tokenId}`,
-          err,
-        );
-        updated.push(nft);
       }
+      if (!this.nftListSettledFor(scope)) {
+        log("refreshNftBalances: scope changed mid-refresh, dropping result");
+        return;
+      }
+      await this.setNftList(updated);
+    } finally {
+      this.balancesRefreshInFlight = false;
     }
-    await this.setNftList(updated);
   }
 
   /**
    * Re-resolve tokenURI + metadata JSON for gallery entries so the
    * stored name/description/image track the chain instead of being
    * frozen at add-time. By default only entries whose last successful
-   * fetch is missing or older than NFT_METADATA_TTL_MS are refreshed;
-   * `force` refreshes everything (wired to the gallery Refresh button).
+   * fetch is missing or older than NFT_METADATA_TTL_MS are refreshed,
+   * and repeatedly failing entries wait out an exponential backoff;
+   * `force` (the gallery Refresh button) retries everything now.
+   *
+   * At most NFT_METADATA_MAX_PER_RUN entries are fetched per run: each
+   * attempt costs one tokenURI RPC plus one /api/ipfs proxy fetch, and
+   * the proxy's 60 req/min/IP budget is shared with the gallery's own
+   * thumbnail loads. The remainder of a large backlog drains on
+   * subsequent visits.
    *
    * Preserve-last-good, mirroring the explorer backend: a failed URI
-   * read or metadata fetch leaves the stored fields untouched, and a
-   * successful fetch only overwrites fields the new document provides,
-   * so a temporarily broken tokenURI can't blank out a working card.
+   * read or metadata fetch leaves the stored content untouched (only
+   * failure bookkeeping is written), and a successful fetch only
+   * overwrites fields the new document provides, so a temporarily
+   * broken tokenURI can't blank out a working card.
    */
   async refreshNftMetadata(force = false) {
-    const startAccount = this.qrlStore.activeAccount.accountAddress;
-    if (!startAccount || this.nftList.length === 0) return;
-    const selectedBlockChain = await StorageUtil.getBlockChain();
-    const rpcUrl =
-      QRL_PROVIDER[selectedBlockChain as keyof typeof QRL_PROVIDER].url;
+    if (this.metadataRefreshInFlight) return;
+    const scope = this.scope;
+    if (!scope.account || this.nftList.length === 0) return;
+    if (!this.nftListSettledFor(scope)) return;
+    this.metadataRefreshInFlight = true;
+    try {
+      const selectedBlockChain = await StorageUtil.getBlockChain();
+      const rpcUrl =
+        QRL_PROVIDER[selectedBlockChain as keyof typeof QRL_PROVIDER].url;
 
-    const now = Date.now();
-    const updates = new Map<string, NFTInterface>();
-    for (const nft of this.nftList) {
-      const stale =
-        !nft.fetchedAt || now - nft.fetchedAt > NFT_METADATA_TTL_MS;
-      if (!force && !stale) continue;
-      try {
-        const uri = await fetchTokenUri(
-          nft.contractAddress,
-          nft.tokenId,
-          rpcUrl,
-          nft.standard,
-        );
-        if (!uri) continue;
-        const meta = await fetchNftMetadata(uri);
-        if (!meta) continue;
+      const now = Date.now();
+      const updates = new Map<string, NFTInterface>();
+      const markFailed = (nft: NFTInterface) => {
         updates.set(nftKey(nft.contractAddress, nft.tokenId), {
           ...nft,
-          name: meta.name ?? nft.name,
-          description: meta.description ?? nft.description,
-          image: meta.image ?? nft.image,
-          fetchedAt: Date.now(),
+          fetchRetryCount: (nft.fetchRetryCount ?? 0) + 1,
+          fetchFailedAt: Date.now(),
         });
-      } catch (err) {
-        console.error(
-          `refreshNftMetadata: ${nft.contractAddress}#${nft.tokenId}`,
-          err,
-        );
-      }
-    }
-    if (updates.size === 0) return;
-    // Stale-write guard, mirrors addDiscoveredNfts: if the account
-    // switched while we awaited RPC, this.nftList belongs to another
-    // scope now and these updates must be dropped.
-    if (this.qrlStore.activeAccount.accountAddress !== startAccount) {
-      log("refreshNftMetadata: active account changed mid-refresh, dropping");
-      return;
-    }
-    // Merge into the CURRENT list rather than the snapshot we iterated:
-    // refreshNftBalances may have dropped or re-balanced entries while
-    // the metadata fetches were in flight, and ownership state wins.
-    const merged = this.nftList.map((n) => {
-      const u = updates.get(nftKey(n.contractAddress, n.tokenId));
-      if (!u) return n;
-      return {
-        ...n,
-        name: u.name,
-        description: u.description,
-        image: u.image,
-        fetchedAt: u.fetchedAt,
       };
-    });
-    await this.setNftList(merged);
-    log(`refreshNftMetadata: refreshed ${updates.size} entries`);
+      let attempts = 0;
+      for (const nft of this.nftList) {
+        if (attempts >= NFT_METADATA_MAX_PER_RUN) break;
+        const stale =
+          !nft.fetchedAt || now - nft.fetchedAt > NFT_METADATA_TTL_MS;
+        if (!force && !stale) continue;
+        if (!force && nft.fetchFailedAt) {
+          const backoff = Math.min(
+            NFT_METADATA_RETRY_BASE_MS *
+              2 ** Math.max((nft.fetchRetryCount ?? 1) - 1, 0),
+            NFT_METADATA_RETRY_MAX_MS,
+          );
+          if (now - nft.fetchFailedAt < backoff) continue;
+        }
+        attempts++;
+        try {
+          const uri = await fetchTokenUri(
+            nft.contractAddress,
+            nft.tokenId,
+            rpcUrl,
+            nft.standard,
+          );
+          if (!uri) {
+            markFailed(nft);
+            continue;
+          }
+          const meta = await fetchNftMetadata(uri);
+          if (!meta) {
+            markFailed(nft);
+            continue;
+          }
+          updates.set(nftKey(nft.contractAddress, nft.tokenId), {
+            ...nft,
+            name: meta.name ?? nft.name,
+            description: meta.description ?? nft.description,
+            image: meta.image ?? nft.image,
+            fetchedAt: Date.now(),
+            fetchRetryCount: undefined,
+            fetchFailedAt: undefined,
+          });
+        } catch (err) {
+          markFailed(nft);
+          console.error(
+            `refreshNftMetadata: ${nft.contractAddress}#${nft.tokenId}`,
+            err,
+          );
+        }
+      }
+      if (updates.size === 0) return;
+      // Scope guard: if the account or network switched while we awaited
+      // RPC, this.nftList belongs to another scope now and these updates
+      // must be dropped.
+      if (!this.nftListSettledFor(scope)) {
+        log("refreshNftMetadata: scope changed mid-refresh, dropping");
+        return;
+      }
+      // Merge into the CURRENT list rather than the snapshot we iterated:
+      // refreshNftBalances may have dropped or re-balanced entries while
+      // the metadata fetches were in flight, and ownership state wins.
+      const merged = this.nftList.map((n) => {
+        const u = updates.get(nftKey(n.contractAddress, n.tokenId));
+        if (!u) return n;
+        return {
+          ...n,
+          name: u.name,
+          description: u.description,
+          image: u.image,
+          fetchedAt: u.fetchedAt,
+          fetchRetryCount: u.fetchRetryCount,
+          fetchFailedAt: u.fetchFailedAt,
+        };
+      });
+      await this.setNftList(merged);
+      log(`refreshNftMetadata: refreshed ${updates.size} entries`);
+    } finally {
+      this.metadataRefreshInFlight = false;
+    }
   }
 
   /**

--- a/src/stores/nftStore.ts
+++ b/src/stores/nftStore.ts
@@ -13,11 +13,13 @@ import { QRL_PROVIDER } from "@/config";
 import { StorageUtil } from "@/utils/storage";
 import { deriveHexSeedAsync } from "@/utils/crypto";
 import { isDesktop, desktopSigner } from "@/desktop/bridge";
-import type { NFTInterface } from "@/constants";
+import { NFT_METADATA_TTL_MS, type NFTInterface } from "@/constants";
 import { erc721ABI } from "@/abi/ERC721ABI";
 import { erc1155ABI } from "@/abi/ERC1155ABI";
 import {
   fetchErc1155Balance,
+  fetchNftMetadata,
+  fetchTokenUri,
   isErc721Owner,
   nftKey,
 } from "@/utils/web3/nft";
@@ -63,6 +65,7 @@ class NftStore {
       loadHiddenNfts: action.bound,
       setNftList: action.bound,
       refreshNftBalances: action.bound,
+      refreshNftMetadata: action.bound,
       transferNft: action.bound,
       discoverNftsForReview: action.bound,
       addDiscoveredNfts: action.bound,
@@ -83,7 +86,7 @@ class NftStore {
   }
 
   // Discovered NFTs minus the ones already visible in the gallery.
-  // Hidden NFTs are still eligible — picking a hidden NFT in the picker
+  // Hidden NFTs are still eligible: picking a hidden NFT in the picker
   // unhides it. Previously-visible items stay filtered so they don't
   // reappear as suggestions.
   get pendingDiscoveredNfts(): NFTInterface[] {
@@ -99,7 +102,7 @@ class NftStore {
   }
 
   // Storage is now keyed by `${blockchain}_${account}` (see StorageUtil)
-  // so reads from the wrong scope are impossible — but we still need the
+  // so reads from the wrong scope are impossible, but we still need the
   // scope to write. Pulls live values from qrlStore at the call site.
   private get scope(): { blockchain: string; account: string } {
     return {
@@ -123,7 +126,7 @@ class NftStore {
     }
     // Storage is per-account-scoped, so an account switch just means
     // reloading from the new scope's key. No cross-account clearing
-    // needed — the old account's list stays under its own key for when
+    // needed; the old account's list stays under its own key for when
     // the user switches back.
     const blockchain = this.qrlStore.qrlConnection.blockchain;
     const persisted = await StorageUtil.getNftList(blockchain, newActiveAccount);
@@ -250,6 +253,81 @@ class NftStore {
       }
     }
     await this.setNftList(updated);
+  }
+
+  /**
+   * Re-resolve tokenURI + metadata JSON for gallery entries so the
+   * stored name/description/image track the chain instead of being
+   * frozen at add-time. By default only entries whose last successful
+   * fetch is missing or older than NFT_METADATA_TTL_MS are refreshed;
+   * `force` refreshes everything (wired to the gallery Refresh button).
+   *
+   * Preserve-last-good, mirroring the explorer backend: a failed URI
+   * read or metadata fetch leaves the stored fields untouched, and a
+   * successful fetch only overwrites fields the new document provides,
+   * so a temporarily broken tokenURI can't blank out a working card.
+   */
+  async refreshNftMetadata(force = false) {
+    const startAccount = this.qrlStore.activeAccount.accountAddress;
+    if (!startAccount || this.nftList.length === 0) return;
+    const selectedBlockChain = await StorageUtil.getBlockChain();
+    const rpcUrl =
+      QRL_PROVIDER[selectedBlockChain as keyof typeof QRL_PROVIDER].url;
+
+    const now = Date.now();
+    const updates = new Map<string, NFTInterface>();
+    for (const nft of this.nftList) {
+      const stale =
+        !nft.fetchedAt || now - nft.fetchedAt > NFT_METADATA_TTL_MS;
+      if (!force && !stale) continue;
+      try {
+        const uri = await fetchTokenUri(
+          nft.contractAddress,
+          nft.tokenId,
+          rpcUrl,
+          nft.standard,
+        );
+        if (!uri) continue;
+        const meta = await fetchNftMetadata(uri);
+        if (!meta) continue;
+        updates.set(nftKey(nft.contractAddress, nft.tokenId), {
+          ...nft,
+          name: meta.name ?? nft.name,
+          description: meta.description ?? nft.description,
+          image: meta.image ?? nft.image,
+          fetchedAt: Date.now(),
+        });
+      } catch (err) {
+        console.error(
+          `refreshNftMetadata: ${nft.contractAddress}#${nft.tokenId}`,
+          err,
+        );
+      }
+    }
+    if (updates.size === 0) return;
+    // Stale-write guard, mirrors addDiscoveredNfts: if the account
+    // switched while we awaited RPC, this.nftList belongs to another
+    // scope now and these updates must be dropped.
+    if (this.qrlStore.activeAccount.accountAddress !== startAccount) {
+      log("refreshNftMetadata: active account changed mid-refresh, dropping");
+      return;
+    }
+    // Merge into the CURRENT list rather than the snapshot we iterated:
+    // refreshNftBalances may have dropped or re-balanced entries while
+    // the metadata fetches were in flight, and ownership state wins.
+    const merged = this.nftList.map((n) => {
+      const u = updates.get(nftKey(n.contractAddress, n.tokenId));
+      if (!u) return n;
+      return {
+        ...n,
+        name: u.name,
+        description: u.description,
+        image: u.image,
+        fetchedAt: u.fetchedAt,
+      };
+    });
+    await this.setNftList(merged);
+    log(`refreshNftMetadata: refreshed ${updates.size} entries`);
   }
 
   /**
@@ -542,7 +620,7 @@ class NftStore {
       } else if (hidden.has(key.toLowerCase())) {
         unhides.push(key.toLowerCase());
       }
-      // else: already visible — skip
+      // else: already visible, skip
     }
     if (additions.length === 0 && unhides.length === 0) return;
     // Stale-write guard: NFT storage is per-account-scoped, so the

--- a/src/utils/web3/nft.ts
+++ b/src/utils/web3/nft.ts
@@ -43,7 +43,7 @@ export const IPFS_GATEWAY = `${SERVER_URL}/ipfs/`;
 const METADATA_FETCH_TIMEOUT_MS = 8000;
 
 // Try ERC-165 supportsInterface(0x...). Returns false on any RPC revert
-// (very common — pre-ERC-165 contracts revert instead of returning false).
+// (very common: pre-ERC-165 contracts revert instead of returning false).
 async function safeSupportsInterface(
   web3: Web3Type,
   contractAddress: string,
@@ -60,7 +60,7 @@ async function safeSupportsInterface(
 
 /**
  * Detect whether an address is an ERC-721 or ERC-1155 contract, or
- * neither (returns null — caller falls through to ERC-20 / unsupported).
+ * neither (returns null; caller falls through to ERC-20 / unsupported).
  */
 export async function detectTokenStandard(
   contractAddress: string,
@@ -99,12 +99,12 @@ export async function fetchNftCollectionInfo(
     try {
       name = await methods.name().call();
     } catch {
-      // Optional in ERC-721 — some implementations omit it.
+      // Optional in ERC-721; some implementations omit it.
     }
     try {
       symbol = await methods.symbol().call();
     } catch {
-      // Optional in ERC-721 — some implementations omit it.
+      // Optional in ERC-721; some implementations omit it.
     }
     const supportsEnumerable = await safeSupportsInterface(
       web3,
@@ -120,7 +120,7 @@ export async function fetchNftCollectionInfo(
 
 /**
  * For ERC-721 contracts that implement Enumerable, list owned token IDs.
- * Returns null if the contract doesn't support Enumerable — callers
+ * Returns null if the contract doesn't support Enumerable; callers
  * must then prompt the user for a tokenId.
  */
 export async function fetchOwned721Ids(
@@ -239,7 +239,7 @@ export function resolveIpfsUri(uri: string): string {
  * Fetch + parse NFT JSON metadata. Returns null on any failure (timeout,
  * 404, JSON parse error). Sanitizes the `image` field to proxied IPFS
  * (same-origin via `/api/ipfs/...`) or inline `data:image/...` only.
- * Raw http(s):// image URLs are dropped on purpose — tokenURI content
+ * Raw http(s):// image URLs are dropped on purpose: tokenURI content
  * is attacker-controlled and would otherwise leak the wallet user's IP
  * to any host the JSON points at.
  */
@@ -264,7 +264,7 @@ export async function fetchNftMetadata(uri: string): Promise<NftMetadata | null>
     if (image) {
       const rawImage = image;
       const resolvedImage = resolveIpfsUri(image);
-      // Only allow images that are either (a) proxied IPFS — `ipfs://`
+      // Only allow images that are either (a) proxied IPFS, `ipfs://`
       // resolves to same-origin `/api/ipfs/...` so the browser fetches
       // through the wallet backend and CSP `img-src 'self'` permits it,
       // or (b) inline `data:image/...`. Reject raw http(s):// images:

--- a/src/utils/web3/nftDiscovery.ts
+++ b/src/utils/web3/nftDiscovery.ts
@@ -74,6 +74,12 @@ export async function discoverNFTs(
       const std = normaliseStandard(n.tokenStandard);
       if (!std) continue;
       if (!n.contractAddress || !n.tokenID) continue;
+      // fetchedAt means "last SUCCESSFUL metadata fetch" (see
+      // NFTInterface). The explorer row may predate its own metadata
+      // backfill, so only stamp entries that actually carry metadata;
+      // unstamped ones get resolved by nftStore.refreshNftMetadata on
+      // the next gallery visit instead of waiting out the TTL.
+      const hasMetadata = Boolean(n.name || n.image);
       out.push({
         contractAddress: n.contractAddress.startsWith("Q")
           ? n.contractAddress
@@ -88,7 +94,7 @@ export async function discoverNFTs(
         description: n.description || undefined,
         image: n.image || undefined,
         balance: n.balance || undefined,
-        fetchedAt,
+        fetchedAt: hasMetadata ? fetchedAt : undefined,
       });
     }
 


### PR DESCRIPTION
Promotes dev to main. Backlog is exactly PR #240 (verified with origin/main..origin/dev):

- Gallery entries re-resolve tokenURI + metadata on a 24h TTL and via the Refresh button, with failure backoff, a 12-fetch/run cap against the /api/ipfs 60 req/min budget, preserve-last-good merges, scope-anchored persistence guards, and scope-aware single-flight refresh runs.
- Companion explorer change (zondscan #161) is already live on the syncer.

Pre-merge checklist:
- Diff reviewed: origin/main..origin/dev is solely #240 (adversarial multi-agent review + Gemini review, all findings addressed).
- Gates on the dev tip: lint clean, tsc clean, 244 jest tests pass, production build OK.
- Known risks: NFT metadata now refreshes on gallery mount; entries whose tokenURI changed on-chain will visibly update (intended). No storage migrations: new optional NFTInterface fields only.
- Runtime impact: prod auto-deploy on merge (deploy-frontend-prod.sh).