### PR TITLE
fix(settings): harden auto-save and row a11y per adversarial review

### DIFF
--- a/src/components/Core/Body/Settings/Settings.tsx
+++ b/src/components/Core/Body/Settings/Settings.tsx
@@ -15,7 +15,7 @@ import { observer } from "mobx-react-lite";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
-import { useState, useEffect, useRef, lazy } from "react";
+import { useState, useEffect, useRef, useCallback, lazy } from "react";
 import { NetworkSettings } from "./NetworkSettings/NetworkSettings";
 import type { EncryptedSeedData } from "@/utils/storage";
 import { StorageUtil } from "@/utils/storage";
@@ -123,19 +123,27 @@ const Settings = observer(() => {
         return () => clearInterval(interval);
     }, []);
 
+    // Last persisted auto-lock value: the fallback when a save must proceed
+    // while the timer field holds an invalid/in-progress edit.
+    const lastSavedTimerRef = useRef(15);
+
     const form = useForm<SettingsFormValues>({
         resolver: zodResolver(SettingsFormSchema),
+        // Never yank focus into the timer input from a background save.
+        shouldFocusError: false,
         defaultValues: async () => {
             const settings = await StorageUtil.getWalletSettings();
+            const minutes = settings.autoLockTimeout ? Math.floor(settings.autoLockTimeout / (60 * 1000)) : 15;
+            lastSavedTimerRef.current = minutes;
             return {
-                autoLockTimeout: settings.autoLockTimeout ? Math.floor(settings.autoLockTimeout / (60 * 1000)) : 15,
+                autoLockTimeout: minutes,
                 showTokensCard: settings.showTokensCard ?? true,
                 showNftsCard: settings.showNftsCard ?? true,
             };
         },
     });
 
-    async function onSubmit(data: SettingsFormValues) {
+    const onSubmit = useCallback(async (data: SettingsFormValues) => {
         setSettingsSaveSuccess(false);
         setSettingsSaveError(null);
         try {
@@ -145,32 +153,57 @@ const Settings = observer(() => {
                 autoLockTimeout: data.autoLockTimeout * 60 * 1000
             };
             await StorageUtil.setWalletSettings(settingsToSave);
+            lastSavedTimerRef.current = data.autoLockTimeout;
             setSettingsSaveSuccess(true);
         } catch (_error) {
             setSettingsSaveError("There was an error saving your settings.");
         }
-    }
+    }, []);
 
     // Preferences auto-save on change (debounced so rapid toggles and
-    // keystrokes in the timer input collapse into one write). Invalid
-    // values never reach onSubmit: handleSubmit runs the zod resolver.
+    // keystrokes in the timer input collapse into one write).
     const saveTimer = useRef<number | null>(null);
-    const queueSave = (delayMs: number) => {
+
+    // sanitizeTimer: a save triggered by something other than the timer field
+    // itself (switch toggle, blur, unmount) must not be blocked by a
+    // half-typed timer value; substitute the last persisted one instead.
+    // Timer-keystroke saves pass false so we never rewrite the field while
+    // the user is still typing; the invalid value just surfaces its message
+    // and no write happens until it is fixed or blurred.
+    const flushSave = useCallback((sanitizeTimer: boolean) => {
+        const timer = form.getValues("autoLockTimeout");
+        const invalid = !Number.isFinite(timer) || timer < 1 || timer > 60;
+        if (invalid && !sanitizeTimer) {
+            void form.trigger("autoLockTimeout");
+            return;
+        }
+        if (invalid) {
+            form.setValue("autoLockTimeout", lastSavedTimerRef.current, { shouldValidate: true });
+        }
+        void form.handleSubmit(onSubmit)();
+    }, [form, onSubmit]);
+
+    const queueSave = (delayMs: number, sanitizeTimer = false) => {
         if (saveTimer.current !== null) {
             window.clearTimeout(saveTimer.current);
         }
         saveTimer.current = window.setTimeout(() => {
-            void form.handleSubmit(onSubmit)();
+            saveTimer.current = null;
+            flushSave(sanitizeTimer);
         }, delayMs);
     };
 
+    // Flush (not discard) a pending save on unmount, so a toggle followed by
+    // an immediate navigation still persists.
     useEffect(() => {
         return () => {
             if (saveTimer.current !== null) {
                 window.clearTimeout(saveTimer.current);
+                saveTimer.current = null;
+                flushSave(true);
             }
         };
-    }, []);
+    }, [flushSave]);
 
     // Transient "Saved" chip in the Preferences section header
     useEffect(() => {
@@ -284,17 +317,32 @@ const Settings = observer(() => {
                                     title="Change PIN"
                                     subtitle="Change your wallet PIN used to encrypt your seeds"
                                     right={
-                                        <ChevronDown
-                                            className={cn(
-                                                "h-4 w-4 shrink-0 text-muted-foreground transition-transform",
-                                                showPinForm && "rotate-180",
-                                            )}
-                                        />
+                                        <>
+                                            {/* Lockout state must be visible without expanding
+                                                the panel. */}
+                                            {pinLockout.isLocked ? (
+                                                <span className="text-xs font-medium text-destructive">Locked</span>
+                                            ) : hasFailedAttempts() && attemptsLeft < 5 ? (
+                                                <span className="text-xs text-yellow-400">
+                                                    {attemptsLeft} attempt{attemptsLeft === 1 ? '' : 's'} left
+                                                </span>
+                                            ) : null}
+                                            <ChevronDown
+                                                className={cn(
+                                                    "h-4 w-4 shrink-0 text-muted-foreground transition-transform",
+                                                    showPinForm && "rotate-180",
+                                                )}
+                                            />
+                                        </>
                                     }
                                     onClick={() => setShowPinForm((open) => !open)}
+                                    // Collapsing mid-change would hide the outcome banner.
+                                    disabled={isChangingPin}
+                                    ariaExpanded={showPinForm}
+                                    ariaControls="change-pin-panel"
                                 />
                                 {showPinForm && (
-                                    <div className="px-4 pb-4 pt-3">
+                                    <div id="change-pin-panel" className="px-4 pb-4 pt-3">
                                         <Form {...changePinForm}>
                                             <form
                                                 onSubmit={changePinForm.handleSubmit(onChangePinSubmit)}
@@ -448,10 +496,22 @@ const Settings = observer(() => {
                                                         max={60}
                                                         className="h-9 w-20 shrink-0 text-center"
                                                         {...field}
-                                                        value={field.value ?? 15}
+                                                        value={Number.isFinite(field.value) ? field.value : ""}
                                                         onChange={(e) => {
-                                                            field.onChange(Number(e.target.value));
+                                                            // Empty stays empty while typing (NaN fails
+                                                            // validation, so nothing is written).
+                                                            field.onChange(e.target.value === "" ? Number.NaN : Number(e.target.value));
                                                             queueSave(800);
+                                                        }}
+                                                        onBlur={() => {
+                                                            field.onBlur();
+                                                            const t = form.getValues("autoLockTimeout");
+                                                            const invalid = !Number.isFinite(t) || t < 1 || t > 60;
+                                                            // Flush a pending save early; leaving the field
+                                                            // invalid reverts it to the last saved value.
+                                                            if (invalid || saveTimer.current !== null) {
+                                                                queueSave(0, true);
+                                                            }
                                                         }}
                                                     />
                                                 </FormControl>
@@ -483,7 +543,7 @@ const Settings = observer(() => {
                                                     checked={field.value ?? true}
                                                     onCheckedChange={(checked) => {
                                                         field.onChange(checked);
-                                                        queueSave(200);
+                                                        queueSave(200, true);
                                                     }}
                                                 />
                                             </FormControl>
@@ -513,7 +573,7 @@ const Settings = observer(() => {
                                                     checked={field.value ?? true}
                                                     onCheckedChange={(checked) => {
                                                         field.onChange(checked);
-                                                        queueSave(200);
+                                                        queueSave(200, true);
                                                     }}
                                                 />
                                             </FormControl>

--- a/src/components/Core/Body/Settings/SettingsList.tsx
+++ b/src/components/Core/Body/Settings/SettingsList.tsx
@@ -49,6 +49,10 @@ interface SettingsRowProps {
     right?: ReactNode;
     onClick?: () => void;
     disabled?: boolean;
+    /** For disclosure rows: reflected as aria-expanded on the button. */
+    ariaExpanded?: boolean;
+    /** id of the element a disclosure row controls. */
+    ariaControls?: string;
 }
 
 export const SettingsRow = ({
@@ -59,6 +63,8 @@ export const SettingsRow = ({
     right,
     onClick,
     disabled,
+    ariaExpanded,
+    ariaControls,
 }: SettingsRowProps) => {
     const content = (
         <>
@@ -81,7 +87,11 @@ export const SettingsRow = ({
                 type="button"
                 onClick={onClick}
                 disabled={disabled}
-                className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-foreground/[0.04] disabled:cursor-not-allowed disabled:opacity-50"
+                aria-expanded={ariaExpanded}
+                aria-controls={ariaControls}
+                // Inset ring: the section card is overflow-hidden, so an
+                // outline drawn outside the border box gets clipped away.
+                className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-foreground/[0.04] focus-visible:outline-none focus-visible:bg-foreground/[0.04] focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-50"
             >
                 {content}
             </button>

--- a/src/components/UI/PinInput/PinInput.tsx
+++ b/src/components/UI/PinInput/PinInput.tsx
@@ -49,8 +49,13 @@ export const PinInput = forwardRef<PinInputHandle, PinInputProps>(({
   const chars = value.split("").slice(0, length);
 
   const focusCell = (idx: number) => {
+    const el = refs.current[idx];
+    // No-op when the cell doesn't exist or is already focused: focus() would
+    // fire no focus event, leaving advancingRef stuck true and letting the
+    // next click bypass the sequential-cell redirect.
+    if (!el || el === document.activeElement) return;
     advancingRef.current = true;
-    refs.current[idx]?.focus();
+    el.focus();
   };
 
   useImperativeHandle(ref, () => ({


### PR DESCRIPTION
Fixes for everything that survived a 3-lens adversarial review (React/state correctness, UX/a11y regression, security) of #251 and #253. No high-severity findings; change-PIN crypto and lockout logic verified byte-identical through the restructure.

- Pending debounced save is now flushed on unmount instead of discarded (toggle then navigate no longer loses the change).
- Whole-form validation no longer blocks switch saves while the auto-lock field holds a half-typed value: non-timer-originated saves substitute the last persisted timer value; `shouldFocusError: false` stops background saves from yanking focus into the number input.
- Auto-lock input can be empty while typing; blur reverts an invalid value to the last saved one and flushes any pending save early.
- SettingsRow buttons: inset `focus-visible` ring (the UA outline was clipped by the card's `overflow-hidden`, leaving keyboard focus invisible).
- Change PIN disclosure row: `aria-expanded`/`aria-controls`, disabled while re-encryption is in flight, and a Locked / attempts-left badge in the row so lockout state is visible without expanding.
- PinInput `focusCell` guards against missing/already-focused cells so `advancingRef` cannot stick true (pre-existing edge, adjacent to #253).

Validation: lint clean, 244/244 tests, tsc + vite build green.

https://claude.ai/code/session_01H577F7pk74WPVrLFv5FUU5