### PR TITLE
release: dependabot batch + keystore parse hardening

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "react-dom": "^19.2.3",
         "react-helmet-async": "^2.0.5",
         "react-hook-form": "^7.52.1",
-        "react-router-dom": "^7.16.0",
+        "react-router-dom": "^7.18.1",
         "socket.io-client": "^4.8.3",
         "tailwind-merge": "^2.6.0",
         "zod": "^4.3.4"
@@ -6612,9 +6612,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7549,9 +7549,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9371,9 +9371,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12095,9 +12095,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -12582,9 +12582,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.24",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
+      "integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
       "funding": [
         {
           "type": "opencollective",
@@ -12601,7 +12601,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -12947,9 +12947,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
-      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -12969,12 +12969,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.16.0.tgz",
-      "integrity": "sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.16.0"
+        "react-router": "7.18.1"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "react-dom": "^19.2.3",
     "react-helmet-async": "^2.0.5",
     "react-hook-form": "^7.52.1",
-    "react-router-dom": "^7.16.0",
+    "react-router-dom": "^7.18.1",
     "socket.io-client": "^4.8.3",
     "tailwind-merge": "^2.6.0",
     "zod": "^4.3.4"

--- a/src/utils/crypto/__tests__/keystoreBackup.test.ts
+++ b/src/utils/crypto/__tests__/keystoreBackup.test.ts
@@ -178,6 +178,22 @@ describe('parseKeystoreBackup', () => {
     ks.crypto.ciphertext = 'zz' + ks.crypto.ciphertext.slice(2);
     expect(() => parseKeystoreBackup({ keystores: [ks] })).toThrow(KeystoreFormatError);
   });
+
+  it('rejects a ciphertext that is not exactly seed+tag sized', () => {
+    // 51-byte seed + 16-byte GCM tag = 67 bytes; wrong-era or corrupt files
+    // must fail at parse, not after a correct password. Extension parity.
+    for (const bytes of [66, 68, 80]) {
+      const ks = firstKeystore();
+      ks.crypto.ciphertext = '00'.repeat(bytes);
+      expect(() => parseKeystoreBackup({ keystores: [ks] })).toThrow(KeystoreFormatError);
+    }
+  });
+
+  it("rejects a salt below argon2's 8-byte minimum", () => {
+    const ks = firstKeystore();
+    ks.crypto.kdfparams.salt = 'abcd';
+    expect(() => parseKeystoreBackup({ keystores: [ks] })).toThrow(KeystoreFormatError);
+  });
 });
 
 describe('decryptKeystoreToHexSeed (extension parity)', () => {

--- a/src/utils/crypto/keystoreBackup.ts
+++ b/src/utils/crypto/keystoreBackup.ts
@@ -74,6 +74,10 @@ const KDF_PARAM_BOUNDS = {
 const SEED_BYTES = 51;
 const IV_BYTES = 12;
 const GCM_TAG_BYTES = 16;
+// argon2 implementations reject salts under 8 bytes; catching it at parse
+// time keeps a bad file from burning a KDF attempt (and, on the WASM path,
+// from being mistaken for WASM unavailability). Mirrors the extension.
+const MIN_SALT_BYTES = 8;
 
 function isHex(value: string): boolean {
   return value.length % 2 === 0 && !/[^0-9a-fA-F]/.test(value);
@@ -135,11 +139,14 @@ function validateKeystore(candidate: unknown, index: number): EncryptedKeystore 
   if (typeof iv !== 'string' || !isHex(iv) || iv.length !== IV_BYTES * 2) {
     throw new KeystoreFormatError(`Invalid IV in ${label} (expected 12 bytes of hex).`);
   }
+  // Exactly one seed + the GCM tag: wrong-era (e.g. future 64-byte QIP-55)
+  // or corrupt files fail here at selection time, not after a correct
+  // password. Mirrors the extension's importer.
   const ciphertext = c['ciphertext'];
   if (
     typeof ciphertext !== 'string' ||
     !isHex(ciphertext) ||
-    ciphertext.length < (GCM_TAG_BYTES + 1) * 2
+    ciphertext.length !== (SEED_BYTES + GCM_TAG_BYTES) * 2
   ) {
     throw new KeystoreFormatError(`Invalid ciphertext in ${label}.`);
   }
@@ -159,7 +166,11 @@ function validateKeystore(candidate: unknown, index: number): EncryptedKeystore 
     );
   }
   const salt = kp['salt'];
-  if (typeof salt !== 'string' || !isHex(salt) || salt.length === 0) {
+  if (
+    typeof salt !== 'string' ||
+    !isHex(salt) ||
+    salt.length < MIN_SALT_BYTES * 2
+  ) {
     throw new KeystoreFormatError(`Invalid salt in ${label}.`);
   }
   return {


### PR DESCRIPTION
Promotes dev to main: #260 (react-router 7.18.1 / brace-expansion / postcss; wallet.js deliberately held at 6.1.0, the 6.2.x QIP-55 bump breaks signing fixtures) and #259 (keystore parse-time salt minimum + exact ciphertext length, extension parity).

Clears the remaining Dependabot alerts on the default branch. Gates green on this exact tree: lint clean, 274/274 tests, build green.

https://claude.ai/code/session_01H577F7pk74WPVrLFv5FUU5