### PR TITLE
feat(pin): auto-advance to next PIN row when complete

### DIFF
--- a/src/components/Core/Body/CreateAccount/AccountCreationForm/AccountCreationForm.tsx
+++ b/src/components/Core/Body/CreateAccount/AccountCreationForm/AccountCreationForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { ShinyButton } from "@/components/UI/ShinyButton";
 import {
   Card,
@@ -26,7 +26,7 @@ import { z } from "zod";
 import { encryptSeedAsync, decryptSeedAsync, getMnemonicFromHexSeed, CryptoOperationError, CryptoErrorCode } from "@/utils/crypto";
 import { StorageUtil } from "@/utils/storage";
 import { isInNativeApp, notifySeedStored } from "@/utils/nativeApp";
-import { PinInput } from "@/components/UI/PinInput/PinInput";
+import { PinInput, type PinInputHandle } from "@/components/UI/PinInput/PinInput";
 import { Separator } from "@/components/UI/Separator";
 import { isDesktop, desktopSigner } from "@/desktop/bridge";
 
@@ -119,6 +119,7 @@ const InnerForm = observer(({ onAccountCreated, hasExistingSeeds, existingSeeds,
   const { qrlStore } = useStore();
   const { qrlInstance } = qrlStore;
   const [isEncrypting, setIsEncrypting] = useState(false);
+  const reEnterPinRef = useRef<PinInputHandle>(null);
 
   // Select schema based on whether user has existing seeds. On desktop the
   // password is the only secret (no PIN) so a dedicated schema is used.
@@ -321,6 +322,7 @@ const InnerForm = observer(({ onAccountCreated, hasExistingSeeds, existingSeeds,
                       disabled={isSubmitting}
                       description={hasExistingSeeds ? "(All wallets use the same PIN)" : "Enter a 4-6 digit PIN"}
                       error={errors.pin?.message}
+                      onComplete={() => reEnterPinRef.current?.focus()}
                     />
                   )}
                 />
@@ -330,6 +332,7 @@ const InnerForm = observer(({ onAccountCreated, hasExistingSeeds, existingSeeds,
                     name="reEnteredPin"
                     render={({ field }) => (
                       <PinInput
+                        ref={reEnterPinRef}
                         length={6}
                         placeholder="Re-enter PIN"
                         value={field.value}

--- a/src/components/Core/Body/PinSetup/PinSetup.tsx
+++ b/src/components/Core/Body/PinSetup/PinSetup.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import {
   Card,
   CardContent,
@@ -16,7 +16,7 @@ import {
   FormMessage,
 } from "../../../UI/Form";
 import { Input } from "../../../UI/Input";
-import { PinInput } from "../../../UI/PinInput/PinInput";
+import { PinInput, type PinInputHandle } from "../../../UI/PinInput/PinInput";
 import { ShinyButton } from "../../../UI/ShinyButton";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Loader } from "lucide-react";
@@ -231,6 +231,7 @@ const WebPinSetup = ({
   const { qrlConnection } = qrlStore;
   const { blockchain } = qrlConnection;
   const [isStoringPin, setIsStoringPin] = useState(false);
+  const reEnterPinRef = useRef<PinInputHandle>(null);
   const [hasExistingSeeds, setHasExistingSeeds] = useState<boolean | null>(null);
   const [existingSeeds, setExistingSeeds] = useState<{ address: string; encryptedSeed: string }[]>([]);
 
@@ -358,6 +359,7 @@ const WebPinSetup = ({
                       disabled={isSubmitting || isStoringPin}
                       description={hasExistingSeeds ? "Your existing wallet PIN" : "Enter a 4-6 digit PIN"}
                       error={form.formState.errors.pin?.message}
+                      onComplete={() => reEnterPinRef.current?.focus()}
                     />
                   )}
                 />
@@ -367,6 +369,7 @@ const WebPinSetup = ({
                     name="reEnteredPin"
                     render={({ field }) => (
                       <PinInput
+                        ref={reEnterPinRef}
                         length={6}
                         placeholder="Re-enter PIN"
                         value={field.value ?? ""}

--- a/src/components/Core/Body/Settings/Settings.tsx
+++ b/src/components/Core/Body/Settings/Settings.tsx
@@ -32,7 +32,7 @@ import {
 import { useNavigate } from "react-router-dom";
 import { ROUTES } from "@/router/router";
 import { SEO } from "@/components/SEO/SEO";
-import { PinInput } from "@/components/UI/PinInput/PinInput";
+import { PinInput, type PinInputHandle } from "@/components/UI/PinInput/PinInput";
 import { decryptSeedAsync, reEncryptSeedAsync } from "@/utils/crypto";
 import { isInNativeApp, sendPinChanged } from "@/utils/nativeApp";
 import { isDesktop } from "@/desktop/bridge";
@@ -88,6 +88,8 @@ const Settings = observer(() => {
     const [attemptsLeft, setAttemptsLeft] = useState(5);
     const [settingsSaveSuccess, setSettingsSaveSuccess] = useState(false);
     const [settingsSaveError, setSettingsSaveError] = useState<string | null>(null);
+    const newPinRef = useRef<PinInputHandle>(null);
+    const confirmPinRef = useRef<PinInputHandle>(null);
 
     // Check for existing encrypted seeds on mount
     useEffect(() => {
@@ -332,6 +334,7 @@ const Settings = observer(() => {
                                                                     placeholder="Enter current PIN"
                                                                     error={fieldState.error?.message}
                                                                     disabled={isChangingPin || pinLockout.isLocked}
+                                                                    onComplete={() => newPinRef.current?.focus()}
                                                                 />
                                                             </FormControl>
                                                         </FormItem>
@@ -346,11 +349,13 @@ const Settings = observer(() => {
                                                             <FormLabel>New PIN</FormLabel>
                                                             <FormControl>
                                                                 <PinInput
+                                                                    ref={newPinRef}
                                                                     value={field.value}
                                                                     onChange={field.onChange}
                                                                     placeholder="Enter new PIN"
                                                                     error={fieldState.error?.message}
                                                                     disabled={isChangingPin || pinLockout.isLocked}
+                                                                    onComplete={() => confirmPinRef.current?.focus()}
                                                                 />
                                                             </FormControl>
                                                             <FormDescription>
@@ -368,6 +373,7 @@ const Settings = observer(() => {
                                                             <FormLabel>Confirm New PIN</FormLabel>
                                                             <FormControl>
                                                                 <PinInput
+                                                                    ref={confirmPinRef}
                                                                     value={field.value}
                                                                     onChange={field.onChange}
                                                                     placeholder="Confirm new PIN"

--- a/src/components/UI/PinInput/PinInput.tsx
+++ b/src/components/UI/PinInput/PinInput.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from "react";
+import React, { useRef, useEffect, forwardRef, useImperativeHandle } from "react";
 import { cn } from "@/utils/cn";
 
 interface PinInputProps {
@@ -11,6 +11,14 @@ interface PinInputProps {
   description?: string;
   error?: string;
   autoFocus?: boolean;
+  /** Fires once when entry fills all `length` cells (typing or paste), so
+   * stacked PIN forms can move focus to the next row. */
+  onComplete?: (pin: string) => void;
+}
+
+export interface PinInputHandle {
+  /** Focus the first empty cell (or the last cell when already full). */
+  focus: () => void;
 }
 
 /**
@@ -19,7 +27,7 @@ interface PinInputProps {
  * (`value`/`onChange`) so every call site stays untouched; only the
  * presentation changed from one input to `length` cells.
  */
-export const PinInput = ({
+export const PinInput = forwardRef<PinInputHandle, PinInputProps>(({
   length = 6,
   onChange,
   value = "",
@@ -30,7 +38,8 @@ export const PinInput = ({
   description,
   error,
   autoFocus = false,
-}: PinInputProps) => {
+  onComplete,
+}, ref) => {
   const refs = useRef<Array<HTMLInputElement | null>>([]);
   // Marks a focus move as programmatic (auto-advance / backspace / arrows /
   // paste) so the cell's onFocus does not bounce it back. focus() fires the
@@ -44,6 +53,10 @@ export const PinInput = ({
     refs.current[idx]?.focus();
   };
 
+  useImperativeHandle(ref, () => ({
+    focus: () => focusCell(Math.min(value.length, length - 1)),
+  }));
+
   useEffect(() => {
     if (autoFocus) {
       advancingRef.current = true;
@@ -51,10 +64,12 @@ export const PinInput = ({
     }
   }, [autoFocus]);
 
-  const setAt = (i: number, ch: string) => {
+  const setAt = (i: number, ch: string): string => {
     const next = value.split("");
     next[i] = ch;
-    onChange(next.join("").replace(/\D/g, "").slice(0, length));
+    const joined = next.join("").replace(/\D/g, "").slice(0, length);
+    onChange(joined);
+    return joined;
   };
 
   const handleChange =
@@ -64,8 +79,9 @@ export const PinInput = ({
       // current cell isn't cleared.
       if (ch && !/\d/.test(ch)) return;
       if (!ch && !chars[i]) return;
-      setAt(i, ch);
+      const next = setAt(i, ch);
       if (ch && i < length - 1) focusCell(i + 1);
+      if (next.length === length && value.length < length) onComplete?.(next);
     };
 
   const handleKeyDown =
@@ -98,6 +114,9 @@ export const PinInput = ({
       const joined = next.join("").replace(/\D/g, "").slice(0, length);
       onChange(joined);
       focusCell(Math.min(i + digits.length, length - 1));
+      // After the in-row focus move, so a listener that refocuses another
+      // row wins.
+      if (joined.length === length && value.length < length) onComplete?.(joined);
     };
 
   return (
@@ -151,6 +170,8 @@ export const PinInput = ({
       )}
     </div>
   );
-};
+});
+
+PinInput.displayName = "PinInput";
 
 export default PinInput;


### PR DESCRIPTION
Filling all six cells of a PIN row (typing or paste) now moves focus to the next row automatically.

- `PinInput` gains an optional `onComplete(pin)` callback, fired exactly on the transition to a full row, plus a `forwardRef` handle exposing `focus()` (targets the first empty cell). The existing `value`/`onChange` string API is unchanged, so untouched call sites behave exactly as before.
- Wired in the three stacked-row forms: PinSetup (import-account, the screenshot case), AccountCreationForm (create account), and the Settings Change PIN form (current -> new -> confirm chain).

Validation: lint clean, 244/244 tests, tsc + vite build green.

https://claude.ai/code/session_01H577F7pk74WPVrLFv5FUU5