### PR TITLE
feat(ui): move Quanta unit below the balance

### DIFF
--- a/src/components/Core/Body/Home/AccountCreateImport/ActiveAccountDisplay/ActiveAccountDisplay.tsx
+++ b/src/components/Core/Body/Home/AccountCreateImport/ActiveAccountDisplay/ActiveAccountDisplay.tsx
@@ -50,7 +50,6 @@ export const ActiveAccountDisplay = observer(() => {
         <div className="cursor-pointer flex items-baseline" onClick={() => handleCopy(activeAccountBalance, 'balance')}>
           <span>
             <SlotBalance value={formatBalance(activeAccountBalance)} spinning={isSlotSpinning} />
-            <span className="ml-1.5 text-base font-medium text-muted-foreground">Quanta</span>
           </span>
           {copiedItem === 'balance' ? (
             <Check className="w-4 h-4 ml-2 self-center text-success" />
@@ -72,8 +71,11 @@ export const ActiveAccountDisplay = observer(() => {
           )}
         </button>
       </div>
+      <div className="flex justify-center mt-0.5">
+        <span className="font-data text-sm font-medium text-muted-foreground">Quanta</span>
+      </div>
       {qrlPrice > 0 && (
-        <div className="flex items-center justify-center gap-2 text-sm mt-2 mb-4 font-data">
+        <div className="flex items-center justify-center gap-2 text-sm mt-1 mb-4 font-data">
           <span className="text-muted-foreground">
             ≈ ${activeAccountBalanceUsd.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
           </span>


### PR DESCRIPTION
Community feedback (Discord): put the unit on a secondary line since balances can run to 18 decimals and the inline unit crowds the number. The official QRL explorer uses the same layout.

- Balance number stays on its own row with the copy/refresh controls
- "Quanta" now renders as a smaller muted line directly under it
- Fiat estimate + 24h change line tightened from mt-2 to mt-1 to keep the stack compact

Gates: lint clean, 244 tests pass, build green. Desktop and mobile app reuse this component, so they pick the change up on their next renderer rebuild.