### PR TITLE
fix(keystore): parse-time salt minimum and exact ciphertext length

### DIFF
--- a/src/utils/crypto/__tests__/keystoreBackup.test.ts
+++ b/src/utils/crypto/__tests__/keystoreBackup.test.ts
@@ -178,6 +178,22 @@ describe('parseKeystoreBackup', () => {
     ks.crypto.ciphertext = 'zz' + ks.crypto.ciphertext.slice(2);
     expect(() => parseKeystoreBackup({ keystores: [ks] })).toThrow(KeystoreFormatError);
   });
+
+  it('rejects a ciphertext that is not exactly seed+tag sized', () => {
+    // 51-byte seed + 16-byte GCM tag = 67 bytes; wrong-era or corrupt files
+    // must fail at parse, not after a correct password. Extension parity.
+    for (const bytes of [66, 68, 80]) {
+      const ks = firstKeystore();
+      ks.crypto.ciphertext = '00'.repeat(bytes);
+      expect(() => parseKeystoreBackup({ keystores: [ks] })).toThrow(KeystoreFormatError);
+    }
+  });
+
+  it("rejects a salt below argon2's 8-byte minimum", () => {
+    const ks = firstKeystore();
+    ks.crypto.kdfparams.salt = 'abcd';
+    expect(() => parseKeystoreBackup({ keystores: [ks] })).toThrow(KeystoreFormatError);
+  });
 });
 
 describe('decryptKeystoreToHexSeed (extension parity)', () => {

--- a/src/utils/crypto/keystoreBackup.ts
+++ b/src/utils/crypto/keystoreBackup.ts
@@ -74,6 +74,10 @@ const KDF_PARAM_BOUNDS = {
 const SEED_BYTES = 51;
 const IV_BYTES = 12;
 const GCM_TAG_BYTES = 16;
+// argon2 implementations reject salts under 8 bytes; catching it at parse
+// time keeps a bad file from burning a KDF attempt (and, on the WASM path,
+// from being mistaken for WASM unavailability). Mirrors the extension.
+const MIN_SALT_BYTES = 8;
 
 function isHex(value: string): boolean {
   return value.length % 2 === 0 && !/[^0-9a-fA-F]/.test(value);
@@ -135,11 +139,14 @@ function validateKeystore(candidate: unknown, index: number): EncryptedKeystore 
   if (typeof iv !== 'string' || !isHex(iv) || iv.length !== IV_BYTES * 2) {
     throw new KeystoreFormatError(`Invalid IV in ${label} (expected 12 bytes of hex).`);
   }
+  // Exactly one seed + the GCM tag: wrong-era (e.g. future 64-byte QIP-55)
+  // or corrupt files fail here at selection time, not after a correct
+  // password. Mirrors the extension's importer.
   const ciphertext = c['ciphertext'];
   if (
     typeof ciphertext !== 'string' ||
     !isHex(ciphertext) ||
-    ciphertext.length < (GCM_TAG_BYTES + 1) * 2
+    ciphertext.length !== (SEED_BYTES + GCM_TAG_BYTES) * 2
   ) {
     throw new KeystoreFormatError(`Invalid ciphertext in ${label}.`);
   }
@@ -159,7 +166,11 @@ function validateKeystore(candidate: unknown, index: number): EncryptedKeystore 
     );
   }
   const salt = kp['salt'];
-  if (typeof salt !== 'string' || !isHex(salt) || salt.length === 0) {
+  if (
+    typeof salt !== 'string' ||
+    !isHex(salt) ||
+    salt.length < MIN_SALT_BYTES * 2
+  ) {
     throw new KeystoreFormatError(`Invalid salt in ${label}.`);
   }
   return {


### PR DESCRIPTION
Backports two parse-hardening rules from the extension's backup importer (adversarial review of DigitalGuards/myqrlwallet-extension#40 flagged them as a shared gap to fix on both sides together):

- `salt` >= 8 bytes at parse time (argon2's implementation floor); previously a short salt passed validation, burned a KDF attempt, and latched the pure-JS fallback with a misleading console signal.
- `ciphertext` exactly 67 bytes (51-byte seed + 16-byte GCM tag); wrong-era (future QIP-55 64-byte) or corrupt files now fail at selection as a clear format error rather than after the user enters a correct password. The post-decrypt 51-byte check stays as defense in depth.

No format change; the extension-certified parity fixture is unaffected (32-byte salts, 67-byte ciphertexts). Low severity: fine to ride the next release, no prod promotion needed now.

Gates: lint clean, 274/274 tests (2 new), build green.

https://claude.ai/code/session_01H577F7pk74WPVrLFv5FUU5