### PR TITLE
fix(csp): allow data: fonts in meta CSP

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 
     <!-- Security Headers - main CSP is set via nginx in production -->
     <!-- This meta CSP provides baseline protection for local development -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; media-src 'self' blob:; connect-src 'self' https://qrlwallet.com wss://qrlwallet.com https://zondscan.com http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*; base-uri 'self'; form-action 'self';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' blob:; connect-src 'self' https://qrlwallet.com wss://qrlwallet.com https://zondscan.com http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*; base-uri 'self'; form-action 'self';">
     <meta name="referrer" content="strict-origin-when-cross-origin">
     
     <!-- Primary Meta Tags -->


### PR DESCRIPTION
## Problem
Console error on qrlwallet.com:

> Loading the font 'data:font/woff2;base64,d09GMg...' violates the following Content Security Policy directive: "default-src 'self'". Note that 'font-src' was not explicitly set, so 'default-src' is used as a fallback.

Vite inlines assets under 4KB as data: URIs. Two JetBrains Mono variable-font subsets (cyrillic-ext normal + italic) are below that limit, so they ship as `data:font/woff2;base64,...` inside the built CSS.

The nginx CSP header already allows `font-src 'self' data:`, but when both a header CSP and a meta CSP are present each policy is enforced independently. The meta CSP in `index.html` had no `font-src` directive, so its `default-src 'self'` fallback blocked the inlined fonts regardless of the header.

## Fix
Add `font-src 'self' data:` to the meta CSP, matching the nginx header and the desktop renderer CSP (`build-renderer.sh`).

## Verification
- `npm run lint` clean
- `npm test`: 244 passed
- `npm run build` green; `dist/index.html` contains `font-src 'self' data:` and `dist/assets/index-*.css` confirmed to contain the inlined `data:font/woff2;base64,d09GMg` subset