### PR TITLE
release: PIN auto-advance + settings review hardening

### DIFF
--- a/src/components/Core/Body/CreateAccount/AccountCreationForm/AccountCreationForm.tsx
+++ b/src/components/Core/Body/CreateAccount/AccountCreationForm/AccountCreationForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { ShinyButton } from "@/components/UI/ShinyButton";
 import {
   Card,
@@ -26,7 +26,7 @@ import { z } from "zod";
 import { encryptSeedAsync, decryptSeedAsync, getMnemonicFromHexSeed, CryptoOperationError, CryptoErrorCode } from "@/utils/crypto";
 import { StorageUtil } from "@/utils/storage";
 import { isInNativeApp, notifySeedStored } from "@/utils/nativeApp";
-import { PinInput } from "@/components/UI/PinInput/PinInput";
+import { PinInput, type PinInputHandle } from "@/components/UI/PinInput/PinInput";
 import { Separator } from "@/components/UI/Separator";
 import { isDesktop, desktopSigner } from "@/desktop/bridge";
 
@@ -119,6 +119,7 @@ const InnerForm = observer(({ onAccountCreated, hasExistingSeeds, existingSeeds,
   const { qrlStore } = useStore();
   const { qrlInstance } = qrlStore;
   const [isEncrypting, setIsEncrypting] = useState(false);
+  const reEnterPinRef = useRef<PinInputHandle>(null);
 
   // Select schema based on whether user has existing seeds. On desktop the
   // password is the only secret (no PIN) so a dedicated schema is used.
@@ -321,6 +322,7 @@ const InnerForm = observer(({ onAccountCreated, hasExistingSeeds, existingSeeds,
                       disabled={isSubmitting}
                       description={hasExistingSeeds ? "(All wallets use the same PIN)" : "Enter a 4-6 digit PIN"}
                       error={errors.pin?.message}
+                      onComplete={() => reEnterPinRef.current?.focus()}
                     />
                   )}
                 />
@@ -330,6 +332,7 @@ const InnerForm = observer(({ onAccountCreated, hasExistingSeeds, existingSeeds,
                     name="reEnteredPin"
                     render={({ field }) => (
                       <PinInput
+                        ref={reEnterPinRef}
                         length={6}
                         placeholder="Re-enter PIN"
                         value={field.value}

--- a/src/components/Core/Body/PinSetup/PinSetup.tsx
+++ b/src/components/Core/Body/PinSetup/PinSetup.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import {
   Card,
   CardContent,
@@ -16,7 +16,7 @@ import {
   FormMessage,
 } from "../../../UI/Form";
 import { Input } from "../../../UI/Input";
-import { PinInput } from "../../../UI/PinInput/PinInput";
+import { PinInput, type PinInputHandle } from "../../../UI/PinInput/PinInput";
 import { ShinyButton } from "../../../UI/ShinyButton";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Loader } from "lucide-react";
@@ -231,6 +231,7 @@ const WebPinSetup = ({
   const { qrlConnection } = qrlStore;
   const { blockchain } = qrlConnection;
   const [isStoringPin, setIsStoringPin] = useState(false);
+  const reEnterPinRef = useRef<PinInputHandle>(null);
   const [hasExistingSeeds, setHasExistingSeeds] = useState<boolean | null>(null);
   const [existingSeeds, setExistingSeeds] = useState<{ address: string; encryptedSeed: string }[]>([]);
 
@@ -358,6 +359,7 @@ const WebPinSetup = ({
                       disabled={isSubmitting || isStoringPin}
                       description={hasExistingSeeds ? "Your existing wallet PIN" : "Enter a 4-6 digit PIN"}
                       error={form.formState.errors.pin?.message}
+                      onComplete={() => reEnterPinRef.current?.focus()}
                     />
                   )}
                 />
@@ -367,6 +369,7 @@ const WebPinSetup = ({
                     name="reEnteredPin"
                     render={({ field }) => (
                       <PinInput
+                        ref={reEnterPinRef}
                         length={6}
                         placeholder="Re-enter PIN"
                         value={field.value ?? ""}

--- a/src/components/Core/Body/Settings/Settings.tsx
+++ b/src/components/Core/Body/Settings/Settings.tsx
@@ -15,7 +15,7 @@ import { observer } from "mobx-react-lite";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
-import { useState, useEffect, useRef, lazy } from "react";
+import { useState, useEffect, useRef, useCallback, lazy } from "react";
 import { NetworkSettings } from "./NetworkSettings/NetworkSettings";
 import type { EncryptedSeedData } from "@/utils/storage";
 import { StorageUtil } from "@/utils/storage";
@@ -123,19 +123,27 @@ const Settings = observer(() => {
         return () => clearInterval(interval);
     }, []);
 
+    // Last persisted auto-lock value: the fallback when a save must proceed
+    // while the timer field holds an invalid/in-progress edit.
+    const lastSavedTimerRef = useRef(15);
+
     const form = useForm<SettingsFormValues>({
         resolver: zodResolver(SettingsFormSchema),
+        // Never yank focus into the timer input from a background save.
+        shouldFocusError: false,
         defaultValues: async () => {
             const settings = await StorageUtil.getWalletSettings();
+            const minutes = settings.autoLockTimeout ? Math.floor(settings.autoLockTimeout / (60 * 1000)) : 15;
+            lastSavedTimerRef.current = minutes;
             return {
-                autoLockTimeout: settings.autoLockTimeout ? Math.floor(settings.autoLockTimeout / (60 * 1000)) : 15,
+                autoLockTimeout: minutes,
                 showTokensCard: settings.showTokensCard ?? true,
                 showNftsCard: settings.showNftsCard ?? true,
             };
         },
     });
 
-    async function onSubmit(data: SettingsFormValues) {
+    const onSubmit = useCallback(async (data: SettingsFormValues) => {
         setSettingsSaveSuccess(false);
         setSettingsSaveError(null);
         try {
@@ -145,32 +153,57 @@ const Settings = observer(() => {
                 autoLockTimeout: data.autoLockTimeout * 60 * 1000
             };
             await StorageUtil.setWalletSettings(settingsToSave);
+            lastSavedTimerRef.current = data.autoLockTimeout;
             setSettingsSaveSuccess(true);
         } catch (_error) {
             setSettingsSaveError("There was an error saving your settings.");
         }
-    }
+    }, []);
 
     // Preferences auto-save on change (debounced so rapid toggles and
-    // keystrokes in the timer input collapse into one write). Invalid
-    // values never reach onSubmit: handleSubmit runs the zod resolver.
+    // keystrokes in the timer input collapse into one write).
     const saveTimer = useRef<number | null>(null);
-    const queueSave = (delayMs: number) => {
+
+    // sanitizeTimer: a save triggered by something other than the timer field
+    // itself (switch toggle, blur, unmount) must not be blocked by a
+    // half-typed timer value; substitute the last persisted one instead.
+    // Timer-keystroke saves pass false so we never rewrite the field while
+    // the user is still typing; the invalid value just surfaces its message
+    // and no write happens until it is fixed or blurred.
+    const flushSave = useCallback((sanitizeTimer: boolean) => {
+        const timer = form.getValues("autoLockTimeout");
+        const invalid = !Number.isFinite(timer) || timer < 1 || timer > 60;
+        if (invalid && !sanitizeTimer) {
+            void form.trigger("autoLockTimeout");
+            return;
+        }
+        if (invalid) {
+            form.setValue("autoLockTimeout", lastSavedTimerRef.current, { shouldValidate: true });
+        }
+        void form.handleSubmit(onSubmit)();
+    }, [form, onSubmit]);
+
+    const queueSave = (delayMs: number, sanitizeTimer = false) => {
         if (saveTimer.current !== null) {
             window.clearTimeout(saveTimer.current);
         }
         saveTimer.current = window.setTimeout(() => {
-            void form.handleSubmit(onSubmit)();
+            saveTimer.current = null;
+            flushSave(sanitizeTimer);
         }, delayMs);
     };
 
+    // Flush (not discard) a pending save on unmount, so a toggle followed by
+    // an immediate navigation still persists.
     useEffect(() => {
         return () => {
             if (saveTimer.current !== null) {
                 window.clearTimeout(saveTimer.current);
+                saveTimer.current = null;
+                flushSave(true);
             }
         };
-    }, []);
+    }, [flushSave]);
 
     // Transient "Saved" chip in the Preferences section header
     useEffect(() => {
@@ -284,17 +317,32 @@ const Settings = observer(() => {
                                     title="Change PIN"
                                     subtitle="Change your wallet PIN used to encrypt your seeds"
                                     right={
-                                        <ChevronDown
-                                            className={cn(
-                                                "h-4 w-4 shrink-0 text-muted-foreground transition-transform",
-                                                showPinForm && "rotate-180",
-                                            )}
-                                        />
+                                        <>
+                                            {/* Lockout state must be visible without expanding
+                                                the panel. */}
+                                            {pinLockout.isLocked ? (
+                                                <span className="text-xs font-medium text-destructive">Locked</span>
+                                            ) : hasFailedAttempts() && attemptsLeft < 5 ? (
+                                                <span className="text-xs text-yellow-400">
+                                                    {attemptsLeft} attempt{attemptsLeft === 1 ? '' : 's'} left
+                                                </span>
+                                            ) : null}
+                                            <ChevronDown
+                                                className={cn(
+                                                    "h-4 w-4 shrink-0 text-muted-foreground transition-transform",
+                                                    showPinForm && "rotate-180",
+                                                )}
+                                            />
+                                        </>
                                     }
                                     onClick={() => setShowPinForm((open) => !open)}
+                                    // Collapsing mid-change would hide the outcome banner.
+                                    disabled={isChangingPin}
+                                    ariaExpanded={showPinForm}
+                                    ariaControls="change-pin-panel"
                                 />
                                 {showPinForm && (
-                                    <div className="px-4 pb-4 pt-3">
+                                    <div id="change-pin-panel" className="px-4 pb-4 pt-3">
                                         <Form {...changePinForm}>
                                             <form
                                                 onSubmit={changePinForm.handleSubmit(onChangePinSubmit)}
@@ -448,10 +496,22 @@ const Settings = observer(() => {
                                                         max={60}
                                                         className="h-9 w-20 shrink-0 text-center"
                                                         {...field}
-                                                        value={field.value ?? 15}
+                                                        value={Number.isFinite(field.value) ? field.value : ""}
                                                         onChange={(e) => {
-                                                            field.onChange(Number(e.target.value));
+                                                            // Empty stays empty while typing (NaN fails
+                                                            // validation, so nothing is written).
+                                                            field.onChange(e.target.value === "" ? Number.NaN : Number(e.target.value));
                                                             queueSave(800);
+                                                        }}
+                                                        onBlur={() => {
+                                                            field.onBlur();
+                                                            const t = form.getValues("autoLockTimeout");
+                                                            const invalid = !Number.isFinite(t) || t < 1 || t > 60;
+                                                            // Flush a pending save early; leaving the field
+                                                            // invalid reverts it to the last saved value.
+                                                            if (invalid || saveTimer.current !== null) {
+                                                                queueSave(0, true);
+                                                            }
                                                         }}
                                                     />
                                                 </FormControl>
@@ -483,7 +543,7 @@ const Settings = observer(() => {
                                                     checked={field.value ?? true}
                                                     onCheckedChange={(checked) => {
                                                         field.onChange(checked);
-                                                        queueSave(200);
+                                                        queueSave(200, true);
                                                     }}
                                                 />
                                             </FormControl>
@@ -513,7 +573,7 @@ const Settings = observer(() => {
                                                     checked={field.value ?? true}
                                                     onCheckedChange={(checked) => {
                                                         field.onChange(checked);
-                                                        queueSave(200);
+                                                        queueSave(200, true);
                                                     }}
                                                 />
                                             </FormControl>

--- a/src/components/Core/Body/Settings/Settings.tsx
+++ b/src/components/Core/Body/Settings/Settings.tsx
@@ -32,7 +32,7 @@ import {
 import { useNavigate } from "react-router-dom";
 import { ROUTES } from "@/router/router";
 import { SEO } from "@/components/SEO/SEO";
-import { PinInput } from "@/components/UI/PinInput/PinInput";
+import { PinInput, type PinInputHandle } from "@/components/UI/PinInput/PinInput";
 import { decryptSeedAsync, reEncryptSeedAsync } from "@/utils/crypto";
 import { isInNativeApp, sendPinChanged } from "@/utils/nativeApp";
 import { isDesktop } from "@/desktop/bridge";
@@ -88,6 +88,8 @@ const Settings = observer(() => {
     const [attemptsLeft, setAttemptsLeft] = useState(5);
     const [settingsSaveSuccess, setSettingsSaveSuccess] = useState(false);
     const [settingsSaveError, setSettingsSaveError] = useState<string | null>(null);
+    const newPinRef = useRef<PinInputHandle>(null);
+    const confirmPinRef = useRef<PinInputHandle>(null);
 
     // Check for existing encrypted seeds on mount
     useEffect(() => {
@@ -332,6 +334,7 @@ const Settings = observer(() => {
                                                                     placeholder="Enter current PIN"
                                                                     error={fieldState.error?.message}
                                                                     disabled={isChangingPin || pinLockout.isLocked}
+                                                                    onComplete={() => newPinRef.current?.focus()}
                                                                 />
                                                             </FormControl>
                                                         </FormItem>
@@ -346,11 +349,13 @@ const Settings = observer(() => {
                                                             <FormLabel>New PIN</FormLabel>
                                                             <FormControl>
                                                                 <PinInput
+                                                                    ref={newPinRef}
                                                                     value={field.value}
                                                                     onChange={field.onChange}
                                                                     placeholder="Enter new PIN"
                                                                     error={fieldState.error?.message}
                                                                     disabled={isChangingPin || pinLockout.isLocked}
+                                                                    onComplete={() => confirmPinRef.current?.focus()}
                                                                 />
                                                             </FormControl>
                                                             <FormDescription>
@@ -368,6 +373,7 @@ const Settings = observer(() => {
                                                             <FormLabel>Confirm New PIN</FormLabel>
                                                             <FormControl>
                                                                 <PinInput
+                                                                    ref={confirmPinRef}
                                                                     value={field.value}
                                                                     onChange={field.onChange}
                                                                     placeholder="Confirm new PIN"

--- a/src/components/Core/Body/Settings/SettingsList.tsx
+++ b/src/components/Core/Body/Settings/SettingsList.tsx
@@ -49,6 +49,10 @@ interface SettingsRowProps {
     right?: ReactNode;
     onClick?: () => void;
     disabled?: boolean;
+    /** For disclosure rows: reflected as aria-expanded on the button. */
+    ariaExpanded?: boolean;
+    /** id of the element a disclosure row controls. */
+    ariaControls?: string;
 }
 
 export const SettingsRow = ({
@@ -59,6 +63,8 @@ export const SettingsRow = ({
     right,
     onClick,
     disabled,
+    ariaExpanded,
+    ariaControls,
 }: SettingsRowProps) => {
     const content = (
         <>
@@ -81,7 +87,11 @@ export const SettingsRow = ({
                 type="button"
                 onClick={onClick}
                 disabled={disabled}
-                className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-foreground/[0.04] disabled:cursor-not-allowed disabled:opacity-50"
+                aria-expanded={ariaExpanded}
+                aria-controls={ariaControls}
+                // Inset ring: the section card is overflow-hidden, so an
+                // outline drawn outside the border box gets clipped away.
+                className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-foreground/[0.04] focus-visible:outline-none focus-visible:bg-foreground/[0.04] focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-50"
             >
                 {content}
             </button>

--- a/src/components/UI/PinInput/PinInput.tsx
+++ b/src/components/UI/PinInput/PinInput.tsx
@@ -49,8 +49,13 @@ export const PinInput = forwardRef<PinInputHandle, PinInputProps>(({
   const chars = value.split("").slice(0, length);
 
   const focusCell = (idx: number) => {
+    const el = refs.current[idx];
+    // No-op when the cell doesn't exist or is already focused: focus() would
+    // fire no focus event, leaving advancingRef stuck true and letting the
+    // next click bypass the sequential-cell redirect.
+    if (!el || el === document.activeElement) return;
     advancingRef.current = true;
-    refs.current[idx]?.focus();
+    el.focus();
   };
 
   useImperativeHandle(ref, () => ({

--- a/src/components/UI/PinInput/PinInput.tsx
+++ b/src/components/UI/PinInput/PinInput.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from "react";
+import React, { useRef, useEffect, forwardRef, useImperativeHandle } from "react";
 import { cn } from "@/utils/cn";
 
 interface PinInputProps {
@@ -11,6 +11,14 @@ interface PinInputProps {
   description?: string;
   error?: string;
   autoFocus?: boolean;
+  /** Fires once when entry fills all `length` cells (typing or paste), so
+   * stacked PIN forms can move focus to the next row. */
+  onComplete?: (pin: string) => void;
+}
+
+export interface PinInputHandle {
+  /** Focus the first empty cell (or the last cell when already full). */
+  focus: () => void;
 }
 
 /**
@@ -19,7 +27,7 @@ interface PinInputProps {
  * (`value`/`onChange`) so every call site stays untouched; only the
  * presentation changed from one input to `length` cells.
  */
-export const PinInput = ({
+export const PinInput = forwardRef<PinInputHandle, PinInputProps>(({
   length = 6,
   onChange,
   value = "",
@@ -30,7 +38,8 @@ export const PinInput = ({
   description,
   error,
   autoFocus = false,
-}: PinInputProps) => {
+  onComplete,
+}, ref) => {
   const refs = useRef<Array<HTMLInputElement | null>>([]);
   // Marks a focus move as programmatic (auto-advance / backspace / arrows /
   // paste) so the cell's onFocus does not bounce it back. focus() fires the
@@ -44,6 +53,10 @@ export const PinInput = ({
     refs.current[idx]?.focus();
   };
 
+  useImperativeHandle(ref, () => ({
+    focus: () => focusCell(Math.min(value.length, length - 1)),
+  }));
+
   useEffect(() => {
     if (autoFocus) {
       advancingRef.current = true;
@@ -51,10 +64,12 @@ export const PinInput = ({
     }
   }, [autoFocus]);
 
-  const setAt = (i: number, ch: string) => {
+  const setAt = (i: number, ch: string): string => {
     const next = value.split("");
     next[i] = ch;
-    onChange(next.join("").replace(/\D/g, "").slice(0, length));
+    const joined = next.join("").replace(/\D/g, "").slice(0, length);
+    onChange(joined);
+    return joined;
   };
 
   const handleChange =
@@ -64,8 +79,9 @@ export const PinInput = ({
       // current cell isn't cleared.
       if (ch && !/\d/.test(ch)) return;
       if (!ch && !chars[i]) return;
-      setAt(i, ch);
+      const next = setAt(i, ch);
       if (ch && i < length - 1) focusCell(i + 1);
+      if (next.length === length && value.length < length) onComplete?.(next);
     };
 
   const handleKeyDown =
@@ -98,6 +114,9 @@ export const PinInput = ({
       const joined = next.join("").replace(/\D/g, "").slice(0, length);
       onChange(joined);
       focusCell(Math.min(i + digits.length, length - 1));
+      // After the in-row focus move, so a listener that refocuses another
+      // row wins.
+      if (joined.length === length && value.length < length) onComplete?.(joined);
     };
 
   return (
@@ -151,6 +170,8 @@ export const PinInput = ({
       )}
     </div>
   );
-};
+});
+
+PinInput.displayName = "PinInput";
 
 export default PinInput;


### PR DESCRIPTION
Promotes dev to main. Contents (origin/main..origin/dev):

- #253 PIN row auto-advance (import-account, create-account, change-PIN chain)
- #254 hardening from the 3-lens adversarial review of #251/#253 (auto-save flush on unmount, invalid-timer no longer blocks switch saves, focus-visible rings, change-PIN row a11y + lockout badge, PinInput focus-flag guards)

Pre-merge checklist:
- Diff reviewed: exactly the two squash commits above
- Gates green on this code: lint clean, 244/244 tests, tsc + vite build
- Adversarial review done: 3 independent lenses, no high-severity findings, all surviving findings fixed in #254; change-PIN crypto/lockout verified byte-identical
- Risks: preferences auto-save semantics (now flushed on unmount); no storage-format or migration impact
- #253 device-tested on dev.qrlwallet.com by Harald ("works perfectly")

https://claude.ai/code/session_01H577F7pk74WPVrLFv5FUU5