### PR TITLE
feat(settings): compact grouped-list settings page

### DIFF
--- a/src/components/Core/Body/Settings/NetworkSettings/NetworkSettings.tsx
+++ b/src/components/Core/Body/Settings/NetworkSettings/NetworkSettings.tsx
@@ -1,9 +1,8 @@
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/UI/Card";
 import { useStore } from "../../../../../stores/store";
 import { observer } from "mobx-react-lite";
 import { QRL_PROVIDER } from "@/config";
-import { Button } from "@/components/UI/Button";
-import { Settings2 } from "lucide-react";
+import { Check, FlaskConical, Globe } from "lucide-react";
+import { SettingsRow, SettingsSection } from "../SettingsList";
 
 export const NetworkSettings = observer(() => {
     const { qrlStore } = useStore();
@@ -11,37 +10,26 @@ export const NetworkSettings = observer(() => {
     const { blockchain, isLoading } = qrlConnection;
     const { TEST_NET, MAIN_NET } = QRL_PROVIDER;
 
-    return (
-        <Card >
-            <CardHeader>
-                <CardTitle className="text-2xl font-bold">Network Settings</CardTitle>
-                <CardDescription>
-                    Configure your network connections and RPC endpoints
-                </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <Button
-                        variant={blockchain === MAIN_NET.id ? "secondary" : "outline"}
-                        className="w-full justify-start"
-                        onClick={() => selectBlockchain(MAIN_NET.id)}
-                        disabled={isLoading}
-                    >
-                        <Settings2 className="mr-2 h-4 w-4" />
-                        Mainnet
-                    </Button>
+    const activeMark = <Check className="h-4 w-4 shrink-0 text-primary" />;
 
-                    <Button
-                        variant={blockchain === TEST_NET.id ? "secondary" : "outline"}
-                        className="w-full justify-start"
-                        onClick={() => selectBlockchain(TEST_NET.id)}
-                        disabled={isLoading}
-                    >
-                        <Settings2 className="mr-2 h-4 w-4" />
-                        Testnet
-                    </Button>
-                </div>
-            </CardContent>
-        </Card>
+    return (
+        <SettingsSection title="Network">
+            <SettingsRow
+                icon={Globe}
+                tint="bg-emerald-500/15 text-emerald-400"
+                title="Mainnet"
+                right={blockchain === MAIN_NET.id ? activeMark : undefined}
+                onClick={() => selectBlockchain(MAIN_NET.id)}
+                disabled={isLoading}
+            />
+            <SettingsRow
+                icon={FlaskConical}
+                tint="bg-amber-500/15 text-amber-400"
+                title="Testnet"
+                right={blockchain === TEST_NET.id ? activeMark : undefined}
+                onClick={() => selectBlockchain(TEST_NET.id)}
+                disabled={isLoading}
+            />
+        </SettingsSection>
     );
 });

--- a/src/components/Core/Body/Settings/Settings.tsx
+++ b/src/components/Core/Body/Settings/Settings.tsx
@@ -1,12 +1,5 @@
 import { Button } from "../../../UI/Button";
-import {
-    Card,
-    CardContent,
-    CardDescription,
-    CardFooter,
-    CardHeader,
-    CardTitle,
-} from "../../../UI/Card";
+import { Card } from "../../../UI/Card";
 import {
     Form,
     FormControl,
@@ -18,16 +11,24 @@ import {
 } from "../../../UI/Form";
 import { Input } from "../../../UI/Input";
 import { Switch } from "@/components/UI/switch";
-import { Separator } from "@/components/UI/Separator";
 import { observer } from "mobx-react-lite";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
-import { useState, useEffect, lazy } from "react";
+import { useState, useEffect, useRef, lazy } from "react";
 import { NetworkSettings } from "./NetworkSettings/NetworkSettings";
 import type { EncryptedSeedData } from "@/utils/storage";
 import { StorageUtil } from "@/utils/storage";
-import { BookUser, ChevronRight, Save, Shield } from "lucide-react";
+import {
+    BookUser,
+    Check,
+    ChevronDown,
+    ChevronRight,
+    Coins,
+    Images,
+    Shield,
+    TimerReset,
+} from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { ROUTES } from "@/router/router";
 import { SEO } from "@/components/SEO/SEO";
@@ -36,6 +37,8 @@ import { decryptSeedAsync, reEncryptSeedAsync } from "@/utils/crypto";
 import { isInNativeApp, sendPinChanged } from "@/utils/nativeApp";
 import { isDesktop } from "@/desktop/bridge";
 import { withSuspense } from "@/utils/react";
+import { cn } from "@/utils/cn";
+import { SettingsIconTile, SettingsRow, SettingsSection } from "./SettingsList";
 import {
     checkLockout,
     recordFailedAttempt,
@@ -76,8 +79,8 @@ type ChangePinFormValues = z.infer<typeof ChangePinSchema>;
 
 const Settings = observer(() => {
     const navigate = useNavigate();
-    const [isSubmitting, setIsSubmitting] = useState(false);
     const [hasEncryptedSeeds, setHasEncryptedSeeds] = useState(false);
+    const [showPinForm, setShowPinForm] = useState(false);
     const [isChangingPin, setIsChangingPin] = useState(false);
     const [changePinError, setChangePinError] = useState<string | null>(null);
     const [changePinSuccess, setChangePinSuccess] = useState(false);
@@ -134,7 +137,6 @@ const Settings = observer(() => {
         setSettingsSaveSuccess(false);
         setSettingsSaveError(null);
         try {
-            setIsSubmitting(true);
             // Convert minutes to milliseconds for storage
             const settingsToSave = {
                 ...data,
@@ -144,10 +146,36 @@ const Settings = observer(() => {
             setSettingsSaveSuccess(true);
         } catch (_error) {
             setSettingsSaveError("There was an error saving your settings.");
-        } finally {
-            setIsSubmitting(false);
         }
     }
+
+    // Preferences auto-save on change (debounced so rapid toggles and
+    // keystrokes in the timer input collapse into one write). Invalid
+    // values never reach onSubmit: handleSubmit runs the zod resolver.
+    const saveTimer = useRef<number | null>(null);
+    const queueSave = (delayMs: number) => {
+        if (saveTimer.current !== null) {
+            window.clearTimeout(saveTimer.current);
+        }
+        saveTimer.current = window.setTimeout(() => {
+            void form.handleSubmit(onSubmit)();
+        }, delayMs);
+    };
+
+    useEffect(() => {
+        return () => {
+            if (saveTimer.current !== null) {
+                window.clearTimeout(saveTimer.current);
+            }
+        };
+    }, []);
+
+    // Transient "Saved" chip in the Preferences section header
+    useEffect(() => {
+        if (!settingsSaveSuccess) return;
+        const timeout = setTimeout(() => setSettingsSaveSuccess(false), 2500);
+        return () => clearTimeout(timeout);
+    }, [settingsSaveSuccess]);
 
     // Change PIN form
     const changePinForm = useForm<ChangePinFormValues>({
@@ -242,259 +270,263 @@ const Settings = observer(() => {
             <SEO title="Settings" />
             <div className="flex w-full items-start justify-center py-2 md:py-8">
                 <div className="relative w-full max-w-2xl px-2 md:px-4">
-                    { /* <video
-                        autoPlay
-                        muted
-                        loop
-                        playsInline
-                        className={"fixed left-0 top-0 z-0 h-96 w-96 -translate-x-8 scale-150 overflow-hidden"}
-                    >
-                        <source src="/tree.mp4" type="video/mp4" />
-                    </video> */ }
-                    <div className="page-enter relative z-10 space-y-4 md:space-y-8">
-                        {/* PIN Management Card - web/native only. On desktop there
-                            is no PIN (the signer uses a password / Argon2id) and
-                            no in-renderer re-encrypt, so the card is hidden. */}
+                    <div className="page-enter relative z-10 space-y-5 md:space-y-6">
+                        {/* Security - web/native only. On desktop there is no
+                            PIN (the signer uses a password / Argon2id) and no
+                            in-renderer re-encrypt, so the section is hidden. */}
                         {hasEncryptedSeeds && !isDesktop && (
-                            <Card className="border-l-4 border-l-primary">
-                                <CardHeader>
-                                    <div className="flex items-center gap-2">
-                                        <Shield className="h-6 w-6 text-primary" />
-                                        <CardTitle className="text-2xl font-bold">PIN Management</CardTitle>
-                                    </div>
-                                    <CardDescription>
-                                        Change your wallet PIN used to encrypt your seeds
-                                    </CardDescription>
-                                </CardHeader>
-
-                                <Form {...changePinForm}>
-                                    <form onSubmit={changePinForm.handleSubmit(onChangePinSubmit)}>
-                                        <CardContent className="space-y-6">
-                                            {pinLockout.isLocked && (
-                                                <div className="rounded-md bg-destructive/15 p-3 text-sm text-destructive">
-                                                    Too many failed attempts. Please wait {formatLockoutTime(pinLockout.remainingMs)}.
-                                                </div>
+                            <SettingsSection title="Security">
+                                <SettingsRow
+                                    icon={Shield}
+                                    tint="bg-primary/15 text-primary"
+                                    title="Change PIN"
+                                    subtitle="Change your wallet PIN used to encrypt your seeds"
+                                    right={
+                                        <ChevronDown
+                                            className={cn(
+                                                "h-4 w-4 shrink-0 text-muted-foreground transition-transform",
+                                                showPinForm && "rotate-180",
                                             )}
-                                            {!pinLockout.isLocked && hasFailedAttempts() && attemptsLeft > 0 && (
-                                                <div className="rounded-md bg-yellow-500/15 p-3 text-sm text-yellow-400">
-                                                    {attemptsLeft} attempt{attemptsLeft === 1 ? '' : 's'} remaining before lockout.
-                                                </div>
-                                            )}
-                                            {changePinError && !pinLockout.isLocked && (
-                                                <div className="rounded-md bg-destructive/15 p-3 text-sm text-destructive">
-                                                    {changePinError}
-                                                </div>
-                                            )}
-                                            {changePinSuccess && (
-                                                <div className="rounded-md bg-success/15 p-3 text-sm text-success">
-                                                    PIN changed successfully! Your wallet PIN has been updated.
-                                                </div>
-                                            )}
-
-                                            <FormField
-                                                control={changePinForm.control}
-                                                name="currentPin"
-                                                render={({ field, fieldState }) => (
-                                                    <FormItem>
-                                                        <FormLabel>Current PIN</FormLabel>
-                                                        <FormControl>
-                                                            <PinInput
-                                                                value={field.value}
-                                                                onChange={field.onChange}
-                                                                placeholder="Enter current PIN"
-                                                                error={fieldState.error?.message}
-                                                                disabled={isChangingPin || pinLockout.isLocked}
-                                                            />
-                                                        </FormControl>
-                                                    </FormItem>
-                                                )}
-                                            />
-
-                                            <FormField
-                                                control={changePinForm.control}
-                                                name="newPin"
-                                                render={({ field, fieldState }) => (
-                                                    <FormItem>
-                                                        <FormLabel>New PIN</FormLabel>
-                                                        <FormControl>
-                                                            <PinInput
-                                                                value={field.value}
-                                                                onChange={field.onChange}
-                                                                placeholder="Enter new PIN"
-                                                                error={fieldState.error?.message}
-                                                                disabled={isChangingPin || pinLockout.isLocked}
-                                                            />
-                                                        </FormControl>
-                                                        <FormDescription>
-                                                            PIN must be 4-6 digits
-                                                        </FormDescription>
-                                                    </FormItem>
-                                                )}
-                                            />
-
-                                            <FormField
-                                                control={changePinForm.control}
-                                                name="confirmNewPin"
-                                                render={({ field, fieldState }) => (
-                                                    <FormItem>
-                                                        <FormLabel>Confirm New PIN</FormLabel>
-                                                        <FormControl>
-                                                            <PinInput
-                                                                value={field.value}
-                                                                onChange={field.onChange}
-                                                                placeholder="Confirm new PIN"
-                                                                error={fieldState.error?.message}
-                                                                disabled={isChangingPin || pinLockout.isLocked}
-                                                            />
-                                                        </FormControl>
-                                                    </FormItem>
-                                                )}
-                                            />
-                                        </CardContent>
-
-                                        <CardFooter>
-                                            <Button
-                                                type="submit"
-                                                className="w-full"
-                                                disabled={isChangingPin || pinLockout.isLocked}
+                                        />
+                                    }
+                                    onClick={() => setShowPinForm((open) => !open)}
+                                />
+                                {showPinForm && (
+                                    <div className="px-4 pb-4 pt-3">
+                                        <Form {...changePinForm}>
+                                            <form
+                                                onSubmit={changePinForm.handleSubmit(onChangePinSubmit)}
+                                                className="space-y-4"
                                             >
-                                                <Shield className="mr-2 h-4 w-4" />
-                                                {isChangingPin ? "Changing PIN..." : "Change PIN"}
-                                            </Button>
-                                        </CardFooter>
-                                    </form>
-                                </Form>
-                            </Card>
+                                                {pinLockout.isLocked && (
+                                                    <div className="rounded-md bg-destructive/15 p-3 text-sm text-destructive">
+                                                        Too many failed attempts. Please wait {formatLockoutTime(pinLockout.remainingMs)}.
+                                                    </div>
+                                                )}
+                                                {!pinLockout.isLocked && hasFailedAttempts() && attemptsLeft > 0 && (
+                                                    <div className="rounded-md bg-yellow-500/15 p-3 text-sm text-yellow-400">
+                                                        {attemptsLeft} attempt{attemptsLeft === 1 ? '' : 's'} remaining before lockout.
+                                                    </div>
+                                                )}
+                                                {changePinError && !pinLockout.isLocked && (
+                                                    <div className="rounded-md bg-destructive/15 p-3 text-sm text-destructive">
+                                                        {changePinError}
+                                                    </div>
+                                                )}
+                                                {changePinSuccess && (
+                                                    <div className="rounded-md bg-success/15 p-3 text-sm text-success">
+                                                        PIN changed successfully! Your wallet PIN has been updated.
+                                                    </div>
+                                                )}
+
+                                                <FormField
+                                                    control={changePinForm.control}
+                                                    name="currentPin"
+                                                    render={({ field, fieldState }) => (
+                                                        <FormItem>
+                                                            <FormLabel>Current PIN</FormLabel>
+                                                            <FormControl>
+                                                                <PinInput
+                                                                    value={field.value}
+                                                                    onChange={field.onChange}
+                                                                    placeholder="Enter current PIN"
+                                                                    error={fieldState.error?.message}
+                                                                    disabled={isChangingPin || pinLockout.isLocked}
+                                                                />
+                                                            </FormControl>
+                                                        </FormItem>
+                                                    )}
+                                                />
+
+                                                <FormField
+                                                    control={changePinForm.control}
+                                                    name="newPin"
+                                                    render={({ field, fieldState }) => (
+                                                        <FormItem>
+                                                            <FormLabel>New PIN</FormLabel>
+                                                            <FormControl>
+                                                                <PinInput
+                                                                    value={field.value}
+                                                                    onChange={field.onChange}
+                                                                    placeholder="Enter new PIN"
+                                                                    error={fieldState.error?.message}
+                                                                    disabled={isChangingPin || pinLockout.isLocked}
+                                                                />
+                                                            </FormControl>
+                                                            <FormDescription>
+                                                                PIN must be 4-6 digits
+                                                            </FormDescription>
+                                                        </FormItem>
+                                                    )}
+                                                />
+
+                                                <FormField
+                                                    control={changePinForm.control}
+                                                    name="confirmNewPin"
+                                                    render={({ field, fieldState }) => (
+                                                        <FormItem>
+                                                            <FormLabel>Confirm New PIN</FormLabel>
+                                                            <FormControl>
+                                                                <PinInput
+                                                                    value={field.value}
+                                                                    onChange={field.onChange}
+                                                                    placeholder="Confirm new PIN"
+                                                                    error={fieldState.error?.message}
+                                                                    disabled={isChangingPin || pinLockout.isLocked}
+                                                                />
+                                                            </FormControl>
+                                                        </FormItem>
+                                                    )}
+                                                />
+
+                                                <Button
+                                                    type="submit"
+                                                    className="w-full"
+                                                    disabled={isChangingPin || pinLockout.isLocked}
+                                                >
+                                                    <Shield className="mr-2 h-4 w-4" />
+                                                    {isChangingPin ? "Changing PIN..." : "Change PIN"}
+                                                </Button>
+                                            </form>
+                                        </Form>
+                                    </div>
+                                )}
+                            </SettingsSection>
                         )}
 
                         <NetworkSettings />
 
-                        <Card className="border-l-4 border-l-primary">
-                            <button
-                                type="button"
-                                className="w-full text-left cursor-pointer"
-                                onClick={() => navigate(ROUTES.ADDRESS_BOOK)}
-                            >
-                                <CardHeader>
-                                    <div className="flex items-center justify-between gap-2">
-                                        <div className="flex items-center gap-3">
-                                            <BookUser className="h-6 w-6 text-secondary" />
-                                            <div>
-                                                <CardTitle className="text-2xl font-bold">Address Book</CardTitle>
-                                                <CardDescription>
-                                                    Manage saved recipients for quick transfers
-                                                </CardDescription>
-                                            </div>
-                                        </div>
-                                        <ChevronRight className="h-5 w-5 text-muted-foreground" />
-                                    </div>
-                                </CardHeader>
-                            </button>
-                        </Card>
-
-                        <Card >
-                            <CardHeader>
-                                <CardTitle className="text-2xl font-bold">Wallet Preferences</CardTitle>
-                                <CardDescription>
-                                    Customize your wallet experience and security settings
-                                </CardDescription>
-                            </CardHeader>
-
-                            <Form {...form}>
-                                <form onSubmit={form.handleSubmit(onSubmit)}>
-                                    <CardContent className="space-y-8">
-                                        {settingsSaveSuccess && (
-                                            <div role="status" className="rounded-md bg-success/15 p-3 text-sm text-success">
-                                                Settings saved successfully! Your wallet settings have been updated.
-                                            </div>
-                                        )}
-                                        {settingsSaveError && (
-                                            <div role="alert" className="rounded-md bg-destructive/15 p-3 text-sm text-destructive">
-                                                {settingsSaveError}
-                                            </div>
-                                        )}
-                                        <FormField
-                                            control={form.control}
-                                            name="autoLockTimeout"
-                                            render={({ field }) => (
-                                                <FormItem>
-                                                    <FormLabel>Auto-lock Timer (minutes)</FormLabel>
-                                                    <FormControl>
-                                                        <Input
-                                                            type="number"
-                                                            min={1}
-                                                            max={60}
-                                                            {...field}
-                                                            value={field.value ?? 15}
-                                                            onChange={(e) => field.onChange(Number(e.target.value))}
-                                                        />
-                                                    </FormControl>
-                                                    <FormDescription>
-                                                        Automatically lock your wallet after specified minutes of inactivity
-                                                    </FormDescription>
-                                                    <FormMessage />
-                                                </FormItem>
-                                            )}
-                                        />
-
-                                        <Separator />
-
-                                        <FormField
-                                            control={form.control}
-                                            name="showTokensCard"
-                                            render={({ field }) => (
-                                                <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
-                                                    <div className="space-y-0.5">
-                                                        <FormLabel>Show Tokens Card</FormLabel>
-                                                        <FormDescription>
-                                                            Display the Tokens section on the Home page
-                                                        </FormDescription>
-                                                    </div>
-                                                    <FormControl>
-                                                        <Switch
-                                                            checked={field.value ?? true}
-                                                            onCheckedChange={field.onChange}
-                                                        />
-                                                    </FormControl>
-                                                </FormItem>
-                                            )}
-                                        />
-
-                                        <FormField
-                                            control={form.control}
-                                            name="showNftsCard"
-                                            render={({ field }) => (
-                                                <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
-                                                    <div className="space-y-0.5">
-                                                        <FormLabel>Show NFTs Card</FormLabel>
-                                                        <FormDescription>
-                                                            Display the NFT collection section on the Home page
-                                                        </FormDescription>
-                                                    </div>
-                                                    <FormControl>
-                                                        <Switch
-                                                            checked={field.value ?? true}
-                                                            onCheckedChange={field.onChange}
-                                                        />
-                                                    </FormControl>
-                                                </FormItem>
-                                            )}
-                                        />
-                                    </CardContent>
-
-                                    <CardFooter>
-                                        <Button
-                                            type="submit"
-                                            className="w-full"
-                                            disabled={isSubmitting}
+                        <Form {...form}>
+                            <SettingsSection
+                                title="Preferences"
+                                action={
+                                    settingsSaveSuccess ? (
+                                        <span
+                                            role="status"
+                                            className="flex items-center gap-1 text-xs text-success"
                                         >
-                                            <Save className="mr-2 h-4 w-4" />
-                                            Save Settings
-                                        </Button>
-                                    </CardFooter>
-                                </form>
-                            </Form>
-                        </Card>
+                                            <Check className="h-3 w-3" />
+                                            Saved
+                                        </span>
+                                    ) : undefined
+                                }
+                            >
+                                {settingsSaveError && (
+                                    <div role="alert" className="bg-destructive/10 px-4 py-2 text-xs text-destructive">
+                                        {settingsSaveError}
+                                    </div>
+                                )}
+
+                                <FormField
+                                    control={form.control}
+                                    name="autoLockTimeout"
+                                    render={({ field }) => (
+                                        <FormItem className="space-y-0">
+                                            <div className="flex items-center gap-3 px-4 py-3">
+                                                <SettingsIconTile
+                                                    icon={TimerReset}
+                                                    tint="bg-violet-500/15 text-violet-400"
+                                                />
+                                                <div className="min-w-0 flex-1">
+                                                    <FormLabel className="text-sm font-medium">
+                                                        Auto-lock Timer
+                                                    </FormLabel>
+                                                    <FormDescription className="mt-0.5 text-xs">
+                                                        Lock the wallet after this many minutes of inactivity
+                                                    </FormDescription>
+                                                </div>
+                                                <FormControl>
+                                                    <Input
+                                                        type="number"
+                                                        min={1}
+                                                        max={60}
+                                                        className="h-9 w-20 shrink-0 text-center"
+                                                        {...field}
+                                                        value={field.value ?? 15}
+                                                        onChange={(e) => {
+                                                            field.onChange(Number(e.target.value));
+                                                            queueSave(800);
+                                                        }}
+                                                    />
+                                                </FormControl>
+                                            </div>
+                                            <FormMessage className="px-4 pb-3 text-xs" />
+                                        </FormItem>
+                                    )}
+                                />
+
+                                <FormField
+                                    control={form.control}
+                                    name="showTokensCard"
+                                    render={({ field }) => (
+                                        <FormItem className="flex flex-row items-center gap-3 space-y-0 px-4 py-3">
+                                            <SettingsIconTile
+                                                icon={Coins}
+                                                tint="bg-sky-500/15 text-sky-400"
+                                            />
+                                            <div className="min-w-0 flex-1">
+                                                <FormLabel className="text-sm font-medium">
+                                                    Show Tokens Card
+                                                </FormLabel>
+                                                <FormDescription className="mt-0.5 text-xs">
+                                                    Display the Tokens section on the Home page
+                                                </FormDescription>
+                                            </div>
+                                            <FormControl>
+                                                <Switch
+                                                    checked={field.value ?? true}
+                                                    onCheckedChange={(checked) => {
+                                                        field.onChange(checked);
+                                                        queueSave(200);
+                                                    }}
+                                                />
+                                            </FormControl>
+                                        </FormItem>
+                                    )}
+                                />
+
+                                <FormField
+                                    control={form.control}
+                                    name="showNftsCard"
+                                    render={({ field }) => (
+                                        <FormItem className="flex flex-row items-center gap-3 space-y-0 px-4 py-3">
+                                            <SettingsIconTile
+                                                icon={Images}
+                                                tint="bg-fuchsia-500/15 text-fuchsia-400"
+                                            />
+                                            <div className="min-w-0 flex-1">
+                                                <FormLabel className="text-sm font-medium">
+                                                    Show NFTs Card
+                                                </FormLabel>
+                                                <FormDescription className="mt-0.5 text-xs">
+                                                    Display the NFT collection section on the Home page
+                                                </FormDescription>
+                                            </div>
+                                            <FormControl>
+                                                <Switch
+                                                    checked={field.value ?? true}
+                                                    onCheckedChange={(checked) => {
+                                                        field.onChange(checked);
+                                                        queueSave(200);
+                                                    }}
+                                                />
+                                            </FormControl>
+                                        </FormItem>
+                                    )}
+                                />
+                            </SettingsSection>
+                        </Form>
+
+                        <SettingsSection title="Connections">
+                            <SettingsRow
+                                icon={BookUser}
+                                tint="bg-secondary/15 text-secondary"
+                                title="Address Book"
+                                subtitle="Manage saved recipients for quick transfers"
+                                right={<ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />}
+                                onClick={() => navigate(ROUTES.ADDRESS_BOOK)}
+                            />
+                        </SettingsSection>
 
                         {/* dApp session management lives here (the list keeps
                             its own header + actions); the /dapp-sessions route

--- a/src/components/Core/Body/Settings/SettingsList.tsx
+++ b/src/components/Core/Body/Settings/SettingsList.tsx
@@ -1,0 +1,92 @@
+import type { LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
+import { Card } from "../../../UI/Card";
+import { cn } from "../../../../utils";
+
+interface SettingsSectionProps {
+    title: string;
+    action?: ReactNode;
+    children: ReactNode;
+}
+
+/**
+ * Grouped-list section: a small muted label above a card whose direct
+ * children are separated by hairline dividers (mirrors the mobile app's
+ * Section/Row settings layout).
+ */
+export const SettingsSection = ({ title, action, children }: SettingsSectionProps) => (
+    <section>
+        <div className="mb-2 flex items-center justify-between px-1">
+            <h2 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                {title}
+            </h2>
+            {action}
+        </div>
+        <Card className="overflow-hidden">
+            <div className="divide-y divide-border/60">{children}</div>
+        </Card>
+    </section>
+);
+
+export const SettingsIconTile = ({ icon: Icon, tint }: { icon: LucideIcon; tint: string }) => (
+    <span
+        className={cn(
+            "flex h-8 w-8 shrink-0 items-center justify-center rounded-lg",
+            tint,
+        )}
+    >
+        <Icon className="h-4 w-4" />
+    </span>
+);
+
+interface SettingsRowProps {
+    icon: LucideIcon;
+    /** Tailwind classes for the icon tile, e.g. "bg-primary/15 text-primary" */
+    tint: string;
+    title: string;
+    subtitle?: string;
+    /** Right-hand slot: Switch, chevron, value text, ... */
+    right?: ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+}
+
+export const SettingsRow = ({
+    icon,
+    tint,
+    title,
+    subtitle,
+    right,
+    onClick,
+    disabled,
+}: SettingsRowProps) => {
+    const content = (
+        <>
+            <SettingsIconTile icon={icon} tint={tint} />
+            <span className="min-w-0 flex-1">
+                <span className="block text-sm font-medium">{title}</span>
+                {subtitle && (
+                    <span className="mt-0.5 block text-xs text-muted-foreground">
+                        {subtitle}
+                    </span>
+                )}
+            </span>
+            {right}
+        </>
+    );
+
+    if (onClick) {
+        return (
+            <button
+                type="button"
+                onClick={onClick}
+                disabled={disabled}
+                className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-foreground/[0.04] disabled:cursor-not-allowed disabled:opacity-50"
+            >
+                {content}
+            </button>
+        );
+    }
+
+    return <div className="flex w-full items-center gap-3 px-4 py-3">{content}</div>;
+};


### PR DESCRIPTION
## What

Reworks the /settings page from four large stacked cards into a compact, iOS-style grouped list that mirrors the mobile app's settings screen: small muted section labels above cards of hairline-divided rows, each row a tinted icon tile + title/subtitle + right-hand control.

## Sections

- **Security** (web/native with encrypted seeds only): Change PIN is now a single row; clicking it expands the existing PIN form inline. All lockout/attempt-tracking logic is untouched.
- **Network**: Mainnet / Testnet as rows with a checkmark on the active network (was two large buttons).
- **Preferences**: Auto-lock Timer (compact inline number input), Show Tokens Card, Show NFTs Card. These now auto-save on change (debounced: 200ms toggles, 800ms timer input) with a transient "Saved" chip in the section header. The Save Settings button is gone.
- **Connections**: Address Book row (chevron, navigates as before).
- **dApp connections**: card unchanged (DAppSessionsList keeps its own header/actions).

New shared primitives `SettingsSection` / `SettingsRow` / `SettingsIconTile` live in `src/components/Core/Body/Settings/SettingsList.tsx`, used by both Settings.tsx and NetworkSettings.tsx.

## Behavior changes

- Preferences save automatically instead of via a Save button. Invalid auto-lock values (outside 1-60) are rejected by the zod resolver and never written; the field shows an inline error.
- PIN form is collapsed by default behind the Change PIN row.

## Validation

- `npm run lint`: clean (zero warnings policy)
- `npm test`: 244/244 passing
- `npm run build`: tsc + vite build green (pre-existing chunk-size warning only)

https://claude.ai/code/session_01H577F7pk74WPVrLFv5FUU5