### PR TITLE
release: recent-transactions popup readability fix

### DIFF
--- a/src/components/Core/Body/AccountList/ActiveAccount/TransactionHistoryPopup.tsx
+++ b/src/components/Core/Body/AccountList/ActiveAccount/TransactionHistoryPopup.tsx
@@ -1,16 +1,20 @@
 import { useState, useEffect } from "react";
 import { observer } from "mobx-react-lite";
 import axios from "axios";
+import { BigNumber } from "bignumber.js";
+import { ArrowDownLeft, ArrowUpRight } from "lucide-react";
 import { SERVER_URL } from "@/config";
-import { formatBalance } from "@/utils/formatting";
+import { formatBalance, formatAddressShort } from "@/utils/formatting";
 import { Card, CardContent } from "../../../../UI/Card";
 import { Button } from "../../../../UI/Button";
-import { getExplorerAddressUrl } from "@/config";
+import { getExplorerAddressUrl, getExplorerTxUrl } from "@/config";
 import { openExternalUrl } from "@/utils/nativeApp";
 
 type TransactionHistoryType = {
     ID: string;
     InOut: number;
+    // Raw EIP-1559 envelope type from the node ("0x2" for every v2 tx),
+    // not a user-facing category. Direction is derived from InOut instead.
     TxType: string;
     Address: string;
     From: string;
@@ -22,6 +26,15 @@ type TransactionHistoryType = {
     BlockNumber: string;
 }
 
+const DUST_DISPLAY_FLOOR = new BigNumber("0.000001");
+
+const formatTxAmount = (amount: string): string => {
+    const bn = new BigNumber(amount);
+    if (bn.isNaN() || bn.isZero()) return "0";
+    if (bn.abs().lt(DUST_DISPLAY_FLOOR)) return "<0.000001";
+    return formatBalance(amount);
+};
+
 interface TransactionHistoryPopupProps {
     accountAddress: string;
     blockchain: string;
@@ -29,8 +42,8 @@ interface TransactionHistoryPopupProps {
     onClose: () => void;
 }
 
-export const TransactionHistoryPopup = observer(({ 
-    accountAddress, 
+export const TransactionHistoryPopup = observer(({
+    accountAddress,
     blockchain,
     isOpen,
     onClose
@@ -74,36 +87,65 @@ export const TransactionHistoryPopup = observer(({
                         <h2 className="text-xl font-bold">Recent Transactions</h2>
                         <Button variant="ghost" size="sm" onClick={onClose}>×</Button>
                     </div>
-                    
+
                     {loading ? (
-                        <div className="text-center py-8">Loading...</div>
+                        <div className="text-center py-8 text-muted-foreground">Loading...</div>
                     ) : transactions.length === 0 ? (
-                        <div className="text-center py-8">No transactions found</div>
+                        <div className="text-center py-8 text-muted-foreground">No transactions found</div>
                     ) : (
-                        <div className="space-y-3">
-                            {transactions.map((tx) => (
-                                <div key={tx.ID} className="border-b border-border pb-3">
-                                    <div className="flex justify-between">
-                                        <span className="font-medium">
-                                            {tx.TxType}
-                                        </span>
-                                        <span className={tx.InOut === 1 ? "text-success" : "text-red-500"}>
-                                            {tx.InOut === 1 ? "+" : "-"}{formatBalance(tx.Amount)} Quanta
-                                        </span>
-                                    </div>
-                                    <div className="text-sm text-muted-foreground">
-                                        <div className="truncate">
-                                            Hash: {tx.TxHash.substring(0, 16)}...
+                        <div className="divide-y divide-border">
+                            {transactions.map((tx) => {
+                                const isIncoming = tx.InOut === 1;
+                                const amountText = formatTxAmount(tx.Amount);
+                                const isZero = amountText === "0";
+                                const sign = isZero || amountText.startsWith("<")
+                                    ? ""
+                                    : isIncoming ? "+" : "-";
+                                const amountClass = isZero
+                                    ? "text-muted-foreground"
+                                    : isIncoming ? "text-success" : "text-red-400";
+                                const counterparty = isIncoming
+                                    ? `From ${formatAddressShort(tx.From)}`
+                                    : tx.To
+                                        ? `To ${formatAddressShort(tx.To)}`
+                                        : "Contract creation";
+
+                                return (
+                                    <button
+                                        key={tx.ID}
+                                        type="button"
+                                        title="View transaction on Explorer"
+                                        onClick={() => openExternalUrl(getExplorerTxUrl(tx.TxHash, blockchain))}
+                                        className="w-full flex items-start justify-between gap-3 px-1 py-3 text-left rounded-md transition-colors hover:bg-foreground/5"
+                                    >
+                                        <div className="flex items-start gap-2.5 min-w-0">
+                                            <div className={`mt-0.5 shrink-0 rounded-full p-1.5 ${isIncoming ? "bg-success/10 text-success" : "bg-red-400/10 text-red-400"}`}>
+                                                {isIncoming ? <ArrowDownLeft size={14} /> : <ArrowUpRight size={14} />}
+                                            </div>
+                                            <div className="min-w-0">
+                                                <div className="text-sm font-medium">
+                                                    {isIncoming ? "Received" : "Sent"}
+                                                </div>
+                                                <div className="text-xs text-muted-foreground font-data truncate">
+                                                    {counterparty}
+                                                </div>
+                                                <div className="text-xs text-muted-foreground">
+                                                    {new Date(parseInt(tx.TimeStamp, 16) * 1000).toLocaleString()}
+                                                </div>
+                                            </div>
                                         </div>
-                                        <div>
-                                            Date: {new Date(parseInt(tx.TimeStamp, 16) * 1000).toLocaleString()}
+                                        <div className="text-right shrink-0">
+                                            <div className={`text-sm font-data ${amountClass}`}>
+                                                {sign}{amountText}
+                                            </div>
+                                            <div className="text-xs text-muted-foreground font-data">Quanta</div>
                                         </div>
-                                    </div>
-                                </div>
-                            ))}
+                                    </button>
+                                );
+                            })}
                         </div>
                     )}
-                    
+
                     <div className="mt-4 flex justify-center">
                         <Button variant="outline" onClick={viewAllTransactions}>
                             View All in Explorer


### PR DESCRIPTION
Promotes dev to main. Single change since last release:

- #247 fix: readable recent-transactions rows in history popup (Sent/Received + counterparty instead of raw EIP-1559 envelope type, <0.000001 dust floor, neutral zero for zero-value calls, Quanta unit on its own line, rows link to the explorer tx page)

## Pre-merge checklist
- Diff reviewed: `origin/main..origin/dev` is one commit, one component (`TransactionHistoryPopup.tsx`, +69/-27)
- Gates on merged dev: lint clean, build (tsc + vite) passes, 244/244 tests pass
- Verified on dev.qrlwallet.com against live tx history (HTLC dust txs render correctly)
- Risks: none identified; UI-only, no store/backend/SDK impact, no migrations