### PR TITLE
fix: readable recent-transactions rows in history popup

### DIFF
--- a/src/components/Core/Body/AccountList/ActiveAccount/TransactionHistoryPopup.tsx
+++ b/src/components/Core/Body/AccountList/ActiveAccount/TransactionHistoryPopup.tsx
@@ -1,16 +1,20 @@
 import { useState, useEffect } from "react";
 import { observer } from "mobx-react-lite";
 import axios from "axios";
+import { BigNumber } from "bignumber.js";
+import { ArrowDownLeft, ArrowUpRight } from "lucide-react";
 import { SERVER_URL } from "@/config";
-import { formatBalance } from "@/utils/formatting";
+import { formatBalance, formatAddressShort } from "@/utils/formatting";
 import { Card, CardContent } from "../../../../UI/Card";
 import { Button } from "../../../../UI/Button";
-import { getExplorerAddressUrl } from "@/config";
+import { getExplorerAddressUrl, getExplorerTxUrl } from "@/config";
 import { openExternalUrl } from "@/utils/nativeApp";
 
 type TransactionHistoryType = {
     ID: string;
     InOut: number;
+    // Raw EIP-1559 envelope type from the node ("0x2" for every v2 tx),
+    // not a user-facing category. Direction is derived from InOut instead.
     TxType: string;
     Address: string;
     From: string;
@@ -22,6 +26,15 @@ type TransactionHistoryType = {
     BlockNumber: string;
 }
 
+const DUST_DISPLAY_FLOOR = new BigNumber("0.000001");
+
+const formatTxAmount = (amount: string): string => {
+    const bn = new BigNumber(amount);
+    if (bn.isNaN() || bn.isZero()) return "0";
+    if (bn.abs().lt(DUST_DISPLAY_FLOOR)) return "<0.000001";
+    return formatBalance(amount);
+};
+
 interface TransactionHistoryPopupProps {
     accountAddress: string;
     blockchain: string;
@@ -29,8 +42,8 @@ interface TransactionHistoryPopupProps {
     onClose: () => void;
 }
 
-export const TransactionHistoryPopup = observer(({ 
-    accountAddress, 
+export const TransactionHistoryPopup = observer(({
+    accountAddress,
     blockchain,
     isOpen,
     onClose
@@ -74,36 +87,65 @@ export const TransactionHistoryPopup = observer(({
                         <h2 className="text-xl font-bold">Recent Transactions</h2>
                         <Button variant="ghost" size="sm" onClick={onClose}>×</Button>
                     </div>
-                    
+
                     {loading ? (
-                        <div className="text-center py-8">Loading...</div>
+                        <div className="text-center py-8 text-muted-foreground">Loading...</div>
                     ) : transactions.length === 0 ? (
-                        <div className="text-center py-8">No transactions found</div>
+                        <div className="text-center py-8 text-muted-foreground">No transactions found</div>
                     ) : (
-                        <div className="space-y-3">
-                            {transactions.map((tx) => (
-                                <div key={tx.ID} className="border-b border-border pb-3">
-                                    <div className="flex justify-between">
-                                        <span className="font-medium">
-                                            {tx.TxType}
-                                        </span>
-                                        <span className={tx.InOut === 1 ? "text-success" : "text-red-500"}>
-                                            {tx.InOut === 1 ? "+" : "-"}{formatBalance(tx.Amount)} Quanta
-                                        </span>
-                                    </div>
-                                    <div className="text-sm text-muted-foreground">
-                                        <div className="truncate">
-                                            Hash: {tx.TxHash.substring(0, 16)}...
+                        <div className="divide-y divide-border">
+                            {transactions.map((tx) => {
+                                const isIncoming = tx.InOut === 1;
+                                const amountText = formatTxAmount(tx.Amount);
+                                const isZero = amountText === "0";
+                                const sign = isZero || amountText.startsWith("<")
+                                    ? ""
+                                    : isIncoming ? "+" : "-";
+                                const amountClass = isZero
+                                    ? "text-muted-foreground"
+                                    : isIncoming ? "text-success" : "text-red-400";
+                                const counterparty = isIncoming
+                                    ? `From ${formatAddressShort(tx.From)}`
+                                    : tx.To
+                                        ? `To ${formatAddressShort(tx.To)}`
+                                        : "Contract creation";
+
+                                return (
+                                    <button
+                                        key={tx.ID}
+                                        type="button"
+                                        title="View transaction on Explorer"
+                                        onClick={() => openExternalUrl(getExplorerTxUrl(tx.TxHash, blockchain))}
+                                        className="w-full flex items-start justify-between gap-3 px-1 py-3 text-left rounded-md transition-colors hover:bg-foreground/5"
+                                    >
+                                        <div className="flex items-start gap-2.5 min-w-0">
+                                            <div className={`mt-0.5 shrink-0 rounded-full p-1.5 ${isIncoming ? "bg-success/10 text-success" : "bg-red-400/10 text-red-400"}`}>
+                                                {isIncoming ? <ArrowDownLeft size={14} /> : <ArrowUpRight size={14} />}
+                                            </div>
+                                            <div className="min-w-0">
+                                                <div className="text-sm font-medium">
+                                                    {isIncoming ? "Received" : "Sent"}
+                                                </div>
+                                                <div className="text-xs text-muted-foreground font-data truncate">
+                                                    {counterparty}
+                                                </div>
+                                                <div className="text-xs text-muted-foreground">
+                                                    {new Date(parseInt(tx.TimeStamp, 16) * 1000).toLocaleString()}
+                                                </div>
+                                            </div>
                                         </div>
-                                        <div>
-                                            Date: {new Date(parseInt(tx.TimeStamp, 16) * 1000).toLocaleString()}
+                                        <div className="text-right shrink-0">
+                                            <div className={`text-sm font-data ${amountClass}`}>
+                                                {sign}{amountText}
+                                            </div>
+                                            <div className="text-xs text-muted-foreground font-data">Quanta</div>
                                         </div>
-                                    </div>
-                                </div>
-                            ))}
+                                    </button>
+                                );
+                            })}
                         </div>
                     )}
-                    
+
                     <div className="mt-4 flex justify-center">
                         <Button variant="outline" onClick={viewAllTransactions}>
                             View All in Explorer


### PR DESCRIPTION
## Problem
The Recent Transactions popup (History button on the active account card) was unreadable:
- Row title showed `0x2`: zondscan's `TxType` is the raw EIP-1559 envelope type from the node, which is `0x2` for every v2 transaction, not a category.
- Dust values printed at full precision: `-0.000000000000001 Quanta` (1000-wei HTLC test txs).
- Zero-value contract calls showed as red `-0.00 Quanta`.

## Changes
- Direction label (Sent/Received) derived from `InOut`, with an arrow icon and the counterparty address (`To Q23832 ... 4decb0`), instead of the raw envelope type.
- Amounts below 0.000001 Quanta display as `<0.000001`; exact values remain on the explorer.
- Zero-value calls render a neutral `0` with no sign or red color.
- Quanta unit moved to its own line under the amount, matching the unit-rename layout convention (#245); amounts use `font-data`.
- Each row links to the transaction page on the explorer; empty `To` renders as Contract creation.

## Validation
- `npm run lint`: clean (zero warnings policy)
- `npm run build`: passes (tsc + vite)
- `npm test`: 244/244 pass

UI-only change in one component; no store, backend, or SDK impact.