### PR TITLE
feat(ui): display native amounts as Quanta

### DIFF
--- a/src/components/Core/Body/AccountList/AccountBalance/AccountBalance.tsx
+++ b/src/components/Core/Body/AccountList/AccountBalance/AccountBalance.tsx
@@ -15,7 +15,7 @@ export const AccountBalance = observer(({ accountAddress, className }: AccountBa
 
   return (
     <div className={cn("text-sm text-secondary font-data", className)}>
-      Balance: {formatBalance(balance)} QRL
+      Balance: {formatBalance(balance)} Quanta
     </div>
   );
 });

--- a/src/components/Core/Body/AccountList/ActiveAccount/TransactionHistoryPopup.tsx
+++ b/src/components/Core/Body/AccountList/ActiveAccount/TransactionHistoryPopup.tsx
@@ -88,7 +88,7 @@ export const TransactionHistoryPopup = observer(({
                                             {tx.TxType}
                                         </span>
                                         <span className={tx.InOut === 1 ? "text-success" : "text-red-500"}>
-                                            {tx.InOut === 1 ? "+" : "-"}{formatBalance(tx.Amount)} QRL
+                                            {tx.InOut === 1 ? "+" : "-"}{formatBalance(tx.Amount)} Quanta
                                         </span>
                                     </div>
                                     <div className="text-sm text-muted-foreground">

--- a/src/components/Core/Body/CreateToken/TokenStatus.tsx
+++ b/src/components/Core/Body/CreateToken/TokenStatus.tsx
@@ -224,7 +224,7 @@ const TokenStatus = observer(() => {
                                 </div>
                                 <div className="flex flex-col gap-1">
                                     <span className="text-sm text-muted-foreground">Gas Used</span>
-                                    <span className="font-medium text-secondary">{gasInQrl} QRL</span>
+                                    <span className="font-medium text-secondary">{gasInQrl} Quanta</span>
                                 </div>
                             </div>
                         </CardContent>

--- a/src/components/Core/Body/Home/AccountCreateImport/ActiveAccountDisplay/ActiveAccountDisplay.tsx
+++ b/src/components/Core/Body/Home/AccountCreateImport/ActiveAccountDisplay/ActiveAccountDisplay.tsx
@@ -50,7 +50,7 @@ export const ActiveAccountDisplay = observer(() => {
         <div className="cursor-pointer flex items-baseline" onClick={() => handleCopy(activeAccountBalance, 'balance')}>
           <span>
             <SlotBalance value={formatBalance(activeAccountBalance)} spinning={isSlotSpinning} />
-            <span className="ml-1.5 text-base font-medium text-muted-foreground">QRL</span>
+            <span className="ml-1.5 text-base font-medium text-muted-foreground">Quanta</span>
           </span>
           {copiedItem === 'balance' ? (
             <Check className="w-4 h-4 ml-2 self-center text-success" />

--- a/src/components/Core/Body/Home/ReceivePopup.tsx
+++ b/src/components/Core/Body/Home/ReceivePopup.tsx
@@ -37,7 +37,7 @@ export const ReceivePopup = observer(({
             <Card className="w-full max-w-md mx-4" onClick={(e) => e.stopPropagation()}>
                 <CardContent className="p-4">
                     <div className="flex justify-between items-center mb-4">
-                        <h2 className="text-xl font-bold">Receive QRL</h2>
+                        <h2 className="text-xl font-bold">Receive Quanta</h2>
                         <Button variant="ghost" size="sm" onClick={onClose}>×</Button>
                     </div>
                     
@@ -72,7 +72,7 @@ export const ReceivePopup = observer(({
                         </div>
                         
                         <div className="text-center text-sm text-muted-foreground mt-2">
-                            <p>Share this address or QR code to receive QRL.</p>
+                            <p>Share this address or QR code to receive Quanta.</p>
                         </div>
                     </div>
                 </CardContent>

--- a/src/components/Core/Body/TransactionHistory/TransactionHistory.tsx
+++ b/src/components/Core/Body/TransactionHistory/TransactionHistory.tsx
@@ -152,7 +152,7 @@ const TransactionHistory = observer(() => {
                                         className="py-2 px-4 border-b cursor-pointer text-left text-sm sm:text-base hidden sm:table-cell"
                                         onClick={() => requestSort('Amount')}
                                     >
-                                        Amount (QRL) {sortConfig?.key === 'Amount' ? (sortConfig.direction === 'ascending' ? '↑' : '↓') : ''}
+                                        Amount (Quanta) {sortConfig?.key === 'Amount' ? (sortConfig.direction === 'ascending' ? '↑' : '↓') : ''}
                                     </th>
                                     <th
                                         className="py-2 px-4 border-b cursor-pointer text-left text-sm sm:text-base table-cell sm:hidden"

--- a/src/components/Core/Body/Transfer/Transfer.tsx
+++ b/src/components/Core/Body/Transfer/Transfer.tsx
@@ -583,7 +583,7 @@ const Transfer = observer(() => {
                       <span className="text-muted-foreground">Value:</span>
                       <span>
                         {isNativeTransfer
-                          ? `${utils.fromPlanck(BigInt(transactionStatus.pendingDetails.value), "quanta")} Quanta`
+                          ? `${utils.fromPlanck(BigInt(transactionStatus.pendingDetails.value), "quanta")} ${NATIVE_TOKEN.symbol}`
                           : `${getOptimalTokenBalance(formValues.amount.toString())} ${assetSymbol}`
                         }
                       </span>

--- a/src/components/Core/Body/Transfer/Transfer.tsx
+++ b/src/components/Core/Body/Transfer/Transfer.tsx
@@ -26,6 +26,7 @@ import {
 import { Input } from "@/components/UI/Input";
 import { Label } from "@/components/UI/Label";
 import { Separator } from "@/components/UI/Separator";
+import { NATIVE_TOKEN } from "@/constants";
 import { ROUTES } from "@/router/router";
 import { useStore } from "@/stores/store";
 import { StorageUtil } from "@/utils/storage";
@@ -309,7 +310,7 @@ const Transfer = observer(() => {
               <CardHeader>
                 <CardTitle className="text-2xl font-bold">Transfer</CardTitle>
                 <CardDescription>
-                  Send QRL or tokens to another wallet
+                  Send Quanta or tokens to another wallet
                 </CardDescription>
               </CardHeader>
               <CardContent>
@@ -345,7 +346,7 @@ const Transfer = observer(() => {
 
   async function onSubmit(formData: z.infer<typeof FormSchema>) {
     setSubmittedAmount(formData.amount.toString());
-    setSubmittedAssetSymbol(isNativeTransfer ? "QRL" : (selectedToken?.symbol || ""));
+    setSubmittedAssetSymbol(isNativeTransfer ? NATIVE_TOKEN.symbol : (selectedToken?.symbol || ""));
     if (isNativeTransfer) {
       await handleNativeTransfer(formData);
     } else {
@@ -525,7 +526,7 @@ const Transfer = observer(() => {
     applyPercentage(percentage);
   };
 
-  const assetSymbol = isNativeTransfer ? "QRL" : (selectedToken?.symbol || "");
+  const assetSymbol = isNativeTransfer ? NATIVE_TOKEN.symbol : (selectedToken?.symbol || "");
 
   // Transaction States
   if (transactionStatus.state === 'confirmed' && transactionStatus.receipt) {
@@ -582,7 +583,7 @@ const Transfer = observer(() => {
                       <span className="text-muted-foreground">Value:</span>
                       <span>
                         {isNativeTransfer
-                          ? `${utils.fromPlanck(BigInt(transactionStatus.pendingDetails.value), "quanta")} QRL`
+                          ? `${utils.fromPlanck(BigInt(transactionStatus.pendingDetails.value), "quanta")} Quanta`
                           : `${getOptimalTokenBalance(formValues.amount.toString())} ${assetSymbol}`
                         }
                       </span>
@@ -703,7 +704,7 @@ const Transfer = observer(() => {
                 <CardHeader>
                   <CardTitle className="text-2xl font-bold">Transfer</CardTitle>
                   <CardDescription>
-                    Send QRL or tokens to another wallet
+                    Send Quanta or tokens to another wallet
                   </CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-6">
@@ -724,7 +725,7 @@ const Transfer = observer(() => {
                             <SelectItem value="native">
                               <div className="flex items-center gap-2">
                                 <Coins className="h-4 w-4" />
-                                <span>QRL (Native)</span>
+                                <span>Quanta (Native)</span>
                               </div>
                             </SelectItem>
                             {visibleTokenList.map((token) => (

--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -8,9 +8,11 @@ export interface TokenInterface {
 
 export const KNOWN_TOKEN_LIST: TokenInterface[] = [];
 
+// Display identity of the native coin. Ecosystem convention: amounts show
+// as "Quanta"; "QRL" stays the project name and exchange ticker.
 export const NATIVE_TOKEN = {
-    name: "QRL",
-    symbol: "QRL",
+    name: "Quanta",
+    symbol: "Quanta",
     decimals: 18,
 };
 

--- a/src/utils/formatting/balance.ts
+++ b/src/utils/formatting/balance.ts
@@ -3,7 +3,7 @@ import { utils } from "@theqrl/web3";
 import { BigNumber } from "bignumber.js";
 
 /**
- * Safely format a raw planck transaction `value` into a "X QRL" string.
+ * Safely format a raw planck transaction `value` into a "X Quanta" string.
  * The value originates from a dApp (qrl_sendTransaction / qrl_signTransaction)
  * and is NOT schema-validated, so it may be non-numeric, negative, or a
  * fractional number. A bare `BigInt(value)` would throw during render and
@@ -11,11 +11,11 @@ import { BigNumber } from "bignumber.js";
  * request. Falls back to a safe label instead of throwing.
  */
 export const formatQuantaValue = (value: unknown): string => {
-    if (value === undefined || value === null || value === "") return "0 QRL";
+    if (value === undefined || value === null || value === "") return `0 ${NATIVE_TOKEN.symbol}`;
     try {
         const planck = BigInt(value as string);
         if (planck < 0n) return "invalid value";
-        return `${utils.fromPlanck(planck.toString(), "quanta")} QRL`;
+        return `${utils.fromPlanck(planck.toString(), "quanta")} ${NATIVE_TOKEN.symbol}`;
     } catch {
         return "invalid value";
     }
@@ -33,7 +33,7 @@ BigNumber.config({
 });
 
 export const getOptimalGasFee = (gas: string, tokenSymbol?: string) => {
-    const symbol = tokenSymbol ?? "QRL";
+    const symbol = tokenSymbol ?? NATIVE_TOKEN.symbol;
     try {
         if (Number(gas) == 0) return `0.0 ${symbol}`;
         const precisionFloat = parseFloat(Number(gas).toString()).toFixed(16);


### PR DESCRIPTION
## Summary
Ecosystem consensus (Discord, 2026-07-20): native tools display coin amounts as **Quanta**; QRL stays the project name and exchange ticker.

- `NATIVE_TOKEN` name/symbol -> "Quanta" in `src/constants/tokens.ts`. Verified nothing compares the symbol string for native-vs-token logic (only display fallbacks consume it), so this flips the asset picker, Available balance, Send button label, success screens, and the service-worker-free render paths in one place.
- `balance.ts`: `formatQuantaValue` and `getOptimalGasFee` now derive their unit from `NATIVE_TOKEN.symbol` instead of hardcoding QRL.
- Flipped remaining literals: home balance card, account list balance, tx history popup and Amount column, token creation + send gas lines, pending value, asset picker "Quanta (Native)", "Send Quanta or tokens", Receive popup.

Kept as QRL: network/project references, address validation copy, SEO/meta, qrl_* protocol identifiers.

Propagates to the desktop renderer and the mobile WebView on their next renderer rebuilds.

## Gates
- `npm run lint` (max-warnings 0): pass
- `npm test`: 244/244 pass
- `npm run build`: pass (pre-existing chunk-size warning only)

## Risks
Display-only. No storage schema, bridge messages, or signing paths touched.